### PR TITLE
Fix geoCountry generally being missing

### DIFF
--- a/src/main/scala/streams/Longitudinal.scala
+++ b/src/main/scala/streams/Longitudinal.scala
@@ -636,9 +636,11 @@ case class Longitudinal() extends DerivedStream {
       x.getOrElse("geoCity", "").asInstanceOf[String]
     }
 
-    // only set the keys if there are valid country entries
+    // only set the keys if there are valid entries
     if (countries.exists( country => country != "" )) {
       root.set("geoCountry", countries.toArray)
+    }
+    if (cities.exists( city => city != "" )) {
       root.set("geoCity", cities.toArray)
     }
   }

--- a/src/main/scala/streams/Longitudinal.scala
+++ b/src/main/scala/streams/Longitudinal.scala
@@ -636,8 +636,11 @@ case class Longitudinal() extends DerivedStream {
       x.getOrElse("geoCity", "").asInstanceOf[String]
     }
 
-    root.set("geoCountry", countries.toArray)
-    root.set("geoCity", cities.toArray)
+    // only set the keys if there are valid country entries
+    if (countries.exists( country => country != "" )) {
+      root.set("geoCountry", countries.toArray)
+      root.set("geoCity", cities.toArray)
+    }
   }
 
   private def buildRecord(history: Iterable[Map[String, Any]], schema: Schema): Option[GenericRecord] = {

--- a/src/main/scala/streams/Longitudinal.scala
+++ b/src/main/scala/streams/Longitudinal.scala
@@ -630,10 +630,10 @@ case class Longitudinal() extends DerivedStream {
 
   private def geo2Avro(payloads: List[Map[String, Any]], root: GenericRecordBuilder, schema: Schema) {
     val countries = payloads.map{ case (x) =>
-      x.getOrElse("geoCountry", return).asInstanceOf[String]
+      x.getOrElse("geoCountry", "").asInstanceOf[String]
     }
     val cities = payloads.map{ case (x) =>
-      x.getOrElse("geoCity", return).asInstanceOf[String]
+      x.getOrElse("geoCity", "").asInstanceOf[String]
     }
 
     root.set("geoCountry", countries.toArray)


### PR DESCRIPTION
Before, geoCountry would be omitted whenever geoCity is missing. However, :chutten mentioned that it's still useful to have geoCountry even this is the case.

The geoCountry/geoCity is set to an empty string because using nullables in arrays seems to expand the schema quite a bit. This seems to be a known issue with Avro.