### PR TITLE
Update explicit scala version in jar path (E10s dataset)

### DIFF
--- a/docs/E10SExperiment.md
+++ b/docs/E10SExperiment.md
@@ -8,7 +8,7 @@ To create a derived dataset for running analyses like
 1. Fire up a 20-node Spark cluster [here](https://analysis.telemetry.mozilla.org/).
 2. `cd /mnt && git clone https://github.com/mozilla/telemetry-batch-view.git && cd telemetry-batch-view`
 3. `sbt assembly` (this might take a while)
-4. `spark-submit --master yarn-client --class com.mozilla.telemetry.views.E10sExperimentView target/scala-2.10/telemetry-batch-view-1.1.jar --from 20160608 --to 20160609 --channel beta --version 48.0 --experiment e10s-beta48-cohorts --bucket telemetry-test-bucket` (this _definitely_ will take a while. You can watch some of its progress by `tail -f /mnt/var/log/spark/spark.log`)
+4. `spark-submit --master yarn-client --class com.mozilla.telemetry.views.E10sExperimentView target/scala-2.11/telemetry-batch-view-1.1.jar --from 20160608 --to 20160609 --channel beta --version 48.0 --experiment e10s-beta48-cohorts --bucket telemetry-test-bucket` (this _definitely_ will take a while. You can watch some of its progress by `tail -f /mnt/var/log/spark/spark.log`)
 
 Testing
 -------


### PR DESCRIPTION
The command to build the E10s dataset makes reference to the explicit scala version in its args. Updating for future reference, as it changed with the update to Spark 2.0.

It also bears mentioning that this now needs to be run on an EMR-5.0.0 cluster supporting Spark 2.0. I wasn't sure if it was worth adding that to the readme (eg. updating the link to a.t.m.o). If this will soon become the default for our clusters, it may not be necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/119)
<!-- Reviewable:end -->
