### PR TITLE
Replace case class to bypass the 22 field limit

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/CrossSectionalView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/CrossSectionalView.scala
@@ -5,16 +5,47 @@ import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.hive.HiveContext
 import org.apache.spark.sql.SQLContext
 
-case class Longitudinal (
-    client_id: String
-  , geo_country: Option[Seq[String]]
-  , session_length: Option[Seq[Long]]
-)
+abstract class DataSetRow() extends Product {
+  // This class is a work around the 22 field limit in case classes. The 22
+  // field limit is removed in scala 2.11, but until we upgrade our spark
+  // clusters, we have to work with 2.10.
+  // Spark only includes encoders for primitive types and objects implementing
+  // the Product interface.
+  val valSeq: Array[Any]
 
-case class CrossSectional (
-    client_id: String
-  , modal_country: Option[String]
-)
+  def productArity() = valSeq.length
+  def productElement(n: Int) = valSeq(n)
+  //TODO(harter): restrict equality to a data type
+  def canEqual(that: Any) = true
+  override def equals(that: Any) = {
+    that match {
+      case that: DataSetRow => that.canEqual(this) && this.valSeq.deep == that.valSeq.deep
+      case _ => false
+    }
+  }
+}
+
+class Longitudinal (
+    val client_id: String
+  , val geo_country: Option[Seq[String]]
+  , val session_length: Option[Seq[Long]]
+) extends DataSetRow {
+  override val valSeq = Array[Any](client_id, geo_country, session_length)
+}
+
+class CrossSectional (
+    val client_id: String
+  , val modal_country: Option[String]
+) extends DataSetRow {
+  override val valSeq = Array[Any](client_id, modal_country)
+
+  def this(ll: Longitudinal) {
+    this(
+      ll.client_id,
+      CrossSectionalView.Aggregation.modalCountry(ll)
+    )
+  }
+}
 
 object CrossSectionalView {
   private class Opts(args: Array[String]) extends ScallopConf(args) {
@@ -55,11 +86,6 @@ object CrossSectionalView {
         case _ => None
       }
     } 
-
-    def generateCrossSectional(base: Longitudinal): CrossSectional = {
-      val output = CrossSectional(base.client_id, modalCountry(base))
-      output
-    }
   }
 
   def main(args: Array[String]): Unit = {
@@ -84,7 +110,7 @@ object CrossSectionalView {
       .sql("SELECT * FROM longitudinal")
       .selectExpr("client_id", "geo_country", "session_length")
       .as[Longitudinal]
-    val output = ds.map(Aggregation.generateCrossSectional)
+    val output = ds.map(new CrossSectional(_))
 
     val prefix = s"s3://${opts.outputBucket()}/CrossSectional/${opts.outName}"
     println("="*80 + "\n" + output.count + "\n" + "="*80)

--- a/src/test/scala/com/mozilla/telemetry/CrossSectionalViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/CrossSectionalViewTest.scala
@@ -23,21 +23,22 @@ class CrossSectionalViewTest extends FlatSpec {
     import sqlContext.implicits._
 
     val longitudinalDataset = Seq(
-      Longitudinal("a", Option(Seq("DE", "DE", "IT")), Option(Seq(2, 3, 4))),
-      Longitudinal("b", Option(Seq("EG", "EG", "DE")), Option(Seq(1, 1, 2)))
+      new Longitudinal("a", Option(Seq("DE", "DE", "IT")), Option(Seq(2, 3, 4))),
+      new Longitudinal("b", Option(Seq("EG", "EG", "DE")), Option(Seq(1, 1, 2)))
     ).toDS
 
-    val actual = longitudinalDataset.map(generateCrossSectional)
+    val actual = longitudinalDataset.map(new CrossSectional(_))
     val expected = Seq(
-      CrossSectional("a", Option("DE")),
-      CrossSectional("b", Option("EG"))).toDS
+      new CrossSectional("a", Option("DE")),
+      new CrossSectional("b", Option("EG"))
+    ).toDS
 
     assert(compareDS(actual, expected))
     sc.stop()
   }
 
   "Modes" must "combine repeated keys" in {
-    val ll = Longitudinal(
+    val ll = new Longitudinal(
       "id",
       Option(Seq("DE", "IT", "DE")),
       Option(Seq(3, 6, 4)))
@@ -46,11 +47,27 @@ class CrossSectionalViewTest extends FlatSpec {
   }
 
   it must "respect session weight" in {
-    val ll = Longitudinal(
+    val ll = new Longitudinal(
       "id",
       Option(Seq("DE", "IT", "IT")),
       Option(Seq(3, 1, 1)))
     val country = modalCountry(ll)
     assert(country == Some("DE"))
+  }
+
+  "DataSetRows" must "distinguish between unequal rows" in {
+    val l1 = new Longitudinal("id", Some(Seq("DE")), Some(Seq(1)))
+    val l2 = new Longitudinal("other_id", Some(Seq("DE")), Some(Seq(1)))
+
+    assert(l1 != l2)
+  }
+
+  it must "acknowledge equal rows" in {
+    val l1 = new Longitudinal("id", Some(Seq("DE")), Some(Seq(1)))
+    val l2 = new Longitudinal("id", Some(Seq("DE")), Some(Seq(1)))
+
+    println(l1.valSeq.hashCode)
+    println(l2.valSeq.hashCode)
+    assert(l1 == l2)
   }
 }


### PR DESCRIPTION
Bug 1298123: Refactor dataset classes so they do not use case classes

Spark datasets can only be generated from classes which implement the
Product interface. We would usually use case classes for this purpose,
but case classes are limited to 22 fields. This change implements a
class to bypass this restriction.

This limit is removed in scala 2.11. Accordingly, this change should
only be a stop gap until we can upgrade our spark clusters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/108)
<!-- Reviewable:end -->
