### PR TITLE
Pack more profiles in a row group.

### DIFF
--- a/src/main/scala/parquet/ParquetFile.scala
+++ b/src/main/scala/parquet/ParquetFile.scala
@@ -28,8 +28,8 @@ object ParquetFile {
     return new Path(uri)
   }
 
-  def serialize(data: Iterator[GenericRecord], schema: Schema): Path = {
-    val blockSize = ParquetWriter.DEFAULT_BLOCK_SIZE
+  def serialize(data: Iterator[GenericRecord], schema: Schema, blockSizeMultiplier: Int = 1): Path = {
+    val blockSize = blockSizeMultiplier*ParquetWriter.DEFAULT_BLOCK_SIZE
     val pageSize = ParquetWriter.DEFAULT_PAGE_SIZE
     val enableDict = ParquetWriter.DEFAULT_IS_DICTIONARY_ENABLED
     val parquetFile = temporaryFileName()

--- a/src/main/scala/streams/Longitudinal.scala
+++ b/src/main/scala/streams/Longitudinal.scala
@@ -114,6 +114,11 @@ case class Longitudinal() extends DerivedStream {
       .repartitionAndSortWithinPartitions(new ClientIdPartitioner(320))
       .map{case (key, value) => (key._1, value)}
 
+    /* One file per partition is generated at the end of the job. We want to have
+       few big files but at the same time we need a high enough degree of parallelism
+       to keep all workers busy. Since the cluster typically used for this job has
+       8 workers and 20 executors, 320 partitions provide a good compromise. */
+
     val partitionCounts = clientMessages
       .mapPartitions{ case it =>
         val clientIterator = new ClientIterator(it)


### PR DESCRIPTION
The longitudinal dataset has only a few hundred profiles per row group, which is detrimental for performance. This patch increases the number of profiles per row group while simultaneously reducing the memory footprint of the job, without which it wouldn't be possible to run on a typical c3.4xlarge cluster.

Furthermore, the number of cores per executor has to be reduced by 2x and the storage memory fraction has to be set to 0 when running the job, e.g.:
```
spark-submit --master yarn-client --executor-cores 8 --class telemetry.DerivedStream \
  --conf spark.storage.memoryFraction=0 ./target/scala-2.10/telemetry-batch-view-1.1.jar \
  --from-date 20151115 --to-date 20160213 Longitudinal
```
Note that even though the number of executors is halved, the time of the job reduces to about 2h over the time period as there is less swapping.