### PR TITLE
Close S3Objects after reading them.

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/heka/HekaFrame.scala
+++ b/src/main/scala/com/mozilla/telemetry/heka/HekaFrame.scala
@@ -69,9 +69,15 @@ object HekaFrame{
         case Success(x) =>
           x
         case _ if n > 1 =>
+          if (is != null) {
+            is.close()
+          }
           is = null
           retry(n - 1)(fn)
         case Failure(e) =>
+          if (is != null) {
+            is.close()
+          }
           throw e
       }
     }
@@ -86,8 +92,14 @@ object HekaFrame{
             None
         }
       }.takeWhile {
-        case Some(x) => true
-        case _ => false
+        case Some(x) =>
+          true
+
+        case _ =>
+          if (is != null) {
+            is.close()
+          }
+          false
       }.flatten
   }
 }


### PR DESCRIPTION
S3Object opens a connection which is not freed even if the object is garbage
collected so it has to be explicitely closed in order to liberate the connection
to the pool.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1285127.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/92)
<!-- Reviewable:end -->
