### PR TITLE
Bug 1302264 - Use metadata_prefix for looking up dataset schema

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/heka/Dataset.scala
+++ b/src/main/scala/com/mozilla/telemetry/heka/Dataset.scala
@@ -78,8 +78,9 @@ object Dataset {
     val metaBucket = "net-mozaws-prod-us-west-2-pipeline-metadata"
     val metaSources = parse(Source.fromInputStream(s3Store.getKey(metaBucket, "sources.json")).mkString)
     val JString(prefix) = metaSources \\ dataset \\ "prefix"
+    val JString(metadataPrefix) = metaSources \\ dataset \\ "metadata_prefix"
     val JString(bucketName) = metaSources \\ dataset \\ "bucket"
-    val schema = parse(Source.fromInputStream(s3Store.getKey(metaBucket, s"$prefix/schema.json")).mkString)
+    val schema = parse(Source.fromInputStream(s3Store.getKey(metaBucket, s"$metadataPrefix/schema.json")).mkString)
       .camelizeKeys
       .extract[Schema]
 

--- a/src/test/scala/com/mozilla/telemetry/DatasetTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/DatasetTest.scala
@@ -31,6 +31,7 @@ object MockS3Store extends AbstractS3Store {
         |{
         |  "telemetry": {
         |    "prefix": "telemetry",
+        |    "metadata_prefix": "telemetry",
         |    "bucket": "foo"
         |  }
         |}


### PR DESCRIPTION
This is an educated guess based off of https://github.com/mozilla/python_moztelemetry/pull/86.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/125)
<!-- Reviewable:end -->
