### PR TITLE
Move package to Spark 2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val root = (project in file(".")).
   settings(
     name := "telemetry-batch-view",
     version := "1.1",
-    scalaVersion := "2.10.6",
+    scalaVersion := "2.11.8",
     retrieveManaged := true,
     ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) },
     libraryDependencies += "org.apache.avro" % "avro" % "1.7.7",
@@ -22,11 +22,11 @@ lazy val root = (project in file(".")).
     libraryDependencies += "net.java.dev.jets3t" % "jets3t" % "0.9.4" excludeAll(ExclusionRule(organization = "javax.servlet")),
     libraryDependencies += "com.github.nscala-time" %% "nscala-time" % "2.10.0",
     libraryDependencies += "org.rogach" %% "scallop" % "1.0.2",
-    libraryDependencies += "org.apache.spark" %% "spark-core" % "1.6.1",
-    libraryDependencies += "org.apache.spark" %% "spark-sql" % "1.6.1",
-    libraryDependencies += "org.apache.spark" %% "spark-mllib" % "1.6.1",
-    libraryDependencies += "org.apache.spark" %% "spark-hive" % "1.6.1",
-    libraryDependencies += "vitillo" % "spark-hyperloglog" % "1.0.2",
+    libraryDependencies += "org.apache.spark" %% "spark-core" % "2.0.0",
+    libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.0.0",
+    libraryDependencies += "org.apache.spark" %% "spark-mllib" % "2.0.0",
+    libraryDependencies += "org.apache.spark" %% "spark-hive" % "2.0.0",
+    libraryDependencies += "vitillo" % "spark-hyperloglog" % "1.1.1",
     libraryDependencies +=  "org.scalaj" %% "scalaj-http" % "2.3.0"
   )
 

--- a/src/main/scala/com/mozilla/telemetry/ml/AddonRecommender.scala
+++ b/src/main/scala/com/mozilla/telemetry/ml/AddonRecommender.scala
@@ -235,6 +235,8 @@ object AddonRecommender {
     model.getEstimatorParamMaps
       .zip(model.avgMetrics)
       .foreach(logger.info)
+
+    sc.stop()
   }
 
   def main(args: Array[String]) {

--- a/src/main/scala/com/mozilla/telemetry/views/Churn.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/Churn.scala
@@ -54,6 +54,7 @@ object ChurnView {
         }
 
       run(messages, opts.outputBucket(), currentDay)
+      sc.stop()
     }
   }
 

--- a/src/main/scala/com/mozilla/telemetry/views/ClientCountView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/ClientCountView.scala
@@ -76,5 +76,6 @@ object ClientCountView {
     val aggregates = aggregate(subset).coalesce(32)
 
     aggregates.write.parquet(s"s3://${conf.outputBucket()}/client_count/v$from$to")
+    sc.stop()
   }
 }

--- a/src/main/scala/com/mozilla/telemetry/views/CrashAggregateView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/CrashAggregateView.scala
@@ -3,13 +3,13 @@ package com.mozilla.telemetry.views
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Row, SQLContext, SaveMode}
-import org.apache.spark.{Accumulator, SparkConf, SparkContext}
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.util.LongAccumulator
 import org.joda.time._
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
 import org.rogach.scallop._
-import scala.collection.JavaConversions._
-import com.mozilla.telemetry.heka.{Dataset, HekaFrame}
+import com.mozilla.telemetry.heka.Dataset
 
 object CrashAggregateView {
   private class Conf(args: Array[String]) extends ScallopConf(args) {
@@ -69,6 +69,8 @@ object CrashAggregateView {
       println(s"${main_processed.value} main pings processed, ${main_ignored.value} pings ignored")
       println(s"${crash_processed.value} crash pings processed, ${crash_ignored.value} pings ignored")
       println("=======================================================================================")
+
+      sc.stop()
     }
   }
 
@@ -122,25 +124,25 @@ object CrashAggregateView {
     } catch { case _: Throwable => 0 }
   }
 
-  def compareCrashes(sc: SparkContext, messages: RDD[Map[String, Any]]): (RDD[Row], Accumulator[Int], Accumulator[Int], Accumulator[Int], Accumulator[Int]) = {
+  def compareCrashes(sc: SparkContext, messages: RDD[Map[String, Any]]): (RDD[Row], LongAccumulator, LongAccumulator, LongAccumulator, LongAccumulator) = {
     // get the crash pairs for all of the pings, keeping track of how many we see
-    val mainProcessedAccumulator = sc.accumulator(0, "Number of processed main pings")
-    val mainIgnoredAccumulator = sc.accumulator(0, "Number of ignored main pings")
-    val crashProcessedAccumulator = sc.accumulator(0, "Number of processed crash pings")
-    val crashIgnoredAccumulator = sc.accumulator(0, "Number of ignored crash pings")
+    val mainProcessedAccumulator = sc.longAccumulator("Number of processed main pings")
+    val mainIgnoredAccumulator = sc.longAccumulator("Number of ignored main pings")
+    val crashProcessedAccumulator = sc.longAccumulator("Number of processed crash pings")
+    val crashIgnoredAccumulator = sc.longAccumulator("Number of ignored crash pings")
     val crashPairs = messages.flatMap((pingFields) => {
       getCrashPair(pingFields) match {
         case Some(crashPair) =>
           pingFields.get("docType") match {
-            case Some("crash") => crashProcessedAccumulator += 1
-            case Some("main") => mainProcessedAccumulator += 1
+            case Some("crash") => crashProcessedAccumulator.add(1)
+            case Some("main") => mainProcessedAccumulator.add(1)
             case _ => null
           }
           List(crashPair)
         case None =>
           pingFields.get("docType") match {
-            case Some("crash") => crashIgnoredAccumulator += 1
-            case Some("main") => mainIgnoredAccumulator += 1
+            case Some("crash") => crashIgnoredAccumulator.add(1)
+            case Some("main") => mainIgnoredAccumulator.add(1)
             case _ => null
           }
           List()
@@ -165,7 +167,7 @@ object CrashAggregateView {
       ).toMap
       val statsMap = (statsNames, stats).zipped.toMap
 
-      Row(activityDate, mapAsJavaMap(dimensionsMap), mapAsJavaMap(statsMap))
+      Row(activityDate, dimensionsMap, statsMap)
     })
 
     (records, mainProcessedAccumulator, mainIgnoredAccumulator, crashProcessedAccumulator, crashIgnoredAccumulator)

--- a/src/main/scala/com/mozilla/telemetry/views/CrossSectionalView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/CrossSectionalView.scala
@@ -127,5 +127,7 @@ object CrossSectionalView {
     // Force the computation, debugging purposes only
     // TODO(harterrt): Remove this
     println("="*80 + "\n" + output.count + "\n" + "="*80)
+
+    sc.stop()
   }
 }

--- a/src/main/scala/com/mozilla/telemetry/views/E10sExperiment.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/E10sExperiment.scala
@@ -70,6 +70,7 @@ object E10sExperimentView {
       }
 
     run(opts, messages)
+    sc.stop()
   }
 
   private def run(opts: Opts, messages: RDD[Message]) {

--- a/src/main/scala/com/mozilla/telemetry/views/Longitudinal.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/Longitudinal.scala
@@ -114,6 +114,7 @@ object LongitudinalView {
     }
 
     run(opts: Opts, messages)
+    sc.stop()
   }
 
   private def run(opts: Opts, messages: RDD[Message]): Unit = {

--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -133,6 +133,8 @@ object MainSummaryView {
       println("     RECORDS SEEN:    %d".format(ignoredCount.value + processedCount.value))
       println("     RECORDS IGNORED: %d".format(ignoredCount.value))
       println("=======================================================================================")
+
+      sc.stop()
     }
   }
 

--- a/src/test/scala/com/mozilla/telemetry/ParquetFile.scala
+++ b/src/test/scala/com/mozilla/telemetry/ParquetFile.scala
@@ -5,7 +5,6 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import com.google.protobuf._
 import com.mozilla.telemetry.heka.{Header, HekaFrame, Message}
 import com.mozilla.telemetry.parquet.ParquetFile
-import com.typesafe.config._
 import org.apache.avro.generic.{GenericDatumReader, GenericDatumWriter, GenericRecord, GenericRecordBuilder}
 import org.apache.avro.io.{DecoderFactory, EncoderFactory}
 import org.apache.avro.{Schema, SchemaBuilder}
@@ -65,7 +64,6 @@ object Resources {
 
 class ParquetSpec extends FlatSpec with Matchers{
   val nMessages = 42
-  val conf = ConfigFactory.load()
 
   private def readData(jsonBlobs: Seq[String], schema: Schema) : Seq[GenericRecord] = {
     val reader = new GenericDatumReader[GenericRecord](schema)


### PR DESCRIPTION
I plan to enlist help moving our jobs to Spark 2.0. I don't expect big issues but I think it makes sense that each owner schedules his jobs with Spark 2.0 through Airflow and makes sure that it works as expected. 

I will file some bugs in the next days and provide one or more examples of how to schedule a Scala job from Airflow with Spark 2.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/111)
<!-- Reviewable:end -->
