### PR TITLE
Add a basic CrossSectionalView with a single metric

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/CrossSectionalView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/CrossSectionalView.scala
@@ -1,0 +1,92 @@
+package com.mozilla.telemetry.views
+
+import org.rogach.scallop._
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.hive.HiveContext
+import org.apache.spark.sql.SQLContext
+
+case class Longitudinal (
+    client_id: String
+  , geo_country: Option[Seq[String]]
+  , session_length: Option[Seq[Long]]
+)
+
+case class CrossSectional (
+    client_id: String
+  , modal_country: Option[String]
+)
+
+object CrossSectionalView {
+  private class Opts(args: Array[String]) extends ScallopConf(args) {
+    val outputBucket = opt[String](
+      "outputBucket",
+      descr = "Bucket in which to save data",
+      required = false,
+      default=Some("telemetry-test-bucket/harter"))
+    val localTable = opt[String](
+      "localTable",
+      descr = "Optional path to a local Parquet file with longitudinal data",
+      required = false)
+    val outName = opt[String](
+      "outName",
+      descr = "Name for the output of this run",
+      required = true)
+    verify()
+  }
+
+  private[telemetry] object Aggregation {
+    // Spark triggers a strange error during distributed computation if these
+    // functions are in the same scope as the main function. This appears to
+    // only be an issue with Spark 1.6. 
+    // TODO(harter): debug this error and remove this object if possible.
+    def weightedMode(values: Seq[String], weights: Seq[Long]): Option[String] = {
+      if (values.size > 0 && values.size == weights.size) {
+        val pairs = values zip weights
+        val agg = pairs.groupBy(_._1).map(kv => (kv._1, kv._2.map(_._2).sum))
+        Some(agg.maxBy(_._2)._1)
+      } else {
+        None
+      }
+    }
+
+    def modalCountry(row: Longitudinal): Option[String] = {
+      (row.geo_country, row.session_length) match {
+        case (Some(gc), Some(sl)) => weightedMode(gc, sl)
+        case _ => None
+      }
+    } 
+
+    def generateCrossSectional(base: Longitudinal): CrossSectional = {
+      val output = CrossSectional(base.client_id, modalCountry(base))
+      output
+    }
+  }
+
+  def main(args: Array[String]): Unit = {
+    val sparkConf = new SparkConf().setAppName(this.getClass.getName)
+    sparkConf.setMaster(sparkConf.get("spark.master", "local[*]"))
+    val sc = new SparkContext(sparkConf)
+
+    val sqlContext = new SQLContext(sc)
+
+    val hiveContext = new HiveContext(sc)
+    import hiveContext.implicits._
+
+    val opts = new Opts(args)
+
+    if(opts.localTable.isSupplied) {
+      val localTable = opts.localTable()
+      val data = sqlContext.read.parquet(localTable)
+      data.registerTempTable("longitudinal")
+    }
+
+    val ds = hiveContext
+      .sql("SELECT * FROM longitudinal")
+      .selectExpr("client_id", "geo_country", "session_length")
+      .as[Longitudinal]
+    val output = ds.map(Aggregation.generateCrossSectional)
+
+    val prefix = s"s3://${opts.outputBucket()}/CrossSectional/${opts.outName}"
+    println("="*80 + "\n" + output.count + "\n" + "="*80)
+  }
+}

--- a/src/test/scala/com/mozilla/telemetry/CrossSectionalViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/CrossSectionalViewTest.scala
@@ -1,0 +1,56 @@
+package com.mozilla.telemetry
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.SQLContext
+import com.mozilla.telemetry.views._
+import CrossSectionalView._
+import Aggregation._
+import org.scalatest.FlatSpec
+import org.apache.spark.sql.Dataset
+
+class CrossSectionalViewTest extends FlatSpec {
+  def compareDS(actual: Dataset[CrossSectional], expected: Dataset[CrossSectional]) = {
+    actual.collect.zip(expected.collect)
+      .map(xx => xx._1 == xx._2)
+      .reduce(_ && _)
+  }
+
+  "CrossSectional" must "be calculated correctly" in {
+    val sparkConf = new SparkConf().setAppName("CrossSectionalTest")
+    sparkConf.setMaster(sparkConf.get("spark.master", "local[1]"))
+    val sc = new SparkContext(sparkConf)
+    val sqlContext = new SQLContext(sc)
+    import sqlContext.implicits._
+
+    val longitudinalDataset = Seq(
+      Longitudinal("a", Option(Seq("DE", "DE", "IT")), Option(Seq(2, 3, 4))),
+      Longitudinal("b", Option(Seq("EG", "EG", "DE")), Option(Seq(1, 1, 2)))
+    ).toDS
+
+    val actual = longitudinalDataset.map(generateCrossSectional)
+    val expected = Seq(
+      CrossSectional("a", Option("DE")),
+      CrossSectional("b", Option("EG"))).toDS
+
+    assert(compareDS(actual, expected))
+    sc.stop()
+  }
+
+  "Modes" must "combine repeated keys" in {
+    val ll = Longitudinal(
+      "id",
+      Option(Seq("DE", "IT", "DE")),
+      Option(Seq(3, 6, 4)))
+    val country = modalCountry(ll)
+    assert(country == Some("DE"))
+  }
+
+  it must "respect session weight" in {
+    val ll = Longitudinal(
+      "id",
+      Option(Seq("DE", "IT", "IT")),
+      Option(Seq(3, 1, 1)))
+    val country = modalCountry(ll)
+    assert(country == Some("DE"))
+  }
+}


### PR DESCRIPTION
Bug 1286573 - Create cross-sectional parquet dataset

This view only calculates a simple modal country and discards the data
after counting the number of rows. From this platform, we can save the
data to S3 and begin adding more metrics to meet the project
requirements.

There was a significant amount of troubleshooting required to get to
this stage. Accordingly, I'd like to keep this commit as the simplest
example of working with a Dataset instead of a Dataframe.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/105)
<!-- Reviewable:end -->
