### PR TITLE
Fix timezone edge case that was incorrect due to integer division

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # telemetry-batch-view
 
-This is a Scala "framework" to build derived datasets, aka batch views, of [Telemetry](https://wiki.mozilla.org/Telemetry) data.
+This is a Scala "framework" to build derived datasets, also known as [batch views](http://robertovitillo.com/2016/01/06/batch-views/), of [Telemetry](https://wiki.mozilla.org/Telemetry) data.
 
 Raw JSON [pings](https://ci.mozilla.org/job/mozilla-central-docs/Tree_Documentation/toolkit/components/telemetry/telemetry/pings.html) are stored on S3 within files containing [framed Heka records](https://hekad.readthedocs.org/en/latest/message/index.html#stream-framing). Reading the raw data in through e.g. Spark can be slow as for a given analysis only a few fields are typically used; not to mention the cost of parsing the JSON blobs. Furthermore, Heka files might contain only a handful of records under certain circumstances.
 

--- a/src/main/scala/utils/Utils.scala
+++ b/src/main/scala/utils/Utils.scala
@@ -51,11 +51,11 @@ object Utils{
     val dateFormatter = org.joda.time.format.ISODateTimeFormat.dateTime()
     val date = dateFormatter.withOffsetParsed().parseDateTime(timestamp)
     val millisPerHour = 60 * 60 * 1000;
-    val timezoneOffsetHours = date.getZone().getOffset(date) / millisPerHour
-    val timezone = if (timezoneOffsetHours < -12) {
-      org.joda.time.DateTimeZone.forOffsetMillis((timezoneOffsetHours + 12 * Math.floor(timezoneOffsetHours / -12).toInt) * millisPerHour)
-    } else if (timezoneOffsetHours > 14) (
-      org.joda.time.DateTimeZone.forOffsetMillis((timezoneOffsetHours - 12 * Math.floor(timezoneOffsetHours / 12).toInt) * millisPerHour)
+    val timezoneOffsetHours = date.getZone().getOffset(date).toDouble / millisPerHour
+    val timezone = if (timezoneOffsetHours < -12.0) {
+      org.joda.time.DateTimeZone.forOffsetMillis(((timezoneOffsetHours + 12 * Math.floor(timezoneOffsetHours / -12).toInt) * millisPerHour).toInt)
+    } else if (timezoneOffsetHours > 14.0) (
+      org.joda.time.DateTimeZone.forOffsetMillis(((timezoneOffsetHours - 12 * Math.floor(timezoneOffsetHours / 12).toInt) * millisPerHour).toInt)
     ) else {
       date.getZone()
     }


### PR DESCRIPTION
Utils was using integer division when it should use float division. As a result, the timezone 14:30, which is invalid, was truncated to timezone 14:00, which is valid.

Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1258683