### PR TITLE
Fix deserialization error causing exceptions for threadHangStats.

### DIFF
--- a/src/main/scala/streams/Longitudinal.scala
+++ b/src/main/scala/streams/Longitudinal.scala
@@ -667,7 +667,7 @@ case class Longitudinal() extends DerivedStream {
       }
       val threadHangStats = body.extract[Array[Map[String, JValue]]]
       for (thread <- threadHangStats) {
-        ranges = thread.getOrElse("activity", return).extract[Map[String, Any]]
+        ranges = thread.getOrElse("activity", return).extract[Map[String, JValue]]
                        .getOrElse("ranges", return).asInstanceOf[List[BigInt]]
                        .map(x => x.toInt).toArray
       }

--- a/src/main/scala/streams/Longitudinal.scala
+++ b/src/main/scala/streams/Longitudinal.scala
@@ -668,7 +668,7 @@ case class Longitudinal() extends DerivedStream {
       val threadHangStats = body.extract[Array[Map[String, JValue]]]
       for (thread <- threadHangStats) {
         ranges = thread.getOrElse("activity", return).extract[Map[String, JValue]]
-                       .getOrElse("ranges", return).asInstanceOf[List[BigInt]]
+                       .getOrElse("ranges", return).extract[List[BigInt]]
                        .map(x => x.toInt).toArray
       }
       threadHangStats


### PR DESCRIPTION
It seems to be related to a few JSON4s bugs, though I'm not sure exactly what triggers them.

Anyways, the fix is really simple and some test output with a small number of pings can be found here: https://console.aws.amazon.com/s3/home?region=us-west-2#&bucket=telemetry-test-bucket&prefix=longitudinal/v20160301/.