### PR TITLE
Bug 1269466 - Add push_notification_received field to ClientCountView

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/ClientCountView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/ClientCountView.scala
@@ -36,13 +36,13 @@ object ClientCountView {
     "substr(subsession_start_date, 0, 10) as activity_date" ::
     "devtools_toolbox_opened_count > 0 as devtools_toolbox_opened" ::
     "loop_activity_counter.open_panel > 0 as loop_activity_open_panel" ::
-    "popup_notification_stats is not null or web_notification_shown > 0 as push_notification_user" ::
+    "popup_notification_stats is not null or web_notification_shown > 0 as push_notification_received" ::
     base
 
   val dimensions = "activity_date" ::
     "devtools_toolbox_opened" ::
     "loop_activity_open_panel" ::
-    "push_notification_user" ::
+    "push_notification_received" ::
     base
 
   def aggregate(frame: DataFrame): DataFrame = {

--- a/src/main/scala/com/mozilla/telemetry/views/ClientCountView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/ClientCountView.scala
@@ -36,9 +36,14 @@ object ClientCountView {
     "substr(subsession_start_date, 0, 10) as activity_date" ::
     "devtools_toolbox_opened_count > 0 as devtools_toolbox_opened" ::
     "loop_activity_counter.open_panel > 0 as loop_activity_open_panel" ::
+    "popup_notification_stats is not null or web_notification_shown > 0 as push_notification_user" ::
     base
 
-  val dimensions = "activity_date" :: "devtools_toolbox_opened" :: "loop_activity_open_panel" :: base
+  val dimensions = "activity_date" ::
+    "devtools_toolbox_opened" ::
+    "loop_activity_open_panel" ::
+    "push_notification_user" ::
+    base
 
   def aggregate(frame: DataFrame): DataFrame = {
     frame

--- a/src/test/scala/com/mozilla/telemetry/ClientCountViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/ClientCountViewTest.scala
@@ -5,7 +5,6 @@ import com.mozilla.spark.sql.hyperloglog.functions._
 import com.mozilla.telemetry.views.ClientCountView
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.StructField
 import org.apache.spark.{SparkConf, SparkContext}
 import org.scalatest.{FlatSpec, Matchers}
 

--- a/src/test/scala/com/mozilla/telemetry/ClientCountViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/ClientCountViewTest.scala
@@ -5,6 +5,7 @@ import com.mozilla.spark.sql.hyperloglog.functions._
 import com.mozilla.telemetry.views.ClientCountView
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.StructField
 import org.apache.spark.{SparkConf, SparkContext}
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -13,6 +14,9 @@ case class LoopActivity(open_panel: Int,
                         room_open: Int,
                         room_share: Int,
                         room_delete: Int)
+
+// popupNotificationStats type is 22 separate int fields -- simplifying down for this test
+case class PopupNotificationStatsDummyType(dummy_field: Int)
 
 case class Submission(client_id: String,
                       app_name: String,
@@ -27,7 +31,10 @@ case class Submission(client_id: String,
                       os: String,
                       os_version: String,
                       devtools_toolbox_opened_count: Int,
-                      loop_activity_counter: LoopActivity)
+                      loop_activity_counter: LoopActivity,
+                      popup_notification_stats: Option[PopupNotificationStatsDummyType],
+                      web_notification_shown: Int
+                     )
 
 object Submission{
   val dimensions = Map(
@@ -46,7 +53,9 @@ object Submission{
     "devtools_toolbox_opened_count" -> List(0, 42),
     "loop_activity_counter" -> List(
       LoopActivity(0, 0, 0, 0, 0),
-      LoopActivity(42, 0, 0, 0, 0)))
+      LoopActivity(42, 0, 0, 0, 0)),
+    "popup_notification_stats" -> List(Some(PopupNotificationStatsDummyType(1)), None),
+    "web_notification_shown" -> List(5, 0))
 
   def randomList: List[Submission] = {
     for {
@@ -64,6 +73,8 @@ object Submission{
       osVersion <- dimensions("os_version")
       devtoolsToolboxOpenedCount <- dimensions("devtools_toolbox_opened_count")
       loopActivity <- dimensions("loop_activity_counter")
+      popupNotificationStats <- dimensions("popup_notification_stats")
+      webNotificationShown <- dimensions("web_notification_shown")
     } yield {
       Submission(clientId.asInstanceOf[String],
                  appName.asInstanceOf[String],
@@ -78,7 +89,10 @@ object Submission{
                  os.asInstanceOf[String],
                  osVersion.asInstanceOf[String],
                  devtoolsToolboxOpenedCount.asInstanceOf[Int],
-                 loopActivity.asInstanceOf[LoopActivity])
+                 loopActivity.asInstanceOf[LoopActivity],
+                 popupNotificationStats.asInstanceOf[Option[PopupNotificationStatsDummyType]],
+                 webNotificationShown.asInstanceOf[Int]
+      )
     }
   }
 }


### PR DESCRIPTION
The push_notification_received indicates whether a user has received a web notification or a popup notification in the session. This field will be used to create an ER dashboard per bug #1269466

Note I took a bit of a license with the PopupNotificationStatsDummyType in the tests since only null/not null is necessary to compute the field

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/121)
<!-- Reviewable:end -->
