### PR TITLE
Bug 1286305: Add new system.os fields to longitudinal dataset

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/utils/package.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/package.scala
@@ -7,6 +7,7 @@ package object utils{
   private val specialCases = Map(
     "submission_url" -> "submissionURL",
     "memory_mb" -> "memoryMB",
+    "windows_ubr" -> "windowsUBR",
     "virtual_max_mb" -> "virtualMaxMB",
     "l2cache_kb" -> "l2cacheKB",
     "l3cache_kb" -> "l3cacheKB",

--- a/src/main/scala/com/mozilla/telemetry/views/Longitudinal.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/Longitudinal.scala
@@ -270,6 +270,9 @@ object LongitudinalView {
         .name("kernel_version").`type`().optional().stringType()
         .name("service_pack_major").`type`().optional().intType()
         .name("service_pack_minor").`type`().optional().intType()
+        .name("windows_build_number").`type`().optional().intType()
+        .name("windows_ubr").`type`().optional().intType()
+        .name("install_year").`type`().optional().intType()
         .name("locale").`type`().optional().stringType()
       .endRecord()
     val systemHddType = SchemaBuilder

--- a/src/test/scala/com/mozilla/telemetry/LongitudinalTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/LongitudinalTest.scala
@@ -81,6 +81,9 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
         ("os" ->
           ("name" -> "Windows_NT") ~
           ("locale" -> "en_US") ~
+          ("windowsBuildNumber" -> 10586) ~
+          ("windowsUBR" -> 446) ~
+          ("installYear" -> 2016) ~
           ("version" -> "6.1")) ~
         ("hdd" ->
           ("profile" ->
@@ -242,6 +245,14 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
     val records = fixture.row.getList[Row](fixture.row.fieldIndex("system_os"))
     assert(records.length == fixture.payloads.length)
     records.foreach(x => assert(x.getAs[String]("name") == "Windows_NT"))
+  }
+
+  "environment.system/os windows fields" must "be converted correctly" in {
+    val records = fixture.row.getList[Row](fixture.row.fieldIndex("system_os"))
+    assert(records.length == fixture.payloads.length)
+    records.foreach(x => assert(x.getAs[Int]("windows_build_number") == 10586))
+    records.foreach(x => assert(x.getAs[Int]("windows_ubr") == 446))
+    records.foreach(x => assert(x.getAs[Int]("install_year") == 2016))
   }
 
   "environment.system/hdd" must "be converted correctly" in {


### PR DESCRIPTION
Adding windowsUBR and windowsBuildNumber to longitudinal dataset.

I'm not sure how uncamelize will behave with "windowsUBR". Is there a way to generate an example dataset locally? I followed the instructions on the README, but needed AWS credentials.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/96)
<!-- Reviewable:end -->
