### PR TITLE
Add caching of ivy dependencies to Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
 language: scala
+# These directories are cached to S3 at the end of the build
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/
+before_cache:
+  # Tricks to avoid unnecessary cache updates
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
+  - find $HOME/.sbt -name "*.lock" -delete
 scala:
   - 2.10.6
 sbt_args: -J-Xss2M


### PR DESCRIPTION
It looks like this is reducing the total [Travis run time](https://travis-ci.org/mozilla/telemetry-batch-view/builds/129172611 ) by ~2 minutes