### PR TITLE
Bug 1282405 - stop using com.typesafe.config

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ Raw JSON [pings](https://ci.mozilla.org/job/mozilla-central-docs/Tree_Documentat
 
 Defining a derived [Parquet](https://parquet.apache.org/) dataset, which uses a columnar layout optimized for analytics workloads, can drastically improve the performance of analysis jobs while reducing the space requirements. A derived dataset might, and should, also perform heavy duty operations common to all analysis that are going to read from that dataset (e.g., parsing dates into normalized timestamps).
 
-The converted datasets are stored in the bucket specified in [*application.conf*](https://github.com/vitillo/aws-lambda-parquet/blob/master/src/main/resources/application.conf#L2).
-
 ### Adding a new derived dataset
 
 See the [views](https://github.com/mozilla/telemetry-batch-view/tree/master/src/main/scala/views) folder for examples of jobs that create derived datasets.

--- a/docs/CrashAggregateView.md
+++ b/docs/CrashAggregateView.md
@@ -7,7 +7,7 @@ Essentially, each row of the view represents the stats for a particular populati
 
 To generate the dataset for April 10, 2016 to April 11, 2016:
 ```bash
-sbt "run-main telemetry.views.CrashAggregateView --from 20160410 --to 20160411"
+sbt "run-main telemetry.views.CrashAggregateView --from 20160410 --to 20160411 --bucket telemetry-bucket"
 ```
 
 **Note:** Currently, due to [avro-parquet issues](https://issues.apache.org/jira/browse/HIVE-12828), Parquet writing only works under the `spark-submit` commands - the above example will fail. This will be fixed when avro-parquet updates or is removed.
@@ -15,7 +15,7 @@ sbt "run-main telemetry.views.CrashAggregateView --from 20160410 --to 20160411"
 For distributed execution, we can build a self-contained JAR file, then run it with Spark. To generate the dataset for April 10, 2016 to April 11, 2016:
 ```bash
 sbt assembly
-spark-submit --master yarn-client --class telemetry.views.CrashAggregateView target/scala-2.10/telemetry-batch-view-*.jar --from 20160410 --to 20160411
+spark-submit --master yarn-client --class telemetry.views.CrashAggregateView target/scala-2.10/telemetry-batch-view-*.jar --from 20160410 --to 20160411 --bucket telemetry-bucket
 ```
 
 Notes:

--- a/src/main/scala/com/mozilla/telemetry/views/ClientCountView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/ClientCountView.scala
@@ -1,7 +1,6 @@
 package com.mozilla.telemetry.views
 
 import com.github.nscala_time.time.Imports._
-import com.typesafe.config._
 import com.mozilla.spark.sql.hyperloglog.aggregates._
 import com.mozilla.spark.sql.hyperloglog.functions._
 import org.apache.spark.{SparkConf, SparkContext}
@@ -14,6 +13,7 @@ object ClientCountView {
   private class Conf(args: Array[String]) extends ScallopConf(args) {
     val from = opt[String]("from", descr = "From submission date", required = false)
     val to = opt[String]("to", descr = "To submission date", required = false)
+    val outputBucket = opt[String]("bucket", descr = "Destination bucket for parquet data", required = true)
     verify()
   }
 
@@ -75,8 +75,6 @@ object ClientCountView {
     val subset = df.where(s"submission_date_s3 >= $from and submission_date_s3 <= $to")
     val aggregates = aggregate(subset).coalesce(32)
 
-    val appConf = ConfigFactory.load()
-    val parquetBucket = appConf.getString("app.parquetBucket")
-    aggregates.write.parquet(s"s3://$parquetBucket/client_count/v$from$to")
+    aggregates.write.parquet(s"s3://${conf.outputBucket()}/client_count/v$from$to")
   }
 }

--- a/src/main/scala/com/mozilla/telemetry/views/CrashAggregateView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/CrashAggregateView.scala
@@ -1,6 +1,5 @@
 package com.mozilla.telemetry.views
 
-import com.typesafe.config._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Row, SQLContext, SaveMode}
@@ -16,6 +15,7 @@ object CrashAggregateView {
   private class Conf(args: Array[String]) extends ScallopConf(args) {
     val from = opt[String]("from", descr = "From submission date", required = false)
     val to = opt[String]("to", descr = "To submission date", required = false)
+    val outputBucket = opt[String]("bucket", descr = "Destination bucket for parquet data", required = true)
     verify()
   }
 
@@ -39,8 +39,6 @@ object CrashAggregateView {
     val sqlContext = new SQLContext(sc)
     val hadoopConf = sc.hadoopConfiguration
     hadoopConf.set("fs.s3n.impl", "org.apache.hadoop.fs.s3native.NativeS3FileSystem")
-    val appConf = ConfigFactory.load()
-    val parquetBucket = appConf.getString("app.parquetBucket")
 
     for (offset <- 0 to Days.daysBetween(from, to).getDays) {
       val currentDate = from.plusDays(offset)
@@ -64,7 +62,7 @@ object CrashAggregateView {
       val records = sqlContext.createDataFrame(rowRDD.coalesce(1), schema)
 
       // upload the resulting aggregate Spark records to S3
-      records.write.mode(SaveMode.Overwrite).parquet(s"s3://$parquetBucket/crash_aggregates/v1/submission_date=$currentDateString")
+      records.write.mode(SaveMode.Overwrite).parquet(s"s3://${conf.outputBucket()}/crash_aggregates/v1/submission_date=$currentDateString")
 
       println("=======================================================================================")
       println(s"JOB COMPLETED SUCCESSFULLY FOR $currentDate")

--- a/src/main/scala/com/mozilla/telemetry/views/E10sExperiment.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/E10sExperiment.scala
@@ -37,7 +37,7 @@ object E10sExperimentView {
     val channel = opt[String]("channel", descr = "channel", required = true)
     val version = opt[String]("version", descr = "version", required = true)
     val experimentId = opt[String]("experiment", descr = "experiment", required = true)
-    val outputBucket = opt[String]("bucket", descr = "bucket", required = true)
+    val outputBucket = opt[String]("bucket", descr = "Destination bucket for parquet data", required = true)
     verify()
   }
 

--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -9,7 +9,6 @@ import org.json4s.jackson.JsonMethods.parse
 import org.rogach.scallop._
 import com.mozilla.telemetry.heka.{Dataset, HekaFrame, Message}
 import com.mozilla.telemetry.utils.MainPing
-import com.typesafe.config.ConfigFactory
 
 object MainSummaryView {
   def streamVersion: String = "v3"
@@ -19,7 +18,7 @@ object MainSummaryView {
   private class Conf(args: Array[String]) extends ScallopConf(args) {
     val from = opt[String]("from", descr = "From submission date", required = false)
     val to = opt[String]("to", descr = "To submission date", required = false)
-    val bucket = opt[String]("bucket", descr = "Destination bucket for parquet data", required = false)
+    val outputBucket = opt[String]("bucket", descr = "Destination bucket for parquet data", required = true)
     val limit = opt[Int]("limit", descr = "Maximum number of files to read from S3", required = false)
     verify()
   }
@@ -34,15 +33,6 @@ object MainSummaryView {
     val from = conf.from.get match {
       case Some(f) => fmt.parseDateTime(f)
       case _ => DateTime.now.minusDays(1)
-    }
-
-    val appConf = ConfigFactory.load()
-
-    // Use the 'bucket' parameter if supplied, else default to
-    // what's in the config.
-    val parquetBucket = conf.bucket.get match {
-      case Some(b) => b
-      case _ => appConf.getString("app.parquetBucket")
     }
 
     // Set up Spark
@@ -107,7 +97,7 @@ object MainSummaryView {
       //    loaded, so we can't do single day incremental updates.
       //  - "ignore" causes new data not to be saved.
       // So we manually add the "submission_date_s3" parameter to the s3path.
-      val s3path = s"s3://$parquetBucket/$jobName/$streamVersion/submission_date_s3=$currentDateString"
+      val s3path = s"s3://${conf.outputBucket()}/$jobName/$streamVersion/submission_date_s3=$currentDateString"
 
       // Repartition the dataframe by sample_id before saving.
       val partitioned = records.repartition(100, records.col("sample_id"))


### PR DESCRIPTION
This library was removed from the project dependencies in
https://github.com/mozilla/telemetry-batch-view/commit/c7c8cc4bcedbc3b7c343fc1490eb775be5dba4c2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/86)
<!-- Reviewable:end -->
