### PR TITLE
Fix the S3 partition field name

### DIFF
--- a/src/main/scala/streams/Churn.scala
+++ b/src/main/scala/streams/Churn.scala
@@ -128,7 +128,7 @@ case class Churn(prefix: String) extends DerivedStream{
   
           while(!records.isEmpty) {
             val localFile = ParquetFile.serialize(records, schema)
-            uploadLocalFileToS3(localFile, s"$prefix/submissionDateS3=$currentDay")
+            uploadLocalFileToS3(localFile, s"$prefix/submission_date_s3=$currentDay")
           }
         }
     }


### PR DESCRIPTION
The name should be separated_by_underscores rather than camelCase.