### PR TITLE
Get scalar data from clients with old pings

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,25 @@ If you run into memory issues during compilation time issue the following comman
 ```bash
 export _JAVA_OPTIONS="-Xss4M -Xmx2G"
 ```
+
+**Running on Windows**
+
+Executing scala/Spark jobs could be particularly problematic on this platform. Here's a list of common issues and the relative solutions:
+
+**Issue:** *I see a weird reflection error or an odd exception when trying to run my code.*
+
+This is probably due to *winutils* being missing or not found. Winutils are needed by HADOOP and can be downloaded from [here](https://github.com/steveloughran/winutils).
+
+**Issue:** *java.net.URISyntaxException: Relative path in absolute URI: ...*
+
+This means that *winutils* cannot be found or that Spark cannot find a valid warehouse directory. Add the following line at the beginning of your entry function to make it work:
+
+```scala
+System.setProperty("hadoop.home.dir", "C:\\path\\to\\winutils")
+System.setProperty("spark.sql.warehouse.dir", "file:///C:/somereal-dir/spark-warehouse")
+```
+
+**Issue:** *The root scratch dir: /tmp/hive on HDFS should be writable. Current permissions are: ---------*
+
+See [SPARK-10528](https://issues.apache.org/jira/browse/SPARK-10528). Run "winutils chmod 777 /tmp/hive" from a privileged prompt to make it work.
+


### PR DESCRIPTION
The scalars section was added by bug 1282091, which
landed on July 2016. Pings before that date don't
have the scalars section. If we have a ping with
the missing section among the pings for a client,
the longitudinal view drops all the data from that
client, if if newer pings have the scalar section.
This patch prevents that from happening.
Bonus: this also adds some documentation about
running this code on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/124)
<!-- Reviewable:end -->
