### PR TITLE
Fix memory problems via .sbtopts so that (quieter) tests can be run.

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,2 +1,4 @@
--J-Xss16M
--J-Xmx2048M
+-J-Xms4G
+-J-Xmx4G
+-J-Xss4M
+-J-XX:MaxMetaspaceSize=256M

--- a/src/test/scala/com/mozilla/telemetry/CrashAggregateViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/CrashAggregateViewTest.scala
@@ -38,6 +38,7 @@ class CrashAggregateViewTest extends FlatSpec with Matchers with BeforeAndAfterA
     val sparkConf = new SparkConf().setAppName("KPI")
     sparkConf.setMaster(sparkConf.get("spark.master", "local[1]"))
     sc = Some(new SparkContext(sparkConf))
+    sc.get.setLogLevel("WARN")
     sqlContext = Some(new SQLContext(sc.get))
   }
 

--- a/src/test/scala/com/mozilla/telemetry/CrossSectionalViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/CrossSectionalViewTest.scala
@@ -205,6 +205,7 @@ class CrossSectionalViewTest extends FlatSpec {
     val sparkConf = new SparkConf().setAppName("CrossSectionalTest")
     sparkConf.setMaster(sparkConf.get("spark.master", "local[1]"))
     val sc = new SparkContext(sparkConf)
+    sc.setLogLevel("WARN")
     val sqlContext = new SQLContext(sc)
     import sqlContext.implicits._
 


### PR DESCRIPTION
Avoid having to manually set environment variables for memory-related JVM parameters by updating them in the .sbtopts file.

This addresses the "GC Limit" OOM problem and possibly others.

Also reduce Spark verbosity in a couple of tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/132)
<!-- Reviewable:end -->
