### PR TITLE
Bug 1300224 - Create a view for Addons data

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/AddonsView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/AddonsView.scala
@@ -1,0 +1,254 @@
+package com.mozilla.telemetry.views
+
+import com.mozilla.telemetry.heka.{Dataset, Message}
+import com.mozilla.telemetry.utils.S3Store
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.util.LongAccumulator
+import org.apache.spark.{SparkConf, SparkContext}
+import org.joda.time.{DateTime, Days, format}
+import org.json4s._
+import org.json4s.jackson.JsonMethods.parse
+import org.rogach.scallop._
+
+import scala.util.Try
+
+case class AddonData(blocklisted: Option[Boolean],
+                     description: Option[String],
+                     name: Option[String],
+                     userDisabled: Option[Boolean],
+                     appDisabled: Option[Boolean],
+                     version: Option[String],
+                     scope: Option[Integer],
+                     `type`: Option[String],
+                     foreignInstall: Option[Boolean],
+                     hasBinaryComponents: Option[Boolean],
+                     installDay: Option[Integer],
+                     updateDay: Option[Integer],
+                     signedState: Option[Integer],
+                     isSystem: Option[Boolean])
+
+object AddonsView {
+  def streamVersion: String = "v1"
+  def jobName: String = "addons"
+
+  // Configuration for command line arguments
+  private class Conf(args: Array[String]) extends ScallopConf(args) {
+    val from = opt[String]("from", descr = "From submission date", required = false)
+    val to = opt[String]("to", descr = "To submission date", required = false)
+    val outputBucket = opt[String]("bucket", descr = "Destination bucket for parquet data", required = true)
+    val limit = opt[Int]("limit", descr = "Maximum number of files to read from S3", required = false)
+    val channel = opt[String]("channel", descr = "Only process data from the given channel", required = false)
+    val appVersion = opt[String]("version", descr = "Only process data from the given app version", required = false)
+    verify()
+  }
+
+  def main(args: Array[String]) {
+    val conf = new Conf(args) // parse command line arguments
+    val fmt = format.DateTimeFormat.forPattern("yyyyMMdd")
+    val to = conf.to.get match {
+      case Some(t) => fmt.parseDateTime(t)
+      case _ => DateTime.now.minusDays(1)
+    }
+    val from = conf.from.get match {
+      case Some(f) => fmt.parseDateTime(f)
+      case _ => DateTime.now.minusDays(1)
+    }
+
+    // Set up Spark
+    val sparkConf = new SparkConf().setAppName(jobName)
+    sparkConf.setMaster(sparkConf.get("spark.master", "local[*]"))
+    implicit val sc = new SparkContext(sparkConf)
+    val hadoopConf = sc.hadoopConfiguration
+    hadoopConf.set("fs.s3n.impl", "org.apache.hadoop.fs.s3native.NativeS3FileSystem")
+
+    // We want to end up with reasonably large parquet files on S3.
+    val parquetSize = 512 * 1024 * 1024
+    hadoopConf.setInt("parquet.block.size", parquetSize)
+    hadoopConf.setInt("dfs.blocksize", parquetSize)
+    // Don't write metadata files, because they screw up partition discovery.
+    // This is fixed in Spark 2.0, see:
+    //   https://issues.apache.org/jira/browse/SPARK-13207
+    //   https://issues.apache.org/jira/browse/SPARK-15454
+    //   https://issues.apache.org/jira/browse/SPARK-15895
+    hadoopConf.set("parquet.enable.summary-metadata", "false")
+
+    val spark = SparkSession
+      .builder()
+      .appName("AddonsView")
+      .getOrCreate()
+
+    for (offset <- 0 to Days.daysBetween(from, to).getDays) {
+      val currentDate = from.plusDays(offset)
+      val currentDateString = currentDate.toString("yyyyMMdd")
+      val filterChannel = conf.channel.get
+      val filterVersion = conf.appVersion.get
+
+      println("=======================================================================================")
+      println(s"BEGINNING JOB $jobName FOR $currentDateString")
+      if (filterChannel.nonEmpty)
+        println(s" Filtering for channel = '${filterChannel.get}'")
+      if (filterVersion.nonEmpty)
+        println(s" Filtering for version = '${filterVersion.get}'")
+
+      val schema = buildSchema
+      val ignoredCount = sc.longAccumulator("Number of Records Ignored")
+      val processedCount = sc.longAccumulator("Number of Records Processed")
+      val badAddonCount = sc.longAccumulator("Number of Bad Addon records skipped")
+      val messages = Dataset("telemetry")
+        .where("sourceName") {
+          case "telemetry" => true
+        }.where("sourceVersion") {
+          case "4" => true
+        }.where("docType") {
+          case "main" => true
+        }.where("appName") {
+          case "Firefox" => true
+        }.where("submissionDate") {
+          case date if date == currentDate.toString("yyyyMMdd") => true
+        }.where("appUpdateChannel") {
+          case channel => filterChannel.isEmpty || channel == filterChannel.get
+        }.where("appVersion") {
+          case v => filterVersion.isEmpty || v == filterVersion.get
+        }.records(conf.limit.get)
+
+      val rowRDD = messages.flatMap(m => {
+        messageToRows(m, badAddonCount) match {
+          case None =>
+            ignoredCount.add(1)
+            None
+          case x =>
+            processedCount.add(1)
+            x
+        }
+      }).flatMap(x => x)
+
+      val records = spark.createDataFrame(rowRDD, schema)
+
+      // Note we cannot just use 'partitionBy' below to automatically populate
+      // the submission_date partition, because none of the write modes do
+      // quite what we want:
+      //  - "overwrite" causes the entire vX partition to be deleted and replaced with
+      //    the current day's data, so doesn't work with incremental jobs
+      //  - "append" would allow us to generate duplicate data for the same day, so
+      //    we would need to add some manual checks before running
+      //  - "error" (the default) causes the job to fail after any data is
+      //    loaded, so we can't do single day incremental updates.
+      //  - "ignore" causes new data not to be saved.
+      // So we manually add the "submission_date_s3" parameter to the s3path.
+      val s3prefix = s"$jobName/$streamVersion/submission_date_s3=$currentDateString"
+      val s3path = s"s3://${conf.outputBucket()}/$s3prefix"
+
+      // Repartition the dataframe by sample_id before saving.
+      val partitioned = records.repartition(100, records.col("sample_id"))
+
+      // Then write to S3 using the given fields as path name partitions. If any
+      // data already exists for the target day, replace it.
+      partitioned.write.partitionBy("sample_id").mode("overwrite").parquet(s3path)
+
+      // Then remove the _SUCCESS file so we don't break Spark partition discovery.
+      S3Store.deleteKey(conf.outputBucket(), s"$s3prefix/_SUCCESS")
+
+      println(s"JOB $jobName COMPLETED SUCCESSFULLY FOR $currentDateString")
+      println(s"     RECORDS SEEN:    ${ignoredCount.value + processedCount.value}")
+      println(s"     RECORDS IGNORED: ${ignoredCount.value}")
+      println(s"     BAD ADDONS:      ${badAddonCount.value}")
+      println("=======================================================================================")
+      sc.stop()
+    }
+  }
+
+  // Convert the given Heka message containing a "main" ping
+  // to a map containing just the fields we're interested in.
+  def messageToRows(message: Message, counter: LongAccumulator): Option[List[Row]] = {
+    val fields = message.fieldsAsMap()
+
+    // Don't compute the expensive stuff until we need it. We may skip a record
+    // due to missing required fields.
+    lazy val addons = parse(fields.getOrElse("environment.addons", "{}").asInstanceOf[String])
+
+    val docId = fields.getOrElse("documentId", None) match {
+      case x: String => x
+      // documentId is required, and must be a string. If either
+      // condition is not satisfied, we skip this record.
+      case _ => return None
+    }
+
+    val clientId = fields.getOrElse("clientId", None) match {
+      case x: String => x
+      // clientId is required, and must be a string.
+      case _ => return None
+    }
+
+    val sampleId = fields.getOrElse("sampleId", None) match {
+      case x: Long => x
+      case x: Double => x.toLong
+      // sampleId is required, and must be a number.
+      case _ => return None
+    }
+
+    val activeAddons = addons \ "activeAddons"
+    val addonIds = activeAddons match {
+      case JObject(addon) => addon map(x => x._1)
+      case _ => List()
+    }
+
+    implicit val formats = DefaultFormats
+
+    val addonsParsed = addonIds map(aid => Try((aid, (activeAddons \ aid).extract[AddonData])))
+    counter.add(addonsParsed.count(_.isFailure))
+    val successes = addonsParsed.filter(_.isSuccess).map(_.get).map { case (aid, addonData: AddonData) =>
+      Row(docId, clientId, sampleId, aid,
+        addonData.blocklisted.orNull,
+        addonData.name.orNull,
+        addonData.userDisabled.orNull,
+        addonData.appDisabled.orNull,
+        addonData.version.orNull,
+        addonData.scope.orNull,
+        addonData.`type`.orNull,
+        addonData.foreignInstall.orNull,
+        addonData.hasBinaryComponents.orNull,
+        addonData.installDay.orNull,
+        addonData.updateDay.orNull,
+        addonData.signedState.orNull,
+        addonData.isSystem.orNull)
+    }
+
+    if (addonIds.isEmpty)
+      // Output a row with a null addon_id for this submission. This way we can identify pings without any addons.
+      Some(List(Row(docId, clientId, sampleId, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null)))
+    else
+      Some(successes)
+  }
+
+  def buildSchema: StructType = {
+    StructType(List(
+      // Fields from the containing ping:
+      StructField("document_id",           StringType, nullable = false), // documentId
+      StructField("client_id",             StringType, nullable = false), // clientId
+      StructField("sample_id",             LongType,   nullable = false), // Fields[sampleId]
+
+      // Per-addon info:
+      // Include the id of each addon in the ping. If there were no addons present, output a record
+      // with a null addon_id so we can do analysis on addon-free clients / documents.
+      StructField("addon_id",              StringType, nullable = true),
+      StructField("blocklisted",           BooleanType, nullable = true),
+
+      // Skip "description" field - if needed, look it up from AMO.
+
+      StructField("name",                  StringType,  nullable = true),
+      StructField("user_disabled",         BooleanType, nullable = true),
+      StructField("app_disabled",          BooleanType, nullable = true),
+      StructField("version",               StringType,  nullable = true),
+      StructField("scope",                 IntegerType, nullable = true),
+      StructField("type",                  StringType,  nullable = true),
+      StructField("foreign_install",       BooleanType, nullable = true),
+      StructField("has_binary_components", BooleanType, nullable = true),
+      StructField("install_day",           IntegerType, nullable = true),
+      StructField("update_day",            IntegerType, nullable = true),
+      StructField("signed_state",          IntegerType, nullable = true),
+      StructField("is_system",             BooleanType, nullable = true)
+    ))
+  }
+}

--- a/src/test/scala/com/mozilla/telemetry/AddonsViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/AddonsViewTest.scala
@@ -1,0 +1,125 @@
+package com.mozilla.telemetry
+
+import com.mozilla.telemetry.heka.HekaFrame
+import com.mozilla.telemetry.views.AddonsView
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{Row, SQLContext}
+import org.apache.spark.{SparkConf, SparkContext}
+import org.scalatest.{FlatSpec, Matchers}
+
+class AddonsViewTest extends FlatSpec with Matchers{
+  def checkRowValues(row: Row, schema: StructType, expected: Map[String,Any]) = {
+    val actual = new GenericRowWithSchema(row.toSeq.toArray, schema).getValuesMap(expected.keys.toList)
+    val aid = expected("addon_id")
+    for ((f, v) <- expected) {
+      withClue(s"$aid[$f]:") { actual.get(f) should be (Some(v)) }
+    }
+    actual should be (expected)
+  }
+
+  "Addon records" can "be converted" in {
+    val sparkConf = new SparkConf().setAppName("Addons")
+    sparkConf.setMaster(sparkConf.get("spark.master", "local[1]"))
+    val sc = new SparkContext(sparkConf)
+    val badAddonCount = sc.longAccumulator("Number of Bad Addon records skipped")
+    sc.setLogLevel("WARN")
+    try {
+      val schema = AddonsView.buildSchema
+
+      // Use an example framed-heka message. It is based on test_main.json.gz,
+      // submitted with a URL of
+      //    /submit/telemetry/foo/main/Firefox/48.0a1/nightly/20160315030230
+      val hekaFileName = "/test_main.snappy.heka"
+      val hekaURL = getClass.getResource(hekaFileName)
+      val input = hekaURL.openStream()
+      val rows = HekaFrame.parse(input).flatMap(AddonsView.messageToRows(_, badAddonCount)).flatten
+
+      // Serialize this one row as Parquet
+      val sqlContext = new SQLContext(sc)
+      val dataframe = sqlContext.createDataFrame(sc.parallelize(rows.toSeq), schema)
+      val tempFile = com.mozilla.telemetry.utils.temporaryFileName()
+      dataframe.write.parquet(tempFile.toString)
+
+      badAddonCount.value should be (0)
+
+      // Then read it back
+      val data = sqlContext.read.parquet(tempFile.toString)
+
+      val docId = "foo"
+      val clientId = "c4582ba1-79fc-1f47-ae2a-671118dccd8b"
+      val sampleId = 4l
+
+      data.count() should be (3)
+      data.filter(data("document_id") === "foo").count() should be (3)
+      val e10s = data.filter(data("addon_id") === "e10srollout@mozilla.org")
+      e10s.count() should be (1)
+      checkRowValues(e10s.first, schema, Map(
+        "document_id"           -> docId,
+        "client_id"             -> clientId,
+        "sample_id"             -> sampleId,
+        "addon_id"              -> "e10srollout@mozilla.org",
+        "blocklisted"           -> false,
+        "name"                  -> "Multi-process staged rollout",
+        "user_disabled"         -> false,
+        "app_disabled"          -> false,
+        "version"               -> "1.0",
+        "scope"                 -> 1,
+        "type"                  -> "extension",
+        "foreign_install"       -> false,
+        "has_binary_components" -> false,
+        "install_day"           -> 16865,
+        "update_day"            -> 16875,
+        "signed_state"          -> null,
+        "is_system"             -> true
+      ))
+
+      val pocket = data.filter(data("addon_id") === "firefox@getpocket.com")
+      pocket.count() should be (1)
+      checkRowValues(pocket.first, schema, Map(
+        "document_id"           -> docId,
+        "client_id"             -> clientId,
+        "sample_id"             -> sampleId,
+        "addon_id"              -> "firefox@getpocket.com",
+        "blocklisted"           -> false,
+        "name"                  -> "Pocket",
+        "user_disabled"         -> false,
+        "app_disabled"          -> false,
+        "version"               -> "1.0",
+        "scope"                 -> 1,
+        "type"                  -> "extension",
+        "foreign_install"       -> false,
+        "has_binary_components" -> false,
+        "install_day"           -> 16861,
+        "update_day"            -> 16875,
+        "signed_state"          -> null,
+        "is_system"             -> true
+      ))
+
+      val loop = data.filter(data("addon_id") === "loop@mozilla.org")
+      loop.count() should be (1)
+      checkRowValues(loop.first, schema, Map(
+        "document_id"           -> docId,
+        "client_id"             -> clientId,
+        "sample_id"             -> sampleId,
+        "addon_id"              -> "loop@mozilla.org",
+        "blocklisted"           -> false,
+        "name"                  -> "Firefox Hello Beta",
+        "user_disabled"         -> false,
+        "app_disabled"          -> false,
+        "version"               -> "1.1.12",
+        "scope"                 -> 1,
+        "type"                  -> "extension",
+        "foreign_install"       -> false,
+        "has_binary_components" -> false,
+        "install_day"           -> 16861,
+        "update_day"            -> 16875,
+        "signed_state"          -> null,
+        "is_system"             -> true
+      ))
+
+    } finally {
+      sc.stop()
+    }
+  }
+}


### PR DESCRIPTION
This view contains one row per active addon, as well as one row with
a null value for addon_id for each client with zero addons.

All fields for each addon are present except the "description" field.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/117)

<!-- Reviewable:end -->
