### PR TITLE
Train with addon ids

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ lazy val root = (project in file(".")).
     libraryDependencies += "org.apache.spark" %% "spark-core" % "1.6.1",
     libraryDependencies += "org.apache.spark" %% "spark-sql" % "1.6.1",
     libraryDependencies += "org.apache.spark" %% "spark-mllib" % "1.6.1",
+    libraryDependencies += "org.apache.spark" %% "spark-hive" % "1.6.1",
     libraryDependencies += "vitillo" % "spark-hyperloglog" % "1.0.2"
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,8 @@ lazy val root = (project in file(".")).
     libraryDependencies += "org.apache.spark" %% "spark-sql" % "1.6.1",
     libraryDependencies += "org.apache.spark" %% "spark-mllib" % "1.6.1",
     libraryDependencies += "org.apache.spark" %% "spark-hive" % "1.6.1",
-    libraryDependencies += "vitillo" % "spark-hyperloglog" % "1.0.2"
+    libraryDependencies += "vitillo" % "spark-hyperloglog" % "1.0.2",
+    libraryDependencies +=  "org.scalaj" %% "scalaj-http" % "2.3.0"
   )
 
 run in Compile <<= Defaults.runTask(fullClasspath in Compile, mainClass in (Compile, run), runner in (Compile, run))

--- a/src/main/scala/com/mozilla/telemetry/ml/AMODatabase.scala
+++ b/src/main/scala/com/mozilla/telemetry/ml/AMODatabase.scala
@@ -1,0 +1,119 @@
+package com.mozilla.telemetry.ml
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+
+import org.json4s._
+import org.json4s.jackson.JsonMethods._
+import org.json4s.jackson.Serialization
+import org.json4s.jackson.Serialization.write
+
+import scala.annotation.tailrec
+import scala.collection.Map
+import scala.io.Source
+import scalaj.http.Http
+
+private case class AMOAddonPage(previous: String, next: String, results: List[AMOAddonInfo])
+private case class AMOAddonInfo(guid: String, default_locale: String, name: Map[String,String])
+
+/**
+  * The AMODatabase singleton encapsulates a local version of the addons.mozilla.org (AMO)
+  * database by using the provided public API.
+  *
+  * There are non-publicly available addons on AMO. This could happen because, the add-on:
+  * - has been disabled by the developer;
+  * - has been rejected;
+  * - it's unlisted. The developer has submitted it to AMO for it to be signed but does not
+  *   want us to distribute it, they'll handle that themselves;
+  * - its developer started the submission process but didn't finish it, so the AMO entry has
+  *   incomplete information.
+  *
+  * In all these cases, the public unauthenticated a.m.o API won't return the addon information.
+  */
+final object AMODatabase {
+  implicit val formats = Serialization.formats(NoTypeHints)
+  // This API URI will fetch all the public addons for Firefox, sorting them by creation date.
+  private val AMORequestURI = "https://addons.mozilla.org/api/v3/addons/search/?app=firefox&sort=created&type=extension"
+  private val logger = org.apache.log4j.Logger.getLogger(this.getClass.getName)
+  private val addonDB: Map[String, AMOAddonInfo] = getDatabase()
+
+  /**
+    * Fetch the remote AMO database by using the /search API endpoint.
+    * @param requestUri The AMO URI to query.
+    * @return A map of addon GUIDs to their info.
+    */
+  private def fetchAddonsDatabase(requestUri: Option[String]): Map[String, AMOAddonInfo] = {
+    @tailrec
+    def fetchAMOPage(requestUri: Option[String], addonMap: Map[String, AMOAddonInfo]): Map[String, AMOAddonInfo] = {
+      requestUri match {
+        case Some(pageUri) => {
+          logger.info(s"Fetching $pageUri")
+
+          // Fetch the JSON results for this "page" and parse it using json4s.
+          val responseBody = Http(pageUri).asString.body
+          val parsedObj = parse(responseBody)
+
+          // We're only interested in a few fields for each addon (e.g. locale).
+          // De-serialize the JSON data into classes and then build the GUID -> Addon map.
+          val data = parsedObj.extract[AMOAddonPage]
+          val partialMap = data.results.map(addon => addon.guid -> addon).toMap
+
+          // Merge the map containing the addon info from this page to the complete map.
+          val nextPageURI = (parsedObj \ "next").extractOpt[String]
+          fetchAMOPage(nextPageURI, addonMap ++ partialMap)
+        }
+        case None => addonMap
+      }
+    }
+    fetchAMOPage(requestUri, Map())
+  }
+
+  /**
+    * Fetch a copy of the AMO addons database or return a cached local copy if
+    * available.
+    * @return A map of addon GUIDs to their info.
+    */
+  private def getDatabase(): Map[String, AMOAddonInfo] = synchronized {
+    // If we have a cached copy of the request handy, use that. Please note that
+    // the "read-from-disk" functionality is only needed for testing purposes, so
+    // cache invalidation isn't a real issue.
+    val dbPath = Paths.get("./addons_database.json")
+    if (Files.exists(dbPath)) {
+      logger.info(s"Hitting addon database cache at $dbPath")
+      parse(Source.fromFile(dbPath.toString()).mkString).extract[Map[String, AMOAddonInfo]]
+    } else {
+      // Otherwise fetch it from addons.mozilla.org (might take some time..) and cache it.
+      val fetchedAddonsMap = fetchAddonsDatabase(Some(AMORequestURI))
+      val serializedFetchedAddons = write(fetchedAddonsMap)
+      Files.write(dbPath, serializedFetchedAddons.getBytes(StandardCharsets.UTF_8))
+      fetchedAddonsMap
+    }
+  }
+
+  /**
+    * Get the name of the desired addon, in the default locale.
+    * @param addonId The GUID for the desired addon.
+    * @return The addon name, if available, or an empty Option. The name should always be available,
+    *         unless the database is corrupted.
+    */
+  def getAddonNameById(addonId: String): Option[String] = {
+    // The addon info contains the default_locale for the addon as a mandatory field, which is a string
+    // containing the name of the default locale (e.g. "it_IT"). This is the locale used as a reference
+    // for translations and, as such, the "preferred" one.
+    addonDB.get(addonId) match {
+      case Some(addonInfo) => addonInfo.name.get(addonInfo.default_locale)
+      case None =>
+        logger.warn(s"Addon GUID not in AMO DB: $addonId")
+        None
+    }
+  }
+
+  /**
+    * Tests whether the addon id is contained in the database.
+    * @param addonId The GUID for the desired addon.
+    * @return True if the addon database contains the addon, False otherwise.
+    */
+  def contains(addonId: String): Boolean = {
+    addonDB.contains(addonId)
+  }
+}

--- a/src/main/scala/com/mozilla/telemetry/ml/AddonRecommender.scala
+++ b/src/main/scala/com/mozilla/telemetry/ml/AddonRecommender.scala
@@ -140,7 +140,7 @@ object AddonRecommender {
           addonType <- meta.`type`
           if !blocklisted && (addonType != "extension" || signedState == 2) && !userDisabled && !appDisabled
         } yield {
-          (clientId, addonName, hash(clientId), hash(addonName))
+          (clientId, addonName, hash(clientId), hash(addonId))
         }
       }
 
@@ -180,9 +180,8 @@ object AddonRecommender {
 
     // Serialize add-on mapping
     val addonMapping = clientAddons
-      .map(_._2)
+      .map{ case (_, addonName, _, hashedAddonId) => (hashedAddonId, addonName)}
       .distinct
-      .map(addon => (hash(addon), addon))
       .cache()
       .collect()
       .toMap

--- a/src/main/scala/com/mozilla/telemetry/ml/AddonRecommender.scala
+++ b/src/main/scala/com/mozilla/telemetry/ml/AddonRecommender.scala
@@ -8,7 +8,7 @@ import com.github.fommil.netlib.BLAS.{getInstance => blas}
 import org.apache.spark.ml.evaluation.NaNRegressionEvaluator
 import org.apache.spark.ml.recommendation.{ALS, ALSModel}
 import org.apache.spark.ml.tuning.{CrossValidator, ParamGridBuilder}
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.hive.HiveContext
 import org.apache.spark.{SparkConf, SparkContext}
 import org.json4s.JsonDSL._
 import org.json4s._
@@ -121,10 +121,10 @@ object AddonRecommender {
     val sparkConf = new SparkConf().setAppName(this.getClass.getName)
     sparkConf.setMaster(sparkConf.get("spark.master", "local[*]"))
     val sc = new SparkContext(sparkConf)
-    val sqlContext = new SQLContext(sc)
-    import sqlContext.implicits._
+    val hiveContext = new HiveContext(sc)
+    import hiveContext.implicits._
 
-    val clientAddons = sqlContext.sql("select * from longitudinal")
+    val clientAddons = hiveContext.sql("select * from longitudinal")
       .where("active_addons is not null")
       .selectExpr("client_id", "active_addons[0] as active_addons")
       .as[Addons]


### PR DESCRIPTION
This changes the addon recommender to fetch the addon database from addons.mozilla.org. We use the dumped information to prune commercial, unreviewed, privated or, in general, unlisted addons before training the model.

We also use the dumped information to get the addon name from the reported default locale, instead of relying on data coming from the clients.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/97)
<!-- Reviewable:end -->
