### PR TITLE
Get rid of metadata that breaks partition discovery.

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/utils/S3.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/S3.scala
@@ -31,6 +31,7 @@ abstract class AbstractS3Store {
   def listFolders(bucket: String, prefix: String, delimiter: String = "/"): Stream[String]
   def getKey(bucket: String, key: String): InputStream
   def uploadFile(file: File, bucket: String, prefix: String, name: String)
+  def deleteKey(bucket: String, key: String)
   def isPrefixEmpty(bucket: String, prefix: String): Boolean
 }
 
@@ -72,6 +73,11 @@ object S3Store extends AbstractS3Store {
     val key = s"$prefix/$name"
     logger.info(s"Uploading file to $bucket/$key")
     s3.putObject(bucket, key, file)
+  }
+
+  def deleteKey(bucket: String, key: String) {
+    logger.info(s"Deleting file s3://$bucket/$key")
+    s3.deleteObject(bucket, key)
   }
 
   def isPrefixEmpty(bucket: String, prefix: String): Boolean = {

--- a/src/test/scala/com/mozilla/telemetry/DatasetTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/DatasetTest.scala
@@ -67,6 +67,8 @@ object MockS3Store extends AbstractS3Store {
 
   def uploadFile(file: java.io.File, bucket: String, prefix: String, name: String) = ???
 
+  def deleteKey(bucket: String, key: String) = ???
+
   def isPrefixEmpty(bucket: String, prefix: String): Boolean = ???
 }
 


### PR DESCRIPTION
Per Bug 1282758, having the _metadata and _SUCCESS files in non-leaf
directories breaks Spark's partition discovery in our current version.
The problem is fixed in Spark 2.0, but until then, we work around it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/88)
<!-- Reviewable:end -->
