### PR TITLE
Include the timezone, but normalize it if needed

### DIFF
--- a/src/test/scala/Longitudinal.scala
+++ b/src/test/scala/Longitudinal.scala
@@ -201,7 +201,7 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester{
       "geo_country"           -> "US",
       "geo_city"              -> "New York",
       "dnt_header"            -> "1",
-      "subsession_start_date" -> "2015-12-09T14:00:00.000Z",
+      "subsession_start_date" -> "2015-12-09T12:00:00.000-02:00",
       "profile_creation_date" -> "2014-02-21T00:00:00.000Z",
       "profile_reset_date"    -> "2014-03-03T00:00:00.000Z"
     )


### PR DESCRIPTION
It's kind of hacky, but it works!

All dates within real timezones are kept as-is. All dates outside are brought inside by adding/subtracting 12 hours.