### PR TITLE
Add documentation from wiki to docs directory

### DIFF
--- a/docs/available_datasets.md
+++ b/docs/available_datasets.md
@@ -1,0 +1,142 @@
+Data Set Documentation
+======================
+
+This document describes a set of datasets which can be queried using
+re:dash/sql.telemetry.mozilla.org (s.t.m.o). In addition, they can be
+queried using a Spark cluster - see 
+[these directions](https://wiki.mozilla.org/Telemetry/Custom_analysis_with_spark#How_can_I_load_parquet_datasets_in_a_Jupyter_notebook.3F).
+The Longditudinal dataset is also available natively within Spark, see the
+[longitudinal tutorial](https://github.com/mozilla/emr-bootstrap-spark/blob/master/examples/Longitudinal%20Dataset%20Tutorial.ipynb).
+
+Longitudinal
+------------
+[Complete documentation](Telemetry/LongitudinalExamples "wikilink")
+
+The longitudinal dataset is a summary of main pings. If you're not sure which
+dataset to use for your query, this is probably what you want. It differs from
+the main_summary table in two important ways:
+
+* The longitudinal dataset groups all data for a client-id in the same row.
+  This makes it easy to report profile level metrics. Without this deduping,
+  metrics would be weighted by the number of submissions instead of by clients.
+* The dataset uses a 1% of all recent profiles, which will reduce query
+  computation time and save resources. The sample of clients will be stable over
+  time.
+
+Accordingly, one should prefer using the Longitudinal dataset except in the
+rare case where a 100% sample is strictly necessary.
+
+As discussed in the [Longitudinal Data Set Example Notebook](https://gist.github.com/vitillo/627eab7e2b3f814725d2):
+
+    The longitudinal dataset is logically organized as a table where rows
+    represent profiles and columns the various metrics (e.g. startup time). Each
+    field of the table contains a list of values, one per Telemetry submission
+    received for that profile. [...]
+
+    The current version of the longitudinal dataset has been build with all
+    main pings received from 1% of profiles across all channels with [...] up to
+    180 days of data.
+
+Main Summary
+------------
+
+[Complete Documentation](https://github.com/mozilla/telemetry-batch-view/blob/master/docs/MainSummary.md)
+
+Like the longitudinal dataset, main summary summarizes [main
+pings](https://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/data/main-ping.html).
+Each row corresponds to a single ping. This table does no sampling and
+includes all desktop pings.
+
+### Caveats
+
+Querying against main summary on SQL.t.m.o/re:dash can **impact
+performance for other users** and can **take a while to complete**
+(\~30m for simple queries). Since main summary includes a row for every
+ping, there are a large number of records which can consume a lot of
+resources on the shared cluster.
+
+Instead, we recommend using the Longitudinal dataset where possible if
+querying from re:dash/s.t.m.o. The longitudinal dataset samples to 1% of
+all data and organized the data by client\_id. In the odd case where
+these queries are necessary, limit to a short submission\_date\_s3 range
+and ideally make use of the sample\_id field. Ideally, users who require
+this dataset would use Spark.
+
+Cross Sectional
+---------------
+
+The Cross Sectional dataset is a simplified version of the Longitudinal
+dataset.
+
+The majority of Longitudinal columns contain array values with one
+element for each ping, which is difficult to work with in SQL. The Cross
+Sectional dataset **replaces these array-valued columns with summary
+statistics**. To give an example, the Longitudinal dataset will contain
+a column named "geo\_country" where each row is an array of locales for
+one client (e.g. array\<"en\_US", "en\_US", "en\_GB"\>). Instead, the
+Cross Sectional dataset includes a column named "geo\_country\_mode"
+where each row contains a single string representing the mode (e.g.
+"en\_US"). The Cross Sectional column is **easier to work with** in SQL
+and is more representative than just choosing a single value from the
+Longitudinal array.
+
+Note that the Cross Sectional dataset is derived from the Longitudinal
+dataset, so the dataset is a **1% sample of main pings**
+
+This dataset is sometimes abbreviated as the **xsec dataset**. You can
+find the current version of the code
+[here](https://github.com/mozilla/telemetry-batch-view/blob/master/src/main/scala/com/mozilla/telemetry/views/CrossSectionalView.scala).
+This dataset is under active development, please **contact
+rharter@mozilla.com with any questions**.
+
+Client Count
+------------
+
+The Client Count dataset is simply a count of clients in a time period,
+separated out into a set of dimensions.
+
+This is useful for questions similar to: *How many X type of users were
+there during Y?* - where X is some dimensions, and Y is some dates.
+Examples of X are: E10s Enabled, Operating System Type, or Country. For
+a complete list of dimensions, see
+[here](https://github.com/mozilla/telemetry-batch-view/blob/master/src/main/scala/com/mozilla/telemetry/views/ClientCountView.scala#L22).
+
+Client Count does not contain a traditional int count column, instead
+the counts are stored as a HyperLogLogs in the hll column. The count of
+the hll is found using `cardinality(cast(hll AS HLL))`, and different
+hll's can be merged using `merge(cast(hll AS HLL))`. An example can be
+found in the [Firefox ER
+Reporting](https://sql.telemetry.mozilla.org/queries/81/source#129).
+
+### Caveats
+
+Currently there is no Python wrapper for the HyperLogLog library, so the
+client count dataset is unavailable in Spark.
+
+Crash Aggregates
+----------------
+
+[Complete
+Documentation](https://github.com/mozilla/telemetry-batch-view/blob/master/docs/CrashAggregateView.md)
+
+The Crash Aggregates dataset compiles crash statistics over various
+dimensions for each day. Example dimensions include channel and country,
+example statistics include usage hours and plugin crashes. See the
+[complete
+documentation](https://github.com/mozilla/telemetry-batch-view/blob/master/docs/CrashAggregateView.md)
+for all available dimensions and statistics.
+
+This dataset is good for queries of the form *How many crashes did X
+types of users get during time Y?* and *Which types of users crashed the
+most during time Y?*.
+
+Mobile Metrics
+--------------
+
+The android\_events, android\_clients, android\_addons, and
+mobile\_clients tables are documented here:
+<https://wiki.mozilla.org/Mobile/Metrics/Redash>
+
+# Appendix
+For reference, this documentation was previously hosted here:
+https://wiki.mozilla.org/Telemetry/Available_Telemetry_Datasets_and_their_Applications

--- a/docs/longitudinal_examples.md
+++ b/docs/longitudinal_examples.md
@@ -1,0 +1,218 @@
+### Introduction
+
+The longitudinal dataset is a summary of main pings. If you're not sure which
+dataset to use for your query, this is probably what you want. It differs from
+the main_summary table in two important ways:
+
+* The longitudinal dataset groups all data for a client-id in the same row.
+  This makes it easy to report profile level metrics. Without this deduping,
+  metrics would be weighted by the number of submissions instead of by clients.
+* The dataset uses a 1% of all recent profiles, which will reduce query
+  computation time and save resources. The sample of clients will be stable over
+  time.
+
+Accordingly, one should prefer using the Longitudinal dataset except in the
+rare case where a 100% sample is strictly necessary.
+
+As discussed in the [Longitudinal Data Set Example Notebook](https://gist.github.com/vitillo/627eab7e2b3f814725d2):
+
+    The longitudinal dataset is logically organized as a table where rows
+    represent profiles and columns the various metrics (e.g. startup time). Each
+    field of the table contains a list of values, one per Telemetry submission
+    received for that profile. [...]
+
+    The current version of the longitudinal dataset has been build with all
+    main pings received from 1% of profiles across all channels with [...] up to
+    180 days of data.
+
+### Table structure
+
+To get an overview of the longitudinal data table:
+
+```sql
+DESCRIBE longitudinal
+```
+
+That table has a row for each client, with columns for the different
+parts of the ping. There are a lot of fields here, so I recommend
+downloading the results as a CSV if you want to search through these
+fields. Unfortunately, there's no way to filter the output of DESCRIBE
+in Presto.
+
+Because this table combines all rows for a given client id, most columns
+contain either Arrays or Maps (described below). A few properties are
+directly available to query on:
+
+```sql
+SELECT count(*) AS count
+FROM longitudinal
+WHERE os = 'Linux'
+```
+
+#### Arrays
+
+Most properties are arrays, which contain one entry for each submission
+from a given client (newest first). Note that indexing starts at 1:
+
+```sql
+SELECT reason[1] AS newest_reason
+FROM longitudinal
+WHERE os = 'Linux'
+```
+
+To expand arrays and maps and work on the data row-wise we can use
+`UNNEST(array)`.
+
+```sql
+WITH lengths AS
+  (SELECT os, greatest(-1, least(31, sl / (24*60*60))) AS days
+   FROM longitudinal
+   CROSS JOIN UNNEST(session_length, reason) AS t(sl, r)
+   WHERE r = 'shutdown' OR r = 'aborted-session')
+SELECT os, days, count(*) AS count
+FROM lengths
+GROUP BY days, os ORDER BY days ASC
+```
+
+However, it may be better to use a sample from the main_summary table
+instead.
+
+Links:
+
+-   [Documentation on array
+    functions](https://prestodb.io/docs/current/functions/array.html)
+-   [`UNNEST`
+    documentation](https://prestodb.io/docs/current/sql/select.html#unnest)
+
+#### Maps
+
+Some fields like `active_addons` or `user_prefs` are handled as maps, on
+which you can use the `[]` operator and special functions:
+
+```sql
+WITH adp AS
+  (SELECT active_addons[1]['{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}']
+            IS NOT null AS has_adblockplus
+   FROM longitudinal)
+SELECT has_adblockplus, count(*) AS count
+FROM adp GROUP BY 1 ORDER BY 2 DESC
+```
+
+Links:
+
+-   [Documentation on map
+    functions](https://prestodb.io/docs/current/functions/map.html)
+
+### Sampling
+
+While composing queries, it can be helpful to work on small samples to
+reduce query runtimes:
+
+```sql
+SELECT * FROM longitudinal LIMIT 1000 ...
+```
+
+There's no need to use other sampling methods, such as TABLESAMPLE, on
+the longitudinal set. Rows are randomly ordered, so a LIMIT sample is
+expected to be random.
+
+### Example Queries
+
+#### Blocklist URLs (extensions.blocklist.url)
+
+```sql
+SELECT bl, COUNT(bl)
+FROM
+  (SELECT element_at(settings, 1).user_prefs['extensions.blocklist.url'] AS bl
+   FROM longitudinal)
+GROUP BY bl
+```
+
+#### Blocklist enabled/disabled (extensions.blocklist.enabled) count:
+```sql
+SELECT bl, COUNT(bl)
+FROM
+  (SELECT element_at(settings, 1).blocklist_enabled AS bl
+   FROM longitudinal)
+GROUP BY bl
+```
+
+#### Parsing most recent submission_date
+
+```sql
+SELECT DATE_PARSE(submission_date[1], '%Y-%m-%dT00:00:00.000Z') as parsed_submission_date
+FROM longitudinal
+```
+
+#### Limiting to most recent ping in the last 7 days
+
+```sql
+SELECT * FROM longitudinal
+WHERE DATE_DIFF('day', DATE_PARSE(submission_date[1], '%Y-%m-%dT00:00:00.000Z'), current_date) < 7
+```
+
+#### Scalar measurement (how many users with more than 100 tabs)
+
+```sql
+WITH samples AS
+ (SELECT
+   client_id,
+   normalized_channel as channel,
+   mctc AS max_concurrent_tabs
+  FROM longitudinal
+  CROSS JOIN UNNEST(scalar_parent_browser_engagement_max_concurrent_tab_count) as t (mctc)
+  WHERE
+   scalar_parent_browser_engagement_max_concurrent_tab_count is not null and
+   normalized_channel = 'nightly')
+SELECT approx_distinct(client_id) FROM samples WHERE max_concurrent_tabs > 100
+```
+
+### Using Views
+
+If you find yourself copy/pasting SQL between different queries,
+consider using a Presto VIEW to allow for code reuse. Views create
+logical tables which you can reuse in other queries. For example, [this
+view](https://sql.telemetry.mozilla.org/queries/776/source) defines some
+important filters and derived variables which are then used in [this
+downstream
+query](https://sql.telemetry.mozilla.org/queries/777/source#1311).
+
+You can define a view by prefixing your query with
+
+```sql
+CREATE OR REPLACE VIEW view_name AS ...
+```
+
+Be careful not to overwrite an existing view! Using a unique name is
+important.
+
+Find more information
+[here](https://prestodb.io/docs/current/sql/create-view.html).
+
+### Working offline
+
+It's often useful to keep a local sample of the l10l data when
+prototyping an analysis. The data is stored in
+s3://telemetry-parquet/longitudinal/. Once you have AWS credentials you
+can copy a shard of the parquet dataset to a local directory using `aws
+cp [filename] .`
+
+To request AWS credentials, see [this
+page](https://mana.mozilla.org/wiki/display/SVCOPS/Requesting+A+Dev+IAM+account+from+Cloud+Operations).
+To initiate your AWS config, try `aws configure`
+
+### FAQ
+
+#### I'm getting an error, "... cannot be resolved"
+
+For some reason, re:dash has trouble parsing SQL strings with double
+quotes. Try using single quotes instead.
+
+### Other Resources
+
+- [Presto Docs](https://prestodb.io/docs/current/sql.html)
+- [Helpful FAQ covering
+  perf/distribution](https://docs.treasuredata.com/articles/presto-query-faq)
+- [Longitudinal schema
+  definition](https://github.com/mozilla/telemetry-batch-view/blob/master/src/main/scala/com/mozilla/telemetry/views/Longitudinal.scala#L194)
+- [Custom_dashboards_with_re:dash](https://wiki.mozilla.org/Custom_dashboards_with_re:dash)

--- a/scripts/wiki_to_md.sh
+++ b/scripts/wiki_to_md.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+pandoc -s ${1}.wiki -o ${1}.md


### PR DESCRIPTION
Step 1 of the documentation reboot is checking in existing dataset documentation. Once this is merged, we can deprecate and redirect the wiki pages to this repo. 

Adds two key pages of documentation from the wiki, Longitudinal Examples
and Available Datasets. Tool documentation will likely live elsewhere.

@fbertsch, can you take a look?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/128)
<!-- Reviewable:end -->
