### PR TITLE
Make CrossSectionalView write to S3

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/CrossSectionalView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/CrossSectionalView.scala
@@ -4,6 +4,7 @@ import org.rogach.scallop._
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.hive.HiveContext
 import org.apache.spark.sql.SQLContext
+import com.mozilla.telemetry.utils.S3Store
 
 case class Longitudinal (
     client_id: String
@@ -22,7 +23,7 @@ object CrossSectionalView {
       "outputBucket",
       descr = "Bucket in which to save data",
       required = false,
-      default=Some("telemetry-test-bucket/harter"))
+      default=Some("telemetry-test-bucket"))
     val localTable = opt[String](
       "localTable",
       descr = "Optional path to a local Parquet file with longitudinal data",
@@ -67,26 +68,38 @@ object CrossSectionalView {
     sparkConf.setMaster(sparkConf.get("spark.master", "local[*]"))
     val sc = new SparkContext(sparkConf)
 
-    val sqlContext = new SQLContext(sc)
-
     val hiveContext = new HiveContext(sc)
     import hiveContext.implicits._
 
     val opts = new Opts(args)
 
+    // Read local parquet data, if supplied
     if(opts.localTable.isSupplied) {
       val localTable = opts.localTable()
-      val data = sqlContext.read.parquet(localTable)
+      val data = hiveContext.read.parquet(localTable)
       data.registerTempTable("longitudinal")
     }
 
+    // Calculate CrossSectional dataset
     val ds = hiveContext
       .sql("SELECT * FROM longitudinal")
       .selectExpr("client_id", "geo_country", "session_length")
       .as[Longitudinal]
     val output = ds.map(Aggregation.generateCrossSectional)
 
-    val prefix = s"s3://${opts.outputBucket()}/CrossSectional/${opts.outName}"
+    // Save to S3
+    val prefix = s"cross_sectional/${opts.outName()}"
+    val outputBucket = opts.outputBucket()
+    val path = s"s3://${outputBucket}/${prefix}"
+
+
+    require(S3Store.isPrefixEmpty(outputBucket, prefix),
+      s"${path} already exists!")
+
+    output.toDF().write.parquet(path)
+
+    // Force the computation, debugging purposes only
+    // TODO(harterrt): Remove this
     println("="*80 + "\n" + output.count + "\n" + "="*80)
   }
 }


### PR DESCRIPTION
Bug 1298119 - Write example XSec dataset to S3

Apparently, writing to S3 was broken with non-backwards compatible
changes to the api. Including an older version of the JAR fixes my write
errors. Without this jar I get a NoSuchMethodError error from AWS.
Reference article:
http://deploymentzone.com/2015/12/20/s3a-on-spark-on-aws-ec2/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/107)
<!-- Reviewable:end -->
