### PR TITLE
Remove DirectParquetOutputCommitter

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -49,8 +49,6 @@ object MainSummaryView {
     val parquetSize = 512 * 1024 * 1024
     hadoopConf.setInt("parquet.block.size", parquetSize)
     hadoopConf.setInt("dfs.blocksize", parquetSize)
-    // Don't write temp files to S3 while building parquet files.
-    hadoopConf.set("spark.sql.parquet.output.committer.class", "org.apache.spark.sql.parquet.DirectParquetOutputCommitter")
     // Don't write metadata files, because they screw up partition discovery.
     // This is fixed in Spark 2.0, see:
     //   https://issues.apache.org/jira/browse/SPARK-13207


### PR DESCRIPTION
This is no longer available in Spark 2.0. See [this issue](https://issues.apache.org/jira/browse/SPARK-10063) and [this discussion](http://dev.sortable.com/spark-directparquetoutputcommitter/) for more info.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/115)
<!-- Reviewable:end -->
