### PR TITLE
Parallelize Dataset implementation.

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/utils/package.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/package.scala
@@ -101,4 +101,12 @@ package object utils{
     logger.info(s"Uploading Parquet file to $bucket/$key")
     s3.putObject(bucket, key, file)
   }
+
+  def time[R](block: => R): R = {
+    val t0 = System.nanoTime()
+    val result = block  // call-by-name
+    val t1 = System.nanoTime()
+    println(s"Elapsed time: ${(t1 - t0)/1000000000.0} s")
+    result
+  }
 }

--- a/src/main/scala/com/mozilla/telemetry/utils/package.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/package.scala
@@ -1,14 +1,8 @@
 package com.mozilla.telemetry
 package object utils{
-  import awscala.s3._
-  import java.util.UUID
   import java.rmi.dgc.VMID
   import org.apache.hadoop.fs.Path
   import org.joda.time._
-  import org.apache.log4j.Logger
-
-  @transient private lazy val s3: S3 = S3()
-  @transient private lazy val logger = Logger.getLogger("Utils")
 
   private val specialCases = Map(
     "submission_url" -> "submissionURL",
@@ -88,18 +82,6 @@ package object utils{
     val vmid = new VMID().toString.replaceAll(":|-", "")
     val fileURI = java.nio.file.Paths.get(System.getProperty("java.io.tmpdir"), s"$vmid.tmp").toUri
     new Path(fileURI)
-  }
-
-  def isS3PrefixEmpty(bucket: String, prefix: String): Boolean = {
-    import awscala.s3._
-    val s3: S3 = S3()
-    s3.objectSummaries(Bucket(bucket), prefix).isEmpty
-  }
-
-  def uploadLocalFileToS3(file: java.io.File, bucket: String, prefix: String, name: String = UUID.randomUUID.toString) {
-    val key = s"$prefix/$name"
-    logger.info(s"Uploading Parquet file to $bucket/$key")
-    s3.putObject(bucket, key, file)
   }
 
   def time[R](block: => R): R = {

--- a/src/main/scala/com/mozilla/telemetry/views/Churn.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/Churn.scala
@@ -61,7 +61,7 @@ object ChurnView {
     val clsName = uncamelize(this.getClass.getSimpleName.replace("$", ""))
     val prefix = s"${clsName}/v1/submission_date_s3=${currentDay}"
 
-    require(isS3PrefixEmpty(outputBucket, prefix), s"s3://${outputBucket}/${prefix} already exists!")
+    require(S3Store.isPrefixEmpty(outputBucket, prefix), s"s3://${outputBucket}/${prefix} already exists!")
 
     messages
       .flatMap(messageToMap)
@@ -75,7 +75,7 @@ object ChurnView {
 
         while(records.nonEmpty) {
           val localFile = new java.io.File(ParquetFile.serialize(records, schema).toUri)
-          uploadLocalFileToS3(localFile, outputBucket, prefix)
+          S3Store.uploadFile(localFile, outputBucket, prefix)
           localFile.delete()
         }
     }

--- a/src/main/scala/com/mozilla/telemetry/views/E10sExperiment.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/E10sExperiment.scala
@@ -78,7 +78,7 @@ object E10sExperimentView {
     val prefix = s"${clsName}/${experimentId}/v${opts.from()}_${opts.to()}"
     val outputBucket = opts.outputBucket()
 
-    require(isS3PrefixEmpty(outputBucket, prefix), s"s3://${outputBucket}/${prefix} already exists!")
+    require(S3Store.isPrefixEmpty(outputBucket, prefix), s"s3://${outputBucket}/${prefix} already exists!")
 
     messages
       .flatMap { message =>
@@ -124,7 +124,7 @@ object E10sExperimentView {
 
         while(records.nonEmpty) {
           val localFile = new java.io.File(ParquetFile.serialize(records, schema).toUri)
-          uploadLocalFileToS3(localFile, outputBucket, prefix)
+          S3Store.uploadFile(localFile, outputBucket, prefix)
           localFile.delete()
         }
       }

--- a/src/main/scala/com/mozilla/telemetry/views/Longitudinal.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/Longitudinal.scala
@@ -115,7 +115,7 @@ object LongitudinalView {
     val prefix = s"${clsName}/v${opts.to()}"
     val outputBucket = opts.outputBucket()
 
-    require(isS3PrefixEmpty(outputBucket, prefix), s"s3://${outputBucket}/${prefix} already exists!")
+    require(S3Store.isPrefixEmpty(outputBucket, prefix), s"s3://${outputBucket}/${prefix} already exists!")
 
     // Sort submissions in descending order
     implicit val ordering = Ordering[(String, String, Int)].reverse
@@ -165,7 +165,7 @@ object LongitudinalView {
           // Block size has to be increased to pack more than a couple hundred profiles
           // within the same row group.
           val localFile = new java.io.File(ParquetFile.serialize(records, schema, 8).toUri())
-          uploadLocalFileToS3(localFile, outputBucket, prefix)
+          S3Store.uploadFile(localFile, outputBucket, prefix)
           localFile.delete()
         }
 

--- a/src/test/scala/com/mozilla/telemetry/DatasetTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/DatasetTest.scala
@@ -55,6 +55,7 @@ object MockS3Store extends AbstractS3Store {
       case "Error/" => Stream(ObjectSummary("error", 1), ObjectSummary("missing", 1))
     }
   }
+
   def listFolders(bucket: String, prefix: String, delimiter: String): Stream[String] = prefix match {
     case "telemetry/" => Stream("20160606/", "20160607/")
     case "20160606/" => Stream("main/", "crash/", "error/")
@@ -63,6 +64,10 @@ object MockS3Store extends AbstractS3Store {
     case "crash/" => Stream("Fennec/")
     case "error/" => Stream("Error/")
   }
+
+  def uploadFile(file: java.io.File, bucket: String, prefix: String, name: String) = ???
+
+  def isPrefixEmpty(bucket: String, prefix: String): Boolean = ???
 }
 
 class DatasetTest extends FlatSpec with Matchers{


### PR DESCRIPTION
This patch makes the scanning of files on S3 about 13x faster on a c3.4xlarge, in doing so it decreases the run-time of the Longitudinal job by about 30 min (10%).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/87)
<!-- Reviewable:end -->
