### PR TITLE
Implement a flexible API to access Heka files on S3.

### DIFF
--- a/src/main/scala/SimpleDerivedStream.scala
+++ b/src/main/scala/SimpleDerivedStream.scala
@@ -23,7 +23,7 @@ abstract class SimpleDerivedStream extends DerivedStream {
   override def transform(sc: SparkContext, bucket: Bucket, input: RDD[ObjectSummary], from: String, to: String) {
     val tasks = input
       .groupBy(summary => prefixGroup(summary.key))
-      .flatMap(x => DerivedStream.groupBySize(x._2.toIterator).toIterator.zip(Iterator.continually{x._1}))
+      .flatMap(x => ObjectSummary.groupBySize(x._2.toIterator).toIterator.zip(Iterator.continually{x._1}))
       .filter{ case (_, prefix) =>
         val partitionedPrefix = partitioning.partitionPrefix(prefix, version)
         if (!isS3PrefixEmpty(partitionedPrefix)) {

--- a/src/main/scala/heka/Dataset.scala
+++ b/src/main/scala/heka/Dataset.scala
@@ -1,0 +1,80 @@
+package telemetry.heka
+
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.json4s._
+import org.json4s.jackson.JsonMethods.parse
+import telemetry.ObjectSummary
+import telemetry.utils.{AbstractS3Store, S3Store}
+import scala.io.Source
+
+case class Schema(dimensions: List[Dimension])
+case class Dimension(fieldName: String)
+
+class Dataset private (bucket: String,
+                       schema: Schema, prefix: String,
+                       clauses: Map[String, PartialFunction[String, Boolean]],
+                       s3Store: => AbstractS3Store) extends java.io.Serializable {
+  def where(dimension: String)(clause: PartialFunction[String, Boolean]): Dataset = {
+    if (clauses.contains(dimension))
+      throw new Exception(s"There should be only one clause for ${dimension}")
+
+    if (!schema.dimensions.contains(Dimension(dimension)))
+      throw new Exception(s"The dimension ${dimension} doesn't exists")
+
+    new Dataset(bucket, schema, prefix, clauses + (dimension -> clause), s3Store)
+  }
+
+  def summaries(fileLimit: Option[Int] = None): Stream[ObjectSummary] = {
+    def scan(dimensions: List[Dimension], prefixes: Stream[String]): Stream[String] = {
+      if (dimensions.isEmpty) {
+        prefixes
+      } else {
+        val dimension = dimensions.head
+        val clause = clauses.getOrElse(dimension.fieldName, {case x => true}: PartialFunction[String, Boolean])
+        val matched = prefixes
+          .flatMap(s3Store.listFolders(bucket, _))
+          .filter{ prefix =>
+            val value = prefix.split("/").last
+            clause.isDefinedAt(value) && clause(value)
+          }
+        scan(dimensions.tail, matched)
+      }
+    }
+
+    val keys = scan(schema.dimensions, Stream(s"${prefix}/"))
+      .flatMap(s3Store.listKeys(bucket, _))
+
+    fileLimit match {
+      case Some(x) => keys.take(x)
+      case _ => keys
+    }
+  }
+
+  def records(fileLimit: Option[Int] = None)(implicit sc: SparkContext): RDD[Message] = {
+    // Partition the files into groups of approximately-equal size
+    val groups = ObjectSummary.groupBySize(summaries(fileLimit).toIterator)
+    sc.parallelize(groups, groups.size).flatMap(x => x).flatMap(o => {
+      val hekaFile = s3Store.getKey(bucket, o.key)
+      for (message <- HekaFrame.parse(hekaFile, o.key)) yield message
+    })
+  }
+}
+
+object Dataset {
+  /* Note that s3Store parameter is used for testing purposes. An implicit cannot be used as Spark will try to
+     serialize it and fail. Furthermore, mocking singleton objects in Scala is non trivial. */
+  def apply(dataset: String, s3Store: => AbstractS3Store = S3Store): Dataset = {
+    implicit val formats = DefaultFormats
+
+    val metaBucket = "net-mozaws-prod-us-west-2-pipeline-metadata"
+    val metaSources = parse(Source.fromInputStream(s3Store.getKey(metaBucket, "sources.json")).mkString)
+    val JString(prefix) = metaSources \\ dataset \\ "prefix"
+    val JString(bucketName) = metaSources \\ dataset \\ "bucket"
+    val schema = parse(Source.fromInputStream(s3Store.getKey(metaBucket, s"${prefix}/schema.json")).mkString)
+      .camelizeKeys
+      .extract[Schema]
+
+    new Dataset(bucketName, schema, prefix, Map(), s3Store)
+  }
+}

--- a/src/main/scala/streams/Churn.scala
+++ b/src/main/scala/streams/Churn.scala
@@ -122,7 +122,7 @@ case class Churn(prefix: String) extends DerivedStream{
       val summaries = sc.parallelize(s3.objectSummaries(bucket, s"$dataPrefix/$currentDay/$filterPrefix")
                         .map(summary => ObjectSummary(summary.getKey(), summary.getSize())))
 
-      val groups = DerivedStream.groupBySize(summaries.collect().toIterator)
+      val groups = ObjectSummary.groupBySize(summaries.collect().toIterator)
       val churnMessages = sc.parallelize(groups, groups.size)
         .flatMap(x => x)
         .flatMap{ case obj =>

--- a/src/main/scala/streams/E10sExperiment.scala
+++ b/src/main/scala/streams/E10sExperiment.scala
@@ -47,7 +47,7 @@ case class E10sExperiment(experimentId: String, prefix: String) extends DerivedS
       return
     }
 
-    val groups = DerivedStream.groupBySize(summaries.collect().toIterator)
+    val groups = ObjectSummary.groupBySize(summaries.collect().toIterator)
     val clientMessages = sc.parallelize(groups, groups.size)
       .flatMap(x => x)
       .flatMap{ case obj =>

--- a/src/main/scala/streams/Longitudinal.scala
+++ b/src/main/scala/streams/Longitudinal.scala
@@ -93,7 +93,7 @@ case class Longitudinal() extends DerivedStream {
 
     // Sort submissions in descending order
     implicit val ordering = Ordering[Tuple3[String, String, Int]].reverse
-    val groups = DerivedStream.groupBySize(summaries.collect().toIterator)
+    val groups = ObjectSummary.groupBySize(summaries.collect().toIterator)
     val clientMessages = sc.parallelize(groups, groups.size)
       .flatMap(x => x)
       .flatMap{ case obj =>

--- a/src/main/scala/utils/S3.scala
+++ b/src/main/scala/utils/S3.scala
@@ -1,0 +1,46 @@
+package telemetry.utils
+
+import java.io.InputStream
+import awscala.s3.{Bucket, S3}
+import telemetry.ObjectSummary
+import scala.collection.JavaConverters._
+
+abstract class AbstractS3Store {
+  def listKeys(bucket: String, prefix: String): Stream[ObjectSummary]
+  def listFolders(bucket: String, prefix: String, delimiter: String = "/"): Stream[String]
+  def getKey(bucket: String, key: String): InputStream
+}
+
+object S3Store extends AbstractS3Store {
+  protected implicit lazy val s3: S3 = S3()
+
+  def getKey(bucket: String, key: String): InputStream = {
+    Bucket(bucket).getObject(key).getOrElse(throw new Exception(s"File missing on S3: ${key}")).getObjectContent
+  }
+
+  def listKeys(bucket: String, prefix: String): Stream[ObjectSummary] = {
+    s3.objectSummaries(Bucket(bucket), prefix)
+      .map(summary => ObjectSummary(summary.getKey, summary.getSize))
+  }
+
+  def listFolders(bucket: String, prefix: String, delimiter: String = "/"): Stream[String] = {
+    import com.amazonaws.services.s3.model.{ListObjectsRequest, ObjectListing}
+
+    val request = new ListObjectsRequest().
+      withBucketName(bucket).
+      withPrefix(prefix).
+      withDelimiter(delimiter)
+    val firstListing = s3.listObjects(request)
+
+    def completeStream(listing: ObjectListing): Stream[String] = {
+      val prefixes = listing.getCommonPrefixes.asScala.toStream
+      prefixes #:::
+        (if (listing.isTruncated)
+          completeStream(s3.listNextBatchOfObjects(listing))
+        else
+          Stream.empty)
+    }
+
+    completeStream(firstListing)
+  }
+}

--- a/src/main/scala/utils/Telemetry.scala
+++ b/src/main/scala/utils/Telemetry.scala
@@ -1,22 +1,21 @@
 package telemetry.utils
 
-import scala.io.Source
-import scala.collection.JavaConversions._
-import scala.collection.JavaConverters._
-import telemetry.heka.{HekaFrame, Message}
-import org.json4s._
-import org.json4s.jackson.JsonMethods.parse
-import org.joda.time.DateTime
-import org.apache.spark.rdd.RDD
 import awscala.s3.{Bucket, S3}
 import org.apache.spark.SparkContext
-import telemetry.{DerivedStream, ObjectSummary}
+import org.apache.spark.rdd.RDD
+import org.joda.time.DateTime
+import org.json4s._
+import org.json4s.jackson.JsonMethods.parse
+import telemetry.ObjectSummary
+import telemetry.heka.{HekaFrame, Message}
+import scala.collection.JavaConverters._
+import scala.io.Source
 
 object Telemetry {
   implicit lazy val s3: S3 = S3()
 
   private def listS3Keys(bucket: Bucket, prefix: String, delimiter: String = "/"): Stream[String] = {
-    import com.amazonaws.services.s3.model.{ ListObjectsRequest, ObjectListing }
+    import com.amazonaws.services.s3.model.{ListObjectsRequest, ObjectListing}
 
     val request = new ListObjectsRequest().withBucketName(bucket.getName).withPrefix(prefix).withDelimiter(delimiter)
     val firstListing = s3.listObjects(request)
@@ -67,27 +66,10 @@ object Telemetry {
     ).flatMap(prefix => s3.objectSummaries(bucket, prefix)).map(summary => ObjectSummary(summary.getKey, summary.getSize))
 
     // Partition the files into groups of approximately-equal size
-    val groups = DerivedStream.groupBySize(summaries.toIterator)
+    val groups = ObjectSummary.groupBySize(summaries.toIterator)
     sc.parallelize(groups, groups.size).flatMap(x => x).flatMap(o => {
       val hekaFile = bucket.getObject(o.key).getOrElse(throw new Exception(s"File missing on S3: ${o.key}"))
       for (message <- HekaFrame.parse(hekaFile.getObjectContent, o.key)) yield message
     })
-  }
-
-  def listOptions(submissionDate: DateTime, pingPath: List[String]): Stream[String] = {
-    // obtain the prefix of the telemetry data source
-    val metadataBucket = Bucket("net-mozaws-prod-us-west-2-pipeline-metadata")
-    val Some(sourcesObj) = metadataBucket.get("sources.json")
-    val metaSources = parse(Source.fromInputStream(sourcesObj.getObjectContent).getLines().mkString("\n"))
-    val JString(telemetryPrefix) = metaSources \\ "telemetry" \\ "prefix"
-    val JString(dataBucket) = metaSources \\ "telemetry" \\ "bucket"
-
-    // get a stream of object summaries that match the desired criteria
-    val bucket = Bucket(dataBucket)
-    matchingPrefixes(
-      bucket,
-      List("").toStream,
-      List(telemetryPrefix, submissionDate.toString("yyyyMMdd")) ++ pingPath ++ List("*")
-    )
   }
 }

--- a/src/test/scala/DatasetTest.scala
+++ b/src/test/scala/DatasetTest.scala
@@ -1,0 +1,98 @@
+package telemetry.test
+
+import java.io.{ByteArrayInputStream, InputStream}
+import org.apache.spark.{SparkConf, SparkContext}
+import org.scalatest.{FlatSpec, Matchers}
+import telemetry.ObjectSummary
+import telemetry.heka.Dataset
+import telemetry.utils.AbstractS3Store
+
+object MockS3Store extends AbstractS3Store {
+  def getKey(bucket: String, key: String): InputStream = key match{
+    case "sources.json" =>
+      val text = """
+        |{
+        |  "telemetry": {
+        |    "prefix": "telemetry",
+        |    "bucket": "foo"
+        |  }
+        |}
+      """.stripMargin
+      new ByteArrayInputStream(text.getBytes)
+
+    case "telemetry/schema.json" =>
+      val text = """
+         |{
+         |  "dimensions": [
+         |    { "field_name": "submissionDate" },
+         |    { "field_name": "docType" },
+         |    { "field_name": "appName" }
+         |  ]
+         |}
+      """.stripMargin
+      new ByteArrayInputStream(text.getBytes)
+
+    case "x" =>
+      new ByteArrayInputStream(Resources.hekaFile(42))
+
+    case _ =>
+      new ByteArrayInputStream(Array())
+  }
+
+  def listKeys(bucket: String, prefix: String): Stream[ObjectSummary] = {
+    prefix match {
+      case "Firefox/" => Stream(ObjectSummary("x", 1), ObjectSummary("y", 2))
+      case "Fennec/" => Stream(ObjectSummary("a", 1))
+    }
+  }
+  def listFolders(bucket: String, prefix: String, delimiter: String): Stream[String] = prefix match {
+    case "telemetry/" => Stream("20160606/", "20160607/")
+    case "20160606/" => Stream("main/", "crash/")
+    case "20160607/" => Stream("other/")
+    case "main/" => Stream("Firefox/")
+    case "crash/" => Stream("Fennec/")
+  }
+}
+
+class DatasetTest extends FlatSpec with Matchers{
+  "Partitions" can "be filtered" in {
+    val files = Dataset("telemetry", MockS3Store)
+      .where("submissionDate") {
+        case date if date.endsWith("06") => true
+      }.where("docType") {
+        case "main" => true
+      }.summaries().toList
+
+    assert(files == List(ObjectSummary("x", 1), ObjectSummary("y", 2)))
+  }
+
+  "Files" can "be limited" in {
+    val files = Dataset("telemetry", MockS3Store)
+      .where("submissionDate") {
+        case "20160606" => true
+      }.where("docType") {
+      case "main" => true
+    }.summaries(Some(1)).toList
+
+    assert(files == List(ObjectSummary("x", 1)))
+  }
+
+  "Records" can "be fetched" in {
+    val sparkConf = new SparkConf().setAppName("KPI")
+    sparkConf.setMaster(sparkConf.get("spark.master", "local[1]"))
+    implicit val sc = new SparkContext(sparkConf)
+
+    try {
+      val records = Dataset("telemetry", MockS3Store)
+        .where("submissionDate") {
+          case "20160606" => true
+        }.where("docType") {
+        case "main" => true
+      }.records()
+
+      assert(records.count() == 42)
+    } finally {
+      sc.stop()
+    }
+  }
+}


### PR DESCRIPTION
The current way of accessing files on S3 is very ugly. This patch adds a simple way to fetch Heka files based on a set of filtering criteria on the dimensions, e.g.:

```scala
Dataset("telemetry")
  .where("sourceName") {
    case "telemetry" => true
  }.where("sourceVersion") {
    case "4" => true
  }.where("docType") {
    case "main" => true
  }.where("appName") {
    case "Firefox" => true
  }.where("submissionDate") {
    case date if date.startsWith("2016") => true
  }.records()
```