### PR TITLE
Refactor agg functions to a separate package

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/utils/Aggregation.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/Aggregation.scala
@@ -1,0 +1,16 @@
+package com.mozilla.telemetry.utils
+
+package object aggregation {
+  def weightedMode[A](values: Seq[A], weights: Seq[Long]): A = {
+    if (values.size != weights.size) {
+      throw new IllegalArgumentException("Args to weighted mode must have the same length.")
+    } else if (values.size == 0) {
+      throw new IllegalArgumentException("Args to weighted mode must have length > 0.")
+    } else {
+      val pairs = values zip weights
+      val agg = pairs.groupBy(_._1).map(kv => (kv._1, kv._2.map(_._2).sum))
+      agg.maxBy(_._2)._1
+    }
+  }
+}
+

--- a/src/test/scala/com/mozilla/telemetry/AggregationTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/AggregationTest.scala
@@ -1,0 +1,16 @@
+package com.mozilla.telemetry
+
+import com.mozilla.telemetry.utils.aggregation
+import org.scalatest.FlatSpec
+
+class AggregationTest extends FlatSpec {
+  "The weighted mode" must "combine repeated keys" in {
+    val mode = aggregation.weightedMode(Seq("DE", "IT", "DE"), Seq(3, 6, 4))
+    assert(mode == "DE")
+  }
+
+  it must "respect session weight" in {
+    val mode = aggregation.weightedMode(Seq("DE", "IT", "IT"), Seq(3, 1, 1))
+    assert(mode == "DE")
+  }
+}

--- a/src/test/scala/com/mozilla/telemetry/CrossSectionalViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/CrossSectionalViewTest.scala
@@ -4,7 +4,6 @@ import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.SQLContext
 import com.mozilla.telemetry.views._
 import CrossSectionalView._
-import Aggregation._
 import org.scalatest.FlatSpec
 import org.apache.spark.sql.Dataset
 
@@ -35,24 +34,6 @@ class CrossSectionalViewTest extends FlatSpec {
 
     assert(compareDS(actual, expected))
     sc.stop()
-  }
-
-  "Modes" must "combine repeated keys" in {
-    val ll = new Longitudinal(
-      "id",
-      Option(Seq("DE", "IT", "DE")),
-      Option(Seq(3, 6, 4)))
-    val country = modalCountry(ll)
-    assert(country == Some("DE"))
-  }
-
-  it must "respect session weight" in {
-    val ll = new Longitudinal(
-      "id",
-      Option(Seq("DE", "IT", "IT")),
-      Option(Seq(3, 1, 1)))
-    val country = modalCountry(ll)
-    assert(country == Some("DE"))
   }
 
   "DataSetRows" must "distinguish between unequal rows" in {


### PR DESCRIPTION
Moved XSec generator functions into class methods and constructors.
Separated Aggregate object into it's own context. Split aggregation into
it's own package

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/109)
<!-- Reviewable:end -->
