### PR TITLE
Bug 1287101 - Pass the new `processes` structure through

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/E10sExperiment.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/E10sExperiment.scala
@@ -149,6 +149,7 @@ object E10sExperimentView {
       .name("histograms").`type`().stringType().noDefault()
       .name("keyedHistograms").`type`().stringType().noDefault()
       .name("childPayloads").`type`().stringType().noDefault()
+      .name("processes").`type`().stringType().noDefault()
       .endRecord
   }
 
@@ -176,6 +177,7 @@ object E10sExperimentView {
       .set("histograms", fields.getOrElse("payload.histograms", ""))
       .set("keyedHistograms", fields.getOrElse("payload.keyedHistograms", ""))
       .set("childPayloads", fields.getOrElse("payload.childPayloads", "{}"))
+      .set("processes", fields.getOrElse("payload.processes", "{}"))
       .build
 
     Some(root)


### PR DESCRIPTION
After bug 1218576, this is where child histograms could be.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/98)
<!-- Reviewable:end -->
