### PR TITLE
Add remaining columns to cross sectional database

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/utils/Aggregation.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/Aggregation.scala
@@ -1,6 +1,14 @@
 package com.mozilla.telemetry.utils
 
 package object aggregation {
+  def mean(values: Seq[Long]): Option[Double] = {
+    if (values.size == 0) {
+      None
+    } else {
+      Some(values.sum.toDouble/values.size)
+    }
+  }
+
   def weightedMean(values: Seq[Option[Long]], weights: Seq[Long]): Option[Double] = {
     if (values.size == weights.size) {
       val clean_pairs = (values zip weights).map(pair => pair._1.map((_, pair._2))).flatten

--- a/src/main/scala/com/mozilla/telemetry/views/CrossSectionalView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/CrossSectionalView.scala
@@ -6,6 +6,8 @@ import org.apache.spark.sql.hive.HiveContext
 import org.apache.spark.sql.SQLContext
 import com.mozilla.telemetry.utils.S3Store
 import com.mozilla.telemetry.utils.aggregation
+import org.joda.time.{Days, LocalDate, Seconds}
+import org.joda.time.DateTimeConstants._
 
 case class ActiveAddon (
   val blocklisted: Option[Boolean],
@@ -24,20 +26,47 @@ case class ActiveAddon (
   val is_system: Option[Boolean]
 )
 
+case class ActivePlugin (
+  val name: Option[String],
+  val version: Option[String],
+  val description: Option[String],
+  val blocklisted: Option[Boolean],
+  val disabled: Option[Boolean],
+  val clicktoplay: Option[Boolean],
+  val mime_types: Option[Seq[String]],
+  val update_day: Option[Long]
+)
+
 object Longitudinal {
 }
 
 case class Longitudinal (
   val client_id: String,
   val normalized_channel: String,
-  val submission_date: Option[Seq[String]],
+  val submission_date: Option[Seq[String]], // TODO(harter): This needs to be scrubbed of negative and large vals
   val geo_country: Option[Seq[String]],
   val session_length: Option[Seq[Long]],
   val is_default_browser: Option[Seq[Option[Boolean]]],
   val default_search_engine: Option[Seq[Option[String]]],
   val locale: Option[Seq[Option[String]]],
   val architecture: Option[Seq[Option[String]]],
-  val active_addons: Option[Seq[Map[String, ActiveAddon]]]
+  val active_addons: Option[Seq[Map[String, ActiveAddon]]],
+  val bookmarks_sum: Option[Seq[Option[Long]]],
+  val cpu_count: Option[Seq[Option[Long]]],
+  val channel: Option[Seq[Option[String]]],
+  val subsession_start_date: Option[Seq[String]],
+  val version: Option[Seq[Option[String]]],
+  val reason: Option[Seq[String]],
+  val memory_mb: Option[Seq[Option[Long]]],
+  val os_name: Option[Seq[Option[String]]],
+  val os_version: Option[Seq[Option[String]]],
+  val pages_count: Option[Seq[Option[Long]]],
+  val active_plugins: Option[Seq[Seq[ActivePlugin]]],
+  val previous_subsession_id: Option[Seq[String]],
+  val profile_creation_date: Option[Seq[String]],
+  val profile_subsession_counter: Option[Seq[Long]],
+  val search_counts: Option[scala.collection.Map[String, Seq[Long]]],
+  val session_id: Option[Seq[String]]
 ) {
   def weightedMean(values: Option[Seq[Option[Long]]]): Option[Double] = {
     (values, this.session_length) match {
@@ -53,13 +82,14 @@ case class Longitudinal (
     }
   }
 
-  def parsedSubmissionDate() = {
-    val date_parser =  new java.text.SimpleDateFormat("yyyy-MM-dd")
-    this.submission_date.getOrElse(Seq()).map(date_parser.parse(_))
+  def addonNames(): Option[Seq[Option[String]]] = {
+    this.active_addons.map( // if active_addons isn't empty
+      _.foldLeft(Seq[Option[String]]())((acc, x) => acc ++ x.values.map(_.name)).distinct
+    )
   }
 
-  def addonCount(): Option[Seq[Int]] = {
-    this.active_addons.map(_.map(_.size))
+  def addonCount(): Option[Seq[Option[Long]]] = {
+    this.active_addons.map(_.map(x => Some(x.size.toLong)))
   }
 
   def foreignAddons(): Option[Seq[Map[String, ActiveAddon]]] = {
@@ -70,60 +100,240 @@ case class Longitudinal (
     )
   }
 
-  def foreignAddonCount(): Option[Seq[Int]] = {
-    this.foreignAddons.map(_.map(_.size))
+  def foreignAddonCount(): Option[Seq[Option[Long]]] = {
+    this.foreignAddons.map(_.map(x => Some(x.size.toLong)))
   }
 
-  def activeHoursByDOW(dow: Int) = {
-    (this.session_length.getOrElse(Seq()) zip this.parsedSubmissionDate)
-      .filter(_._2.getDay == dow).map(_._1).sum/3600.0
+  def pluginsCount(): Option[Seq[Option[Long]]] = {
+    this.active_plugins.map(_.map(x => Some(x.length.toLong)))
   }
+
+  def parsedStartDate(): Option[Seq[LocalDate]] = {
+    this.subsession_start_date.map(_.map(parseDate))
+  }
+
+  def activeHoursByDOW(dow: Int): Option[Double] = {
+    this.session_length.map(sl => this.parsedStartDate.map(psd => sl zip psd)).getOrElse(None)
+      .map(_.filter(_._2.getDayOfWeek == dow).map(_._1).sum.toDouble / SECONDS_PER_HOUR)
+  }
+
+  def activeDaysByDOW(dow: Int): Option[Long] = {
+    this.parsedStartDate.map(_.filter(_.getDayOfWeek == dow).distinct.length)
+  }
+
+  def rangeOfPossibleDates(): Option[Seq[LocalDate]] = {
+    this.parsedStartDate.map(
+      psd => {
+        val start = this.parsedStartDate.getOrElse(Seq()).minBy(_.toDate)
+        val end = this.parsedStartDate.getOrElse(Seq()).maxBy(_.toDate)
+        val between = Days.daysBetween(start, end).getDays
+
+        (0 to between).map(start.plusDays(_))
+      }
+    )
+  }
+
+  def daysPossibleByDOW(dow: Int): Option[Long] = {
+    // Note that joda time uses 1:7 to refer to Monday through Sunday
+    this.rangeOfPossibleDates.map(_.filter(_.getDayOfWeek == dow).size)
+  }
+
+  def countPingReason(value: String): Long = {
+    this.reason.getOrElse(Seq()).filter(_ == value).size
+  }
+
+  def previousSubsessionIdCounts(): Option[Map[String, Int]] = {
+      this.previous_subsession_id.map(_.groupBy(identity).mapValues(_.size))
+  }
+
+  def ssStartToSubmission(): Option[Seq[Long]] = {
+    (this.subsession_start_date, this.submission_date) match {
+      case (Some(sd), Some(ssd)) => Some((sd zip ssd).map(x => getDateDiff(x._1, x._2)))
+      case _ => None
+    }
+  }
+
+  private def getDateDiff(begin: String, end: String): Long = {
+    Days.daysBetween(parseDate(begin), parseDate(end)).getDays.toLong
+  }
+
+  private def parseDate(sdate: String): LocalDate = {
+    new LocalDate(sdate.slice(0, 10))
+  }
+}
+
+object CrossSectional {
+  private val MarginOfError = 1.05
 }
 
 case class CrossSectional (
   val client_id: String,
   val normalized_channel: String,
-  val active_hours_total: Double,
-  val active_hours_0_mon: Double,
-  val active_hours_1_tue: Double,
-  val active_hours_2_wed: Double,
-  val active_hours_3_thu: Double,
-  val active_hours_4_fri: Double,
-  val active_hours_5_sat: Double,
-  val active_hours_6_sun: Double,
+  val active_hours_total: Option[Double],
+  val active_hours_0_mon: Option[Double],
+  val active_hours_1_tue: Option[Double],
+  val active_hours_2_wed: Option[Double],
+  val active_hours_3_thu: Option[Double],
+  val active_hours_4_fri: Option[Double],
+  val active_hours_5_sat: Option[Double],
+  val active_hours_6_sun: Option[Double],
   val geo_mode: Option[String],
-  val geo_cfgs: Long,
+  val geo_configs: Long,
   val architecture_mode: Option[String],
   val ffLocale_mode: Option[String],
   val addon_count_foreign_avg: Option[Double],
-  val addon_count_foreign_cfgs: Option[Long],
+  val addon_count_foreign_configs: Option[Long],
   val addon_count_foreign_mode: Option[Long],
   val addon_count_avg: Option[Double],
-  val addon_count_cfgs: Option[Long],
-  val addon_count_mode: Option[Long]
+  val addon_count_configs: Option[Long],
+  val addon_count_mode: Option[Long],
+  val number_of_pings: Option[Long],
+  val bookmarks_avg: Option[Double],
+  val bookmarks_max: Option[Long],
+  val bookmarks_min: Option[Long],
+  val cpu_count_mode: Option[Long],
+  val channel_configs: Option[Long],
+  val channel_mode: Option[String],
+  val days_active: Option[Long],
+  val days_active_0_mon: Option[Long],
+  val days_active_1_tue: Option[Long],
+  val days_active_2_wed: Option[Long],
+  val days_active_3_thu: Option[Long],
+  val days_active_4_fri: Option[Long],
+  val days_active_5_sat: Option[Long],
+  val days_active_6_sun: Option[Long],
+  val days_possible: Option[Long],
+  val days_possible_0_mon: Option[Long],
+  val days_possible_1_tue: Option[Long],
+  val days_possible_2_wed: Option[Long],
+  val days_possible_3_thu: Option[Long],
+  val days_possible_4_fri: Option[Long],
+  val days_possible_5_sat: Option[Long],
+  val days_possible_6_sun: Option[Long],
+  val default_pct: Option[Double],
+  val locale_configs: Option[Long],
+  val locale_mode: Option[String],
+  val version_configs: Option[Long],
+  val version_max: Option[String],
+  val addon_names_list: Option[Seq[Option[String]]],
+  val main_ping_reason_num_aborted: Long,
+  val main_ping_reason_num_end_of_day: Long,
+  val main_ping_reason_num_env_change: Long,
+  val main_ping_reason_num_shutdown: Long,
+  val memory_avg: Option[Double],
+  val memory_configs: Option[Long],
+  val os_name_mode: Option[String],
+  val os_version_mode: Option[String],
+  val os_version_configs: Option[Long],
+  val pages_count_avg: Option[Double],
+  val pages_count_min: Option[Long],
+  val pages_count_max: Option[Long],
+  val plugins_count_avg: Option[Double],
+  val plugins_count_configs: Option[Long],
+  val plugins_count_mode: Option[Long],
+  val start_date_oldest: Option[String],
+  val start_date_newest: Option[String],
+  val subsession_length_badTimer: Option[Long],
+  val subsession_length_negative: Option[Long],
+  val subsession_length_tooLong: Option[Long],
+  val previous_subsession_id_repeats: Option[Long],
+  val profile_creation_date: Option[String],
+  val profile_subsession_counter_min: Option[Long],
+  val profile_subsession_counter_max: Option[Long],
+  val profile_subsession_counter_configs: Option[Long],
+  val search_counts_total: Option[Long],
+  val search_default_configs: Option[Long],
+  val search_default_mode: Option[String],
+  val session_num_total: Option[Long],
+  val subsession_branches: Option[Long],
+  val date_skew_per_ping_avg: Option[Double],
+  val date_skew_per_ping_max: Option[Long],
+  val date_skew_per_ping_min: Option[Long]
 ) {
   def this(base: Longitudinal) = {
     this(
       client_id = base.client_id,
       normalized_channel = base.normalized_channel,
-      active_hours_total = base.session_length.getOrElse(Seq()).sum / 3600.0,
-      active_hours_0_mon = base.activeHoursByDOW(1),
-      active_hours_1_tue = base.activeHoursByDOW(2),
-      active_hours_2_wed = base.activeHoursByDOW(3),
-      active_hours_3_thu = base.activeHoursByDOW(4),
-      active_hours_4_fri = base.activeHoursByDOW(5),
-      active_hours_5_sat = base.activeHoursByDOW(6),
-      active_hours_6_sun = base.activeHoursByDOW(0),
+      active_hours_total = base.session_length.map(_.sum.toDouble / SECONDS_PER_HOUR),
+      active_hours_0_mon = base.activeHoursByDOW(MONDAY),
+      active_hours_1_tue = base.activeHoursByDOW(TUESDAY),
+      active_hours_2_wed = base.activeHoursByDOW(WEDNESDAY),
+      active_hours_3_thu = base.activeHoursByDOW(THURSDAY),
+      active_hours_4_fri = base.activeHoursByDOW(FRIDAY),
+      active_hours_5_sat = base.activeHoursByDOW(SATURDAY),
+      active_hours_6_sun = base.activeHoursByDOW(SUNDAY),
       geo_mode = base.weightedMode(base.geo_country),
-      geo_cfgs = base.geo_country.getOrElse(Seq()).distinct.length,
+      geo_configs = base.geo_country.getOrElse(Seq()).distinct.length,
       architecture_mode = base.weightedMode(base.architecture).getOrElse(None),
       ffLocale_mode = base.weightedMode(base.locale).getOrElse(None),
-      addon_count_foreign_avg = base.weightedMean(base.foreignAddonCount.map(_.map(x => Some(x.toLong)))),
-      addon_count_foreign_cfgs = base.foreignAddons.map(_.distinct.length),
-      addon_count_foreign_mode = base.weightedMode(base.foreignAddonCount).map(_.toLong),
-      addon_count_avg = base.weightedMean(base.addonCount.map(_.map(x => Some(x.toLong)))),
-      addon_count_cfgs = base.active_addons.map(_.distinct.length),
-      addon_count_mode = base.weightedMode(base.addonCount).map(_.toLong)
+      addon_count_foreign_avg = base.weightedMean(base.foreignAddonCount),
+      addon_count_foreign_configs = base.foreignAddonCount.map(_.distinct.length),
+      addon_count_foreign_mode = base.weightedMode(base.foreignAddonCount).getOrElse(None),
+      addon_count_avg = base.weightedMean(base.addonCount),
+      addon_count_configs = base.addonCount.map(_.distinct.length),
+      addon_count_mode = base.weightedMode(base.addonCount).getOrElse(None),
+      number_of_pings = base.session_length.map(_.length),
+      bookmarks_avg = base.weightedMean(base.bookmarks_sum),
+      bookmarks_max = base.bookmarks_sum.map(_.flatten.max),
+      bookmarks_min = base.bookmarks_sum.map(_.flatten.min),
+      cpu_count_mode = base.weightedMode(base.cpu_count).getOrElse(None),
+      channel_configs = base.channel.map(_.distinct.length),
+      channel_mode = base.weightedMode(base.channel).getOrElse(None),
+      days_active = base.parsedStartDate.map(_.distinct.length),
+      days_active_0_mon = base.activeDaysByDOW(MONDAY),
+      days_active_1_tue = base.activeDaysByDOW(TUESDAY),
+      days_active_2_wed = base.activeDaysByDOW(WEDNESDAY),
+      days_active_3_thu = base.activeDaysByDOW(THURSDAY),
+      days_active_4_fri = base.activeDaysByDOW(FRIDAY),
+      days_active_5_sat = base.activeDaysByDOW(SATURDAY),
+      days_active_6_sun = base.activeDaysByDOW(SUNDAY),
+      days_possible = base.rangeOfPossibleDates.map(_.size),
+      days_possible_0_mon = base.daysPossibleByDOW(MONDAY),
+      days_possible_1_tue = base.daysPossibleByDOW(TUESDAY),
+      days_possible_2_wed = base.daysPossibleByDOW(WEDNESDAY),
+      days_possible_3_thu = base.daysPossibleByDOW(THURSDAY),
+      days_possible_4_fri = base.daysPossibleByDOW(FRIDAY),
+      days_possible_5_sat = base.daysPossibleByDOW(SATURDAY),
+      days_possible_6_sun = base.daysPossibleByDOW(SUNDAY),
+      default_pct = base.weightedMean(base.is_default_browser.map(_.map(_.map(x => if(x) 1l else 0l)))),
+      locale_configs = base.locale.map(_.distinct.length),
+      locale_mode = base.weightedMode(base.locale).getOrElse(None),
+      version_configs = base.version.map(_.distinct.length),
+      version_max = base.version.map(_.max).getOrElse(None),
+      addon_names_list = base.addonNames,
+      main_ping_reason_num_aborted = base.countPingReason("aborted-session"),
+      main_ping_reason_num_end_of_day = base.countPingReason("daily"),
+      main_ping_reason_num_env_change  = base.countPingReason("environment-change"),
+      main_ping_reason_num_shutdown  = base.countPingReason("shutdown"),
+      memory_avg = base.weightedMean(base.memory_mb),
+      memory_configs = base.memory_mb.map(_.distinct.length),
+      os_name_mode = base.weightedMode(base.os_name).getOrElse(None),
+      os_version_mode = base.weightedMode(base.os_version).getOrElse(None),
+      os_version_configs = base.os_version.map(_.distinct.length),
+      pages_count_avg = base.weightedMean(base.pages_count),
+      pages_count_min = base.pages_count.map(_.flatten.min),
+      pages_count_max = base.pages_count.map(_.flatten.max),
+      plugins_count_avg = base.weightedMean(base.pluginsCount),
+      plugins_count_configs = base.pluginsCount.map(_.distinct.length),
+      plugins_count_mode = base.weightedMode(base.pluginsCount).getOrElse(None),
+      start_date_oldest = base.parsedStartDate.map(_.minBy(_.toDate).toString),
+      start_date_newest = base.parsedStartDate.map(_.maxBy(_.toDate).toString),
+      subsession_length_badTimer = base.session_length.map(_.filter(_ == -1).length),
+      subsession_length_negative = base.session_length.map(_.filter(_ < -1).length),
+      subsession_length_tooLong = base.session_length.map(_.filter(_ > SECONDS_PER_DAY * CrossSectional.MarginOfError).length),
+      previous_subsession_id_repeats = base.previousSubsessionIdCounts.map(_.values.max),
+      profile_creation_date = base.profile_creation_date.map(_.head),
+      profile_subsession_counter_min = base.profile_subsession_counter.map(_.min),
+      profile_subsession_counter_max = base.profile_subsession_counter.map(_.max),
+      profile_subsession_counter_configs = base.profile_subsession_counter.map(_.distinct.length),
+      search_counts_total = base.search_counts.map(_.values.foldLeft(0l)(_ + _.sum)),
+      search_default_configs = base.default_search_engine.map(_.distinct.length),
+      search_default_mode = base.weightedMode(base.default_search_engine).getOrElse(None),
+      session_num_total = base.session_id.map(_.distinct.length),
+      subsession_branches = base.previousSubsessionIdCounts.map(_.values.filter(_ > 1).size),
+      date_skew_per_ping_avg = base.ssStartToSubmission.map(aggregation.mean).getOrElse(None),
+      date_skew_per_ping_max = base.ssStartToSubmission.map(_.max),
+      date_skew_per_ping_min = base.ssStartToSubmission.map(_.min)
     )
   }
 }
@@ -176,7 +386,13 @@ object CrossSectionalView {
       .selectExpr(
         "client_id", "normalized_channel", "submission_date", "geo_country",
         "session_length", "settings.locale", "settings.is_default_browser",
-        "settings.default_search_engine", "build.architecture", "active_addons"
+        "settings.default_search_engine", "build.architecture", "active_addons",
+        "places_bookmarks_count.sum as bookmarks_sum", "system_cpu.count as cpu_count",
+        "settings.update.channel", "subsession_start_date", "build.version",
+        "reason", "system.memory_mb", "system_os.name as os_name",
+        "system_os.version as os_version", "places_pages_count.sum as pages_count",
+        "active_plugins", "previous_subsession_id", "profile_creation_date",
+        "profile_subsession_counter", "search_counts", "session_id"
       )
       .as[Longitudinal]
     val output = ds.map(new CrossSectional(_))

--- a/src/test/scala/com/mozilla/telemetry/CrossSectionalViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/CrossSectionalViewTest.scala
@@ -47,6 +47,21 @@ class CrossSectionalViewTest extends FlatSpec {
       .foldLeft(true)((acc, pair) => acc && (pair._1 compare  pair._2))
   }
 
+  def getExampleActiveAddon(foreign: Boolean = false, name: String = "Name") = {
+    new ActiveAddon(
+      Some(false), Some("Description"), Some(name), Some(false),
+      Some(false), Some("Version"), Some(1), Some("Type"), Some(foreign),
+      Some(false), Some(1), Some(1), Some(1), Some(false)
+    )
+  }
+
+  def getExampleActivePlugin() = {
+    new ActivePlugin(
+      Some("Name"), Some("Version"), Some("Description"), Some(true),
+      Some(false), Some(false), Some(Seq("mime1", "mime2")), Some(123)
+    )
+  }
+
   def getExampleLongitudinal(
     client_id: String,
     active_addons: Option[Seq[Map[String, ActiveAddon]]] = None
@@ -55,47 +70,134 @@ class CrossSectionalViewTest extends FlatSpec {
       client_id = client_id,
       normalized_channel = "release",
       submission_date = Some(Seq("2016-01-01T00:00:00.0+00:00",
-        "2016-01-02T00:00:00.0+00:00", "2016-01-03T00:00:00.0+00:00")),
+        "2016-01-02T00:00:00.0+00:00", "2016-01-07T00:00:00.0+00:00")),
       geo_country = Some(Seq("DE", "DE", "IT")),
       session_length = Some(Seq(3600, 7200, 14400)),
-      is_default_browser = Some(Seq(Some(true), Some(true), Some(true))),
-      default_search_engine = Some(Seq(Some("grep"), Some("grep"), Some("grep"))),
+      is_default_browser = Some(Seq(Some(true), Some(false), Some(true))),
+      default_search_engine = Some(Seq(Some("hooli"), Some("grep"), Some("grep"))),
       locale = Some(Seq(Some("de_DE"), Some("de_DE"), None)),
       architecture = Some(Seq(None, Some("arch"), Some("arch"))),
-      active_addons = active_addons
+      active_addons = active_addons,
+      bookmarks_sum = Some(Seq(Some(3), Some(2), Some(2))),
+      cpu_count = Some(Seq(Some(1), Some(2), Some(1))),
+      channel = Some(Seq(Some("release"),Some("release"),Some("release"))),
+      subsession_start_date = Some(Seq("2016-01-01T00:00:00.0+00:00",
+        "2016-01-02T00:00:00.0+00:00", "2016-01-05T00:00:00.0+00:00")),
+      version = Some(Seq(Some("42.0"), Some("41.0"), Some("41.0"))),
+      reason = Some(Seq("daily", "shutdown", "shutdown")),
+      memory_mb = Some(Seq(Some(1023), Some(1023), Some(1023))),
+      os_name = Some(Seq(Some("Windows_NT"), Some("Windows_NT"), Some("Windows_NT"))),
+      os_version = Some(Seq(Some("5.1"), Some("5.1"), Some("5.1"))),
+      pages_count = Some(Seq(Some(100l), Some(200l), Some(400l))),
+      active_plugins = Some(Seq(
+        Seq(getExampleActivePlugin(), getExampleActivePlugin()),
+        Seq(getExampleActivePlugin()),
+        Seq(getExampleActivePlugin(), getExampleActivePlugin())
+      )),
+      previous_subsession_id = Some(Seq("one", "one", "two")),
+      profile_creation_date = Some(Seq("2016-04-21T00:00:00.000Z",
+        "2016-04-21T00:00:00.000Z", "2016-04-21T00:00:00.000Z")),
+      profile_subsession_counter = Some(Seq(3,2,1)),
+      search_counts = Some(Map("dogpile" -> Seq(1l, 0l, 2l, 10l),
+                               "ask_jeeves" -> Seq(20l, 0l, 0l, 0l),
+                               "hooli" -> Seq(5l, 4l, 0l, 0l))),
+      session_id = Some(Seq("A", "B", "C"))
     )
   }
 
   def getExampleCrossSectional(
     client_id: String,
     addon_count_foreign_avg: Option[Double] = None,
-    addon_count_foreign_cfgs: Option[Long] = None,
+    addon_count_foreign_configs: Option[Long] = None,
     addon_count_foreign_mode: Option[Long] = None,
     addon_count_avg: Option[Double] = None,
-    addon_count_cfgs: Option[Long] = None,
-    addon_count_mode: Option[Long] = None
+    addon_count_configs: Option[Long] = None,
+    addon_count_mode: Option[Long] = None,
+    addon_names_list: Option[Seq[Option[String]]] = None
   ) = {
     new CrossSectional(
       client_id = client_id,
       normalized_channel = "release",
-      active_hours_total = 25200 / 3600.0,
-      active_hours_0_mon = 0.0,
-      active_hours_1_tue = 0.0,
-      active_hours_2_wed = 0.0,
-      active_hours_3_thu = 0.0,
-      active_hours_4_fri = 3600/3600.0,
-      active_hours_5_sat = 7200/3600.0,
-      active_hours_6_sun = 14400 / 3600.0,
+      active_hours_total = Some(25200 / 3600.0),
+      active_hours_0_mon = Some(0.0),
+      active_hours_1_tue = Some(14400 / 3600.0),
+      active_hours_2_wed = Some(0.0),
+      active_hours_3_thu = Some(0.0),
+      active_hours_4_fri = Some(3600/3600.0),
+      active_hours_5_sat = Some(7200/3600.0),
+      active_hours_6_sun = Some(0.0),
       geo_mode = Some("IT"),
-      geo_cfgs = 2,
+      geo_configs = 2,
       architecture_mode = Some("arch"),
       ffLocale_mode = None,
       addon_count_foreign_avg = addon_count_foreign_avg,
-      addon_count_foreign_cfgs = addon_count_foreign_cfgs,
+      addon_count_foreign_configs = addon_count_foreign_configs,
       addon_count_foreign_mode = addon_count_foreign_mode,
       addon_count_avg = addon_count_avg,
-      addon_count_cfgs = addon_count_cfgs,
-      addon_count_mode = addon_count_mode
+      addon_count_configs = addon_count_configs,
+      addon_count_mode = addon_count_mode,
+      number_of_pings = Some(3),
+      bookmarks_avg = Some(15.0 / 7),
+      bookmarks_max = Some(3),
+      bookmarks_min = Some(2),
+      cpu_count_mode = Some(1),
+      channel_configs = Some(1),
+      channel_mode = Some("release"),
+      days_active = Some(3),
+      days_active_0_mon = Some(0),
+      days_active_1_tue = Some(1),
+      days_active_2_wed = Some(0),
+      days_active_3_thu = Some(0),
+      days_active_4_fri = Some(1),
+      days_active_5_sat = Some(1),
+      days_active_6_sun = Some(0),
+      days_possible = Some(5),
+      days_possible_0_mon = Some(1),
+      days_possible_1_tue = Some(1),
+      days_possible_2_wed = Some(0),
+      days_possible_3_thu = Some(0),
+      days_possible_4_fri = Some(1),
+      days_possible_5_sat = Some(1),
+      days_possible_6_sun = Some(1),
+      default_pct = Some(5.0 / 7),
+      locale_configs = Some(2),
+      locale_mode = None,
+      version_configs = Some(2),
+      version_max = Some("42.0"),
+      addon_names_list = addon_names_list,
+      main_ping_reason_num_aborted = 0,
+      main_ping_reason_num_end_of_day = 1,
+      main_ping_reason_num_env_change = 0,
+      main_ping_reason_num_shutdown = 2,
+      memory_avg = Some(1023.0),
+      memory_configs = Some(1),
+      os_name_mode = Some("Windows_NT"),
+      os_version_mode = Some("5.1"),
+      os_version_configs = Some(1),
+      pages_count_avg = Some(2100.0 / 7),
+      pages_count_min = Some(100),
+      pages_count_max = Some(400),
+      plugins_count_avg = Some(12.0 / 7),
+      plugins_count_configs = Some(2),
+      plugins_count_mode = Some(2),
+      start_date_oldest = Some("2016-01-01"),
+      start_date_newest = Some("2016-01-05"),
+      subsession_length_badTimer = Some(0),
+      subsession_length_negative = Some(0),
+      subsession_length_tooLong = Some(0),
+      previous_subsession_id_repeats = Some(2),
+      profile_creation_date = Some("2016-04-21T00:00:00.000Z"),
+      profile_subsession_counter_min = Some(1),
+      profile_subsession_counter_max = Some(3),
+      profile_subsession_counter_configs = Some(3),
+      search_counts_total = Some(42),
+      search_default_configs = Some(2),
+      search_default_mode = Some("grep"),
+      session_num_total = Some(3),
+      subsession_branches = Some(1),
+      date_skew_per_ping_avg = Some(2.0 / 3),
+      date_skew_per_ping_max = Some(2),
+      date_skew_per_ping_min = Some(0)
     )
   }
 
@@ -128,7 +230,6 @@ class CrossSectionalViewTest extends FlatSpec {
         Some(false), Some(1), Some(1), Some(1), Some(false)
       )
     }
-
     val actual = new CrossSectional(getExampleLongitudinal(
       client_id = "a",
       active_addons = Some(Seq(
@@ -141,11 +242,36 @@ class CrossSectionalViewTest extends FlatSpec {
     val expected = getExampleCrossSectional(
       client_id = "a",
       addon_count_foreign_avg = Some(12.0 / 7),
-      addon_count_foreign_cfgs = Some(2),
+      addon_count_foreign_configs = Some(2),
       addon_count_foreign_mode = Some(2),
       addon_count_avg = Some(2.0),
-      addon_count_cfgs = Some(2),
-      addon_count_mode = Some(2)
+      addon_count_configs = Some(1),
+      addon_count_mode = Some(2),
+      addon_names_list = Some(Seq(Some("Name"), Some("Test")))
+    )
+
+    assert(actual compare expected)
+  }
+
+  it must "identify adblockers properly" in {
+    val actual = new CrossSectional(getExampleLongitudinal(
+        client_id = "a"
+      , active_addons = Some(Seq(
+            Map(("one", getExampleActiveAddon()), ("two", getExampleActiveAddon()))
+          , Map(("one", getExampleActiveAddon()), ("two", getExampleActiveAddon(name = "UBloCKer Plus Plus")))
+          , Map(("one", getExampleActiveAddon()), ("two", getExampleActiveAddon(foreign = true)))
+      ))
+    ))
+
+    val expected = getExampleCrossSectional(
+      client_id = "a",
+      addon_count_foreign_avg = Some(4.0 / 7.0),
+      addon_count_foreign_configs = Some(2),
+      addon_count_foreign_mode = Some(1),
+      addon_count_avg = Some(2.0),
+      addon_count_configs = Some(1),
+      addon_count_mode = Some(2),
+      addon_names_list = Some(Seq(Some("Name"), Some("UBloCKer Plus Plus")))
     )
 
     assert(actual compare expected)


### PR DESCRIPTION
This commit gives us feature parity with the python prototype by
bcolloran:
https://github.com/mozilla/bcolloran_spark/blob/master/perClientDataPrep/cross-sectional%20data%20table%20%282016-07-14%29%20-%20deduped%20clientIds.ipynb

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/127)
<!-- Reviewable:end -->
