### PR TITLE
Create a derived parquet dataset for the sync ping.

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/SyncView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/SyncView.scala
@@ -1,0 +1,384 @@
+package com.mozilla.telemetry.views
+
+import com.mozilla.telemetry.heka.{Dataset, Message}
+import com.mozilla.telemetry.utils.S3Store
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{Row, SQLContext}
+import org.apache.spark.{SparkConf, SparkContext}
+import org.joda.time.{DateTime, Days, format}
+import org.json4s.{DefaultFormats, JValue}
+import org.json4s.JsonAST._
+import org.json4s.jackson.JsonMethods.parse
+import org.rogach.scallop._ // Just for my attempted mocks below.....
+
+object SyncView {
+  def streamVersion: String = "v1"
+  def jobName: String = "sync_summary"
+
+  // Configuration for command line arguments
+  private class Conf(args: Array[String]) extends ScallopConf(args) {
+    val from = opt[String]("from", descr = "From submission date", required = false)
+    val to = opt[String]("to", descr = "To submission date", required = false)
+    val outputBucket = opt[String]("bucket", descr = "Destination bucket for parquet data", required = false)
+    val outputFilename = opt[String]("outputFilename", descr = "Destination local filename for parquet data", required = false)
+    val limit = opt[Int]("limit", descr = "Maximum number of files to read from S3", required = false)
+    verify()
+  }
+
+  def main(args: Array[String]) {
+    val conf = new Conf(args) // parse command line arguments
+    if (!conf.outputBucket.supplied && !conf.outputFilename.supplied)
+      conf.errorMessageHandler("One of outputBucket or outputFilename must be specified")
+    val fmt = format.DateTimeFormat.forPattern("yyyyMMdd")
+    val to = conf.to.get match {
+      case Some(t) => fmt.parseDateTime(t)
+      case _ => DateTime.now.minusDays(1)
+    }
+    val from = conf.from.get match {
+      case Some(f) => fmt.parseDateTime(f)
+      case _ => DateTime.now.minusDays(1)
+    }
+
+    // Set up Spark
+    val sparkConf = new SparkConf().setAppName(jobName)
+    sparkConf.setMaster(sparkConf.get("spark.master", "local[*]"))
+    implicit val sc = new SparkContext(sparkConf)
+    val sqlContext = new SQLContext(sc)
+    val hadoopConf = sc.hadoopConfiguration
+
+    // We want to end up with reasonably large parquet files on S3.
+    val parquetSize = 512 * 1024 * 1024
+    hadoopConf.setInt("parquet.block.size", parquetSize)
+    hadoopConf.setInt("dfs.blocksize", parquetSize)
+    hadoopConf.set("parquet.enable.summary-metadata", "false")
+
+    for (offset <- 0 to Days.daysBetween(from, to).getDays) {
+      val currentDate = from.plusDays(offset)
+      val currentDateString = currentDate.toString("yyyyMMdd")
+
+      println("=======================================================================================")
+      println(s"BEGINNING JOB $jobName FOR $currentDateString")
+
+      val ignoredCount = sc.accumulator(0, "Number of Records Ignored")
+      val processedCount = sc.accumulator(0, "Number of Records Processed")
+
+      val messages = Dataset("telemetry")
+        .where("sourceName") {
+          case "telemetry" => true
+        }.where("sourceVersion") {
+          case "4" => true
+        }.where("docType") {
+          case "sync" => true
+        }.where("appName") {
+          case "Firefox" => true
+        }.where("submissionDate") {
+          case date if date == currentDate.toString("yyyyMMdd") => true
+        }.records(conf.limit.get)
+
+      val rowRDD = messages.flatMap(m => {
+        messageToRow(m) match {
+          case Nil =>
+            ignoredCount += 1
+            None
+          case x =>
+            processedCount += 1
+            x
+        }
+      })
+
+      val records = sqlContext.createDataFrame(rowRDD, SyncPingConverter.syncType)
+
+      if (conf.outputBucket.supplied) {
+        // Note we cannot just use 'partitionBy' below to automatically populate
+        // the submission_date partition, because none of the write modes do
+        // quite what we want:
+        //  - "overwrite" causes the entire vX partition to be deleted and replaced with
+        //    the current day's data, so doesn't work with incremental jobs
+        //  - "append" would allow us to generate duplicate data for the same day, so
+        //    we would need to add some manual checks before running
+        //  - "error" (the default) causes the job to fail after any data is
+        //    loaded, so we can't do single day incremental updates.
+        //  - "ignore" causes new data not to be saved.
+        // So we manually add the "submission_date_s3" parameter to the s3path.
+        val s3prefix = s"$jobName/$streamVersion/submission_date_s3=$currentDateString"
+        val s3path = s"s3://${conf.outputBucket()}/$s3prefix"
+
+        records.write.mode("error").parquet(s3path)
+
+        // Then remove the _SUCCESS file so we don't break Spark partition discovery.
+        S3Store.deleteKey(conf.outputBucket(), s"$s3prefix/_SUCCESS")
+        println(s"Wrote data to s3 path $s3path")
+      } else {
+        // Write the data to a local file.
+        records.write.parquet(conf.outputFilename())
+        println(s"Wrote data to local file ${conf.outputFilename()}")
+      }
+
+      println(s"JOB $jobName COMPLETED SUCCESSFULLY FOR $currentDateString")
+      println("     RECORDS SEEN:    %d".format(ignoredCount.value + processedCount.value))
+      println("     RECORDS IGNORED: %d".format(ignoredCount.value))
+      println("=======================================================================================")
+    }
+  }
+
+  // Convert the given Heka message containing a "sync" ping
+  // to a list of rows containing all the fields.
+  def messageToRow(message: Message): List[Row] = {
+    val fields = message.fieldsAsMap()
+
+    val payload = parse(message.payload.getOrElse("{}").asInstanceOf[String])
+    SyncPingConverter.pingToRows(payload)
+  }
+}
+
+// Convert Sync pings, which are defined by the schema at:
+// https://dxr.mozilla.org/mozilla-central/source/services/sync/tests/unit/sync_ping_schema.json
+object SyncPingConverter {
+  /*
+   * The type definitions for the rows we create.
+   */
+  private val failureType = StructType(List(
+    // failures are probably *too* flexible in the schema, but all current errors have a "name" and a second field
+    // that is a string or an int. To keep things simple and small here, we just define a string "value" field and
+    // convert ints to the string.
+    StructField("name", StringType, nullable = false),
+    StructField("value", StringType, nullable = true)
+  ))
+
+  // The record of incoming sync-records.
+  private val incomingType = StructType(List(
+    StructField("applied", LongType, nullable = false),
+    StructField("failed", LongType, nullable = false),
+    StructField("newFailed", LongType, nullable = false),
+    StructField("reconciled", LongType, nullable = false)
+  ))
+
+  // Outgoing records.
+  private val outgoingType = StructType(List(
+    StructField("sent", LongType, nullable = false),
+    StructField("failed", LongType, nullable = false)
+  ))
+
+  // The schema for an engine.
+  private val engineType = StructType(List(
+    StructField("name", StringType, nullable = false),
+    StructField("took", LongType, nullable = false),
+    StructField("status", StringType, nullable = true),
+    StructField("failureReason", failureType, nullable = true),
+    StructField("incoming", incomingType, nullable = true),
+    StructField("outgoing", ArrayType(outgoingType, containsNull = false), nullable = true)
+  ))
+
+  // The status for the Sync itself (ie, not the status for an engine - that's just a string)
+  private val statusType = StructType(List(
+    StructField("sync", StringType, nullable = true),
+    StructField("service", StringType, nullable = true)
+  ))
+
+  // The record of a single sync event.
+  def syncType = StructType(List(
+    // These field names are the same as used by MainSummaryView
+    StructField("app_build_id", StringType, nullable = true), // application/buildId
+    StructField("app_display_version", StringType, nullable = true), // application/displayVersion
+    StructField("app_name", StringType, nullable = true), // application/name
+    StructField("app_version", StringType, nullable = true), // application/version
+    // XXX - how do we record the "platform"?
+
+    // These fields are unique to the sync pings.
+    StructField("uid", StringType, nullable = false),
+    StructField("deviceID", StringType, nullable = true), // should always exists, but old pings didn't record it.
+    StructField("when", LongType, nullable = false),
+    StructField("took", LongType, nullable = false),
+    StructField("failureReason", failureType, nullable = true),
+    StructField("status", statusType, nullable = true),
+    // "why" is defined in the client-side schema but currently never populated.
+    StructField("why", StringType, nullable = true),
+    StructField("engines", ArrayType(SyncPingConverter.engineType, containsNull = false), nullable = true)
+  ))
+
+ /*
+ * Convert the JSON payload to rows matching the above types.
+ */
+  // XXX - this looks dodgy - I'm sure there's a more scala-ish way to write this...
+  private def failureReasonToRow(failure: JValue): Row = failure match {
+    case JObject(x) =>
+      implicit val formats = DefaultFormats
+      Row(
+        (failure \ "name").extract[String],
+        (failure \ "name").extract[String] match {
+          case "httperror" => (failure \ "code").extract[String]
+          case "nserror" => (failure \ "code").extract[String]
+          case "shutdownerror" => null
+          case "autherror" => (failure \ "from").extract[String]
+          case "othererror" => (failure \ "error").extract[String]
+          case "unexpectederror" => (failure \ "error").extract[String]
+          case _ => null
+        }
+      )
+    case _ =>
+      null
+  }
+
+  // Create a row representing incomingType
+  private def incomingToRow(incoming: JValue): Row = incoming match {
+    case JObject(x) =>
+      Row(
+        incoming \ "applied" match {
+          case JInt(x) => x.toLong
+          case _ => 0L
+        },
+        incoming \ "failed" match {
+          case JInt(x) => x.toLong
+          case _ => 0L
+        },
+        incoming \ "newFailed" match {
+          case JInt(x) => x.toLong
+          case _ => 0L
+        },
+        incoming \ "reconciled" match {
+          case JInt(x) => x.toLong
+          case _ => 0L
+        }
+      )
+    case _ => null
+  }
+
+  private def outgoingToRow(outgoing: JValue): List[Row] = outgoing match {
+    case JArray(x) =>
+      val buf = scala.collection.mutable.ListBuffer.empty[Row]
+      for (outgoing_entry <- x) {
+        buf.append(Row(
+          outgoing_entry \ "sent" match {
+          case JInt(x) => x.toLong
+          case _ => 0L
+          },
+          outgoing_entry \ "failed" match {
+            case JInt(x) => x.toLong
+            case _ => 0L
+          }
+        ))
+      }
+      if (buf.isEmpty) null
+      else buf.toList
+    case _ => null
+  }
+
+
+  // Parse an element of "engines" elt in a sync object
+  private def engineToRow(engine: JValue): Row = {
+    Row(
+      engine \ "name" match {
+        case JString(x) => x
+        case _ => return null // engines must have a name!
+      },
+      engine \ "took" match {
+        case JInt(x) => x.toLong
+        case _ => 0L
+      },
+      engine \ "status" match {
+        case JString(x) => x
+        case _ => null
+      },
+      failureReasonToRow(engine \ "failureReason"),
+      incomingToRow(engine \ "incoming"),
+      outgoingToRow(engine \ "outgoing")
+    )
+  }
+
+  private def toEnginesRows(engines: JValue): List[Row] = engines match {
+    case JArray(x) =>
+      val buf = scala.collection.mutable.ListBuffer.empty[Row]
+      // Need simple array iteration??
+      for (e <- x) {
+        buf.append(engineToRow(e))
+      }
+      if (buf.isEmpty) null
+      else buf.toList
+    case _ => null
+  }
+
+  private def statusToRow(status: JValue): Row = status match {
+    case JObject(x) =>
+      Row(
+        status \ "sync" match {
+          case JString(x) => x
+          case _ => null
+        },
+        status \ "service" match {
+          case JString(x) => x
+          case _ => null
+        }
+      )
+    case _ => null
+  }
+
+  // Take an entire ping and return a list of rows with "syncType" as a schemma.
+  def pingToRows(ping: JValue): List[Row] = {
+    ping \ "payload" \ "syncs" match {
+      case JArray(x) => multiSyncPayloadToRow(ping, x)
+      case _ =>
+        val row = singleSyncPayloadToRow(ping, ping \ "payload")
+        row match {
+          case Some(x) => List(x)
+          case None => List()
+      }
+    }
+  }
+
+  // Convert a "new style v1" ping that records multiple Syncs to a number of rows.
+  private def multiSyncPayloadToRow(ping: JValue, syncs: List[JValue]): List[Row] = {
+    syncs.flatMap(sync => singleSyncPayloadToRow(ping, sync))
+  }
+
+  // Convert an "old style" ping that records a single Sync to a row.
+  private def singleSyncPayloadToRow(ping: JValue, payload: JValue): Option[Row] = {
+    val application = ping \ "application"
+    val row = Row(
+      // The metadata...
+      application \ "buildId" match {
+        case JString(x) => x
+        case _ => return None // a required field.
+      },
+      application \ "displayVersion" match {
+        case JString(x) => x
+        case _ => return None // a required field.
+      },
+      application \ "name" match {
+        case JString(x) => x
+        case _ => return None // a required field.
+      },
+      application \ "version" match {
+        case JString(x) => x
+        case _ => return None // a required field.
+      },
+
+      // Info about the sync.
+      payload \ "uid" match {
+        case JString(x) => x
+        case _ => return None // a required field.
+      },
+      payload \ "deviceID" match {
+        case JString(x) => x
+        case _ => null
+      },
+      payload \ "when" match {
+        case JInt(x) => x.toLong
+        case _ => return None
+      },
+      payload \ "took" match {
+        case JInt(x) => x.toLong
+        case _ => return None
+      },
+      failureReasonToRow(payload \ "failureReason"),
+      statusToRow(payload \ "status"),
+      payload \ "why" match {
+        case JString(x) => x
+        case _ => null
+      },
+      toEnginesRows(payload \ "engines")
+    )
+
+    Some(row)
+  }
+
+}

--- a/src/test/scala/com/mozilla/telemetry/SyncViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/SyncViewTest.scala
@@ -1,0 +1,171 @@
+package com.mozilla.telemetry
+
+import com.mozilla.telemetry.views.SyncPingConverter
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
+import org.apache.spark.sql.{Row, SQLContext}
+import org.apache.spark.{SparkConf, SparkContext}
+import org.json4s.JsonAST.JNothing
+import org.json4s.{DefaultFormats, JValue}
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.mutable
+
+class SyncViewTest extends FlatSpec with Matchers{
+  "Old Style SyncPing payload" can "be serialized" in {
+    val sparkConf = new SparkConf().setAppName("SyncPing")
+    sparkConf.setMaster(sparkConf.get("spark.master", "local[1]"))
+    val sc = new SparkContext(sparkConf)
+    val ping = SyncViewTestPayloads.singleSyncPing
+    implicit val formats = DefaultFormats
+    sc.setLogLevel("WARN")
+    try {
+      val row = SyncPingConverter.pingToRows(SyncViewTestPayloads.singleSyncPing)
+      val sqlContext = new SQLContext(sc)
+      val rdd = sc.parallelize(row.toSeq)
+
+      val dataframe = sqlContext.createDataFrame(rdd, SyncPingConverter.syncType)
+
+      // verify the contents.
+      dataframe.count() should be (1)
+      val checkRow = dataframe.first()
+
+      checkRow.getAs[String]("app_build_id") should be ((ping \ "application" \ "buildId").extract[String])
+      checkRow.getAs[String]("app_display_version") should be ((ping \ "application" \ "displayVersion").extract[String])
+      checkRow.getAs[String]("app_name") should be ((ping \ "application" \ "name").extract[String])
+      checkRow.getAs[String]("app_version") should be ((ping \ "application" \ "version").extract[String])
+
+      val payload = ping \ "payload"
+      checkRow.getAs[Long]("when") should be ((payload \ "when").extract[Long])
+      checkRow.getAs[String]("uid") should be ((payload \ "uid").extract[String])
+      checkRow.getAs[Long]("took") should be ((payload \ "took").extract[Long])
+
+      val status = checkRow.getAs[GenericRowWithSchema]("status")
+      status.getAs[String]("service") should be ((payload \ "status" \ "service").extract[String])
+      status.getAs[String]("sync") should be ((payload \ "status" \ "sync").extract[String])
+
+      val engines = checkRow.getAs[mutable.WrappedArray[GenericRowWithSchema]]("engines")
+      validateEngines(engines, (payload \ "engines").extract[List[JValue]])
+    } finally {
+      sc.stop()
+    }
+  }
+
+  "New Style SyncPing payload" can "be serialized" in {
+    val sparkConf = new SparkConf().setAppName("SyncPing")
+    sparkConf.setMaster(sparkConf.get("spark.master", "local[1]"))
+    val sc = new SparkContext(sparkConf)
+    sc.setLogLevel("WARN")
+    try {
+      val row = SyncPingConverter.pingToRows(SyncViewTestPayloads.multiSyncPing)
+      val sqlContext = new SQLContext(sc)
+      val rdd = sc.parallelize(row.toSeq)
+      val dataframe = sqlContext.createDataFrame(rdd, SyncPingConverter.syncType)
+
+      // verify the contents
+      validateMultiSyncPing(dataframe.collect(), SyncViewTestPayloads.multiSyncPing)
+    } finally {
+      sc.stop()
+    }
+  }
+
+  "SyncPing records" can "be round-tripped to parquet" in {
+    val sparkConf = new SparkConf().setAppName("SyncPing")
+    sparkConf.setMaster(sparkConf.get("spark.master", "local[1]"))
+    val sc = new SparkContext(sparkConf)
+    sc.setLogLevel("WARN")
+    try {
+      val row = SyncPingConverter.pingToRows(SyncViewTestPayloads.multiSyncPing)
+      // Write a parquet file with the rows.
+      val sqlContext = new SQLContext(sc)
+      val rdd = sc.parallelize(row.toSeq)
+      val dataframe = sqlContext.createDataFrame(rdd, SyncPingConverter.syncType)
+      val tempFile = com.mozilla.telemetry.utils.temporaryFileName()
+      dataframe.write.parquet(tempFile.toString)
+      // read it back in and verify it.
+      val localDataset = sqlContext.read.load(tempFile.toString)
+      localDataset.registerTempTable("sync")
+      val localDataframe = sqlContext.sql("SELECT * FROM sync")
+      validateMultiSyncPing(localDataframe.collect(), SyncViewTestPayloads.multiSyncPing)
+    } finally {
+      sc.stop()
+    }
+  }
+
+  // A helper to validate rows created for engines against the source JSON payload
+  private def validateEngines(engines: mutable.WrappedArray[GenericRowWithSchema], jsonengines: List[JValue]): Unit = {
+    implicit val formats = DefaultFormats
+
+    for ( (engine, jsonengine) <- engines zip jsonengines ) {
+      val name = engine.getAs[String]("name")
+      name should be ((jsonengine \ "name").extract[String])
+      engine.getAs[Long]("took") should be ((jsonengine \ "took").extractOrElse[Long](0))
+      engine.getAs[String]("status") should be ((jsonengine \ "status").extractOrElse[String](null))
+      // failureReason can be null or a row with "name" and "value
+      engine.getAs[GenericRowWithSchema]("failureReason") match {
+        case null =>
+          (jsonengine \ "failureReason") should be (JNothing)
+        case reason =>
+          reason.getAs[String]("name") should be ((jsonengine \ "failureReason" \ "name").extract[String])
+          reason.getAs[String]("value") should be ((jsonengine \ "failureReason" \ "code").extract[String])
+      }
+      // incoming can be null or have a number of fields.
+      engine.getAs[GenericRowWithSchema]("incoming") match {
+        case null =>
+          (jsonengine \ "incoming") should be (JNothing)
+        case incoming =>
+          incoming.getAs[Long]("applied") should be ((jsonengine \ "incoming" \ "applied").extractOrElse[Long](0))
+          incoming.getAs[Long]("failed") should be ((jsonengine \ "incoming" \ "failed").extractOrElse[Long](0))
+          incoming.getAs[Long]("reconciled") should be ((jsonengine \ "incoming" \ "reconciled").extractOrElse[Long](0))
+      }
+      // outgoing can be null or have a number of fields.
+      engine.getAs[mutable.WrappedArray[GenericRowWithSchema]]("outgoing") match {
+        case null =>
+          (jsonengine \ "outgoing") should be (JNothing)
+        case outgoing: mutable.WrappedArray[GenericRowWithSchema] =>
+          outgoing(0).getAs[Long]("sent") should be ((jsonengine \ "outgoing" \ "sent").extract[Long])
+      }
+    }
+  }
+
+  // A helper to check the contents of the multi-sync ping.
+  private def validateMultiSyncPing(rows: Array[Row], ping: JValue) {
+    implicit val formats = DefaultFormats
+    rows.length should be (2)
+
+    val firstSync = rows(0)
+
+    firstSync.getAs[String]("app_build_id") should be ((ping \ "application" \ "buildId").extract[String])
+    firstSync.getAs[String]("app_display_version") should be ((ping \ "application" \ "displayVersion").extract[String])
+    firstSync.getAs[String]("app_name") should be ((ping \ "application" \ "name").extract[String])
+    firstSync.getAs[String]("app_version") should be ((ping \ "application" \ "version").extract[String])
+
+    val firstPing = (ping \ "payload" \ "syncs")(0)
+    firstSync.getAs[Long]("when") should be ((firstPing \ "when").extract[Long])
+    firstSync.getAs[String]("uid") should be ((firstPing \ "uid").extract[String])
+    firstSync.getAs[Long]("took") should be ((firstPing \ "took").extract[Long])
+
+    firstSync.getAs[GenericRowWithSchema]("status") should be (null)
+
+    val engines = firstSync.getAs[mutable.WrappedArray[GenericRowWithSchema]]("engines")
+    validateEngines(engines, (firstPing \ "engines").extract[List[JValue]])
+
+    // The second sync in this payload.
+    val secondSync = rows(1)
+
+    secondSync.getAs[String]("app_build_id") should be ((ping \ "application" \ "buildId").extract[String])
+    secondSync.getAs[String]("app_display_version") should be ((ping \ "application" \ "displayVersion").extract[String])
+    secondSync.getAs[String]("app_name") should be ((ping \ "application" \ "name").extract[String])
+    secondSync.getAs[String]("app_version") should be ((ping \ "application" \ "version").extract[String])
+
+    val secondPing = (ping \ "payload" \ "syncs")(1)
+
+    secondSync.getAs[Long]("when") should be ((secondPing \ "when").extract[Long])
+    secondSync.getAs[String]("uid") should be ((secondPing \ "uid").extract[String])
+    secondSync.getAs[Long]("took") should be ((secondPing \ "took").extract[Long])
+
+    secondSync.getAs[GenericRowWithSchema]("status") should be (null)
+
+    val secondEngines = secondSync.getAs[mutable.WrappedArray[GenericRowWithSchema]]("engines")
+    validateEngines(secondEngines, (secondPing \ "engines").extract[List[JValue]])
+  }
+}

--- a/src/test/scala/com/mozilla/telemetry/SyncViewTestPayloads.scala
+++ b/src/test/scala/com/mozilla/telemetry/SyncViewTestPayloads.scala
@@ -1,0 +1,199 @@
+package com.mozilla.telemetry
+
+import org.json4s.jackson.JsonMethods._
+
+object SyncViewTestPayloads {
+  // Test payloads, typically taken directly from about:telemetry.
+
+  // An "old style" payload where each "ping" recorded exactly 1 sync.
+  def singleSyncPing = parse("""{
+    |  "type": "sync",
+    |  "id": "824bb059-d22f-4930-b915-45580ecf463e",
+    |  "creationDate": "2016-09-02T04:35:18.787Z",
+    |  "version": 4,
+    |  "application": {
+    |    "architecture": "x86-64",
+    |    "buildId": "20160831030224",
+    |    "name": "Firefox",
+    |    "version": "51.0a1",
+    |    "displayVersion": "51.0a1",
+    |    "vendor": "Mozilla",
+    |    "platformVersion": "51.0a1",
+    |    "xpcomAbi": "x86_64-msvc",
+    |    "channel": "nightly"
+    |  },
+    |  "payload": {
+    |    "when": 1472790916859,
+    |    "uid": "123456789012345678901234567890",
+    |    "took": 1918,
+    |    "version": 1,
+    |    "status": {
+    |        "service": "error.sync.failed_partial",
+    |        "sync": "error.login.reason.network"
+    |    },
+    |    "engines": [
+    |      {
+    |        "name": "clients",
+    |        "took": 203
+    |      },
+    |      {
+    |        "name": "passwords",
+    |        "took": 123
+    |      },
+    |      {
+    |        "name": "tabs",
+    |        "incoming": {
+    |          "applied": 2,
+    |          "failed": 1
+    |        },
+    |        "outgoing": [
+    |          {
+    |            "sent": 1
+    |          }
+    |        ],
+    |        "took": 624
+    |      },
+    |      {
+    |        "name": "bookmarks",
+    |        "took": 15,
+    |        "failureReason": {
+    |            "name": "nserror",
+    |            "code": 2152398878
+    |        },
+    |        "status": "error.engine.reason.unknown_fail"
+    |      },
+    |      {
+    |        "name": "forms",
+    |        "outgoing": [
+    |          {
+    |            "sent": 1
+    |          }
+    |        ],
+    |        "took": 250
+    |      },
+    |      {
+    |        "name": "history",
+    |        "outgoing": [
+    |          {
+    |            "sent": 6
+    |          }
+    |        ],
+    |        "took": 249
+    |      }
+    |    ]
+    |  }
+    |}""".stripMargin)
+
+  // A "new style" payload where there may be any number of syncs in a single ping.
+  def multiSyncPing = parse(
+    """
+    |{
+    |  "type": "sync",
+    |  "id": "a1d969b7-0084-4a78-a841-2abaf887f1b4",
+    |  "creationDate": "2016-09-08T18:19:09.808Z",
+    |  "version": 4,
+    |  "application": {
+    |    "architecture": "x86-64",
+    |    "buildId": "20160907030427",
+    |    "name": "Firefox",
+    |    "version": "51.0a1",
+    |    "displayVersion": "51.0a1",
+    |    "vendor": "Mozilla",
+    |    "platformVersion": "51.0a1",
+    |    "xpcomAbi": "x86_64-msvc",
+    |    "channel": "nightly"
+    |  },
+    |  "payload": {
+    |    "why": "schedule",
+    |    "version": 1,
+    |    "syncs": [
+    |      {
+    |        "when": 1473313854446,
+    |        "uid": "12345678912345678912345678912345",
+    |        "took": 2277,
+    |        "engines": [
+    |          {
+    |            "name": "clients",
+    |            "outgoing": [
+    |              {
+    |                "sent": 1
+    |              }
+    |            ],
+    |            "took": 468
+    |          },
+    |          {
+    |            "name": "passwords",
+    |            "took": 16
+    |          },
+    |          {
+    |            "name": "tabs",
+    |            "incoming": {
+    |              "applied": 2,
+    |              "reconciled": 1
+    |            },
+    |            "outgoing": [
+    |              {
+    |                "sent": 1
+    |              }
+    |            ],
+    |            "took": 795
+    |          },
+    |          {
+    |            "name": "bookmarks"
+    |          },
+    |          {
+    |            "name": "forms",
+    |            "outgoing": [
+    |              {
+    |                "sent": 2
+    |              }
+    |            ],
+    |            "took": 266
+    |          },
+    |          {
+    |            "name": "history",
+    |            "incoming": {
+    |              "applied": 2
+    |            },
+    |            "outgoing": [
+    |              {
+    |                "sent": 2
+    |              }
+    |            ],
+    |            "took": 514
+    |          }
+    |        ]
+    |      },
+    |      {
+    |        "when": 1473313890947,
+    |        "uid": "12345678912345678912345678912345",
+    |        "took": 484,
+    |        "engines": [
+    |          {
+    |            "name": "clients",
+    |            "took": 249
+    |          },
+    |          {
+    |            "name": "passwords"
+    |          },
+    |          {
+    |            "name": "tabs",
+    |            "took": 16
+    |          },
+    |          {
+    |            "name": "bookmarks"
+    |          },
+    |          {
+    |            "name": "forms"
+    |          },
+    |          {
+    |            "name": "history"
+    |          }
+    |        ]
+    |      }
+    |    ]
+    |  }
+    |}
+    """.stripMargin)
+
+}


### PR DESCRIPTION
This is a first cut that seems to "work", for some definitions of "work".

Alot of code was cargo-culted from MainSummaryView - I'm not sure how much
is relevant here. Some of the new parsing code I added is almost certainly
not idiomatic scala.

There are some tests. Some .json test files are parsed and their contents
verified. One of these payloads is also round-tripped through a local parquet
file and the content verified.

I also had a test that added a .heka file I grabbed of s3 and verified I could
parse it, but I felt that had little value as I couldn't actually verify the
contents. The commit where I removed it is at:
> https://github.com/mhammond/telemetry-batch-view/commit/ad40720d09d1717660bfc0ea140e67e80998f1b1
and I can reinstate that if you like.

Note that the code is handling the older format (where we sent one sync per
ping) and the current format (where we batch a number of syncs into one ping).
@Dexterp37 questioned whether the parquet structure should match the actual
ping formats, but I think this format is preferred - there's one row per
sync-event rather than one row per ping.

@vitillo, @Dexterp37 suggested you might be a good person to flag for this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/114)
<!-- Reviewable:end -->
