### PR TITLE
Add a dimension to track profile age in CrashAggregateView.

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/CrashAggregateView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/CrashAggregateView.scala
@@ -103,7 +103,8 @@ object CrashAggregateView {
     List("environment.addons", "activeExperiment", "branch"),
     List("environment.settings", "e10sEnabled"),
     List("environment.settings", "e10sCohort"),
-    List("environment.system", "gfx", "features", "compositor")
+    List("environment.system", "gfx", "features", "compositor"),
+    List("environment.profile", "creationDate")
   )
 
   // names of the comparable dimensions above, used as dimension names in the database
@@ -120,7 +121,8 @@ object CrashAggregateView {
     "experiment_branch",
     "e10s_enabled",
     "e10s_cohort",
-    "gfx_compositor"
+    "gfx_compositor",
+    "profile_age"
   )
 
   val statsNames = List(
@@ -299,9 +301,11 @@ object CrashAggregateView {
               Some(topLevelField)
             } else { // JSON field, the rest of the path tells us where to look in the JSON
               val is_gfx_compositor = dimensionNames(index).equals("gfx_compositor")
+              val is_profile_date = dimensionNames(index).equals("profile_age")
               val dimensionValue = path.tail.foldLeft(parse(topLevelField))((value, fieldName) => value \ fieldName) // retrieve the value at the given path
               dimensionValue match {
                 case JString(value) if is_gfx_compositor && value == "none" => None
+                case JInt(value) if is_profile_date => Some(Math.min(Math.max(-1, Math.round(Days.daysBetween(new DateTime(0).plusDays(value.toInt), activityDate).getDays() / 7)), 53).toString)
                 case JString(value) => Some(value)
                 case JBool(value) => Some(if (value) "True" else "False")
                 case JInt(value) => Some(value.toString)

--- a/src/test/scala/com/mozilla/telemetry/CrashAggregateViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/CrashAggregateViewTest.scala
@@ -4,6 +4,7 @@ import com.mozilla.telemetry.views.CrashAggregateView
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.{SparkConf, SparkContext}
 import org.json4s.JsonAST.JValue
+import org.joda.time._
 import org.json4s.JsonDSL._
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
@@ -28,7 +29,8 @@ class CrashAggregateViewTest extends FlatSpec with Matchers with BeforeAndAfterA
     ("experiment_branch", List("control", "experiment")),
     ("e10s",              List(true, false)),
     ("e10s_cohort",       List("control", "test")),
-    ("gfx_compositor",    List("simple", "none", null))
+    ("gfx_compositor",    List("simple", "none", null)),
+    ("profile_created",   List("17107" /*Nov 2, 2016*/))
   )
 
   var sc: Option[SparkContext] = None
@@ -119,6 +121,8 @@ class CrashAggregateViewTest extends FlatSpec with Matchers with BeforeAndAfterA
         "activeExperiment" ->
           ("id" -> dimensions("experiment_id").asInstanceOf[String]) ~
           ("branch" -> dimensions("experiment_branch").asInstanceOf[String])
+      val profile =
+        "creationDate" -> dimensions("profile_created").asInstanceOf[String].toInt
       val payload = if (isMain) "{}" else compact(render(
           "payload" ->
             ("crashDate" -> dimensions("activity_date").asInstanceOf[String].substring(0, 10)) ~
@@ -139,7 +143,8 @@ class CrashAggregateViewTest extends FlatSpec with Matchers with BeforeAndAfterA
         "environment.system" -> compact(render(system)),
         "environment.settings" -> compact(render(settings)),
         "environment.build" -> compact(render(build)),
-        "environment.addons" -> compact(render(addons))
+        "environment.addons" -> compact(render(addons)),
+        "environment.profile" -> compact(render(profile))
       )
     }
 
@@ -188,6 +193,14 @@ class CrashAggregateViewTest extends FlatSpec with Matchers with BeforeAndAfterA
 
   "dimensions" must "be converted correctly" in {
     val dimensionValues = pingDimensions.toMap
+    val validActivityDateStrings = List(
+      "2016-03-02", "2016-06-01", // these are directly from the dataset
+      "2016-03-05", "2016-05-31" // these are bounded to be around the submission date
+    )
+    val validActivityDates = validActivityDateStrings
+      .map(dateString => format.DateTimeFormat.forPattern("yyyy-MM-dd").withZone(DateTimeZone.UTC).parseDateTime(dateString).withMillisOfDay(0))
+    val profile_ages = validActivityDates
+      .map(date => Math.min(Math.max(-1, Math.round(Days.daysBetween(new DateTime(0).plusDays(dimensionValues("profile_created")(0).asInstanceOf[String].toInt), date).getDays() / 7)), 53).toString)
     for (row <- fixture.records.select("dimensions").collect()) {
       val dimensions = row.getJavaMap[String, String](0)
       assert(dimensionValues("build_version")     contains dimensions.getOrElse("build_version", null))
@@ -203,6 +216,7 @@ class CrashAggregateViewTest extends FlatSpec with Matchers with BeforeAndAfterA
       assert(List("True", "False")                contains dimensions.getOrElse("e10s_enabled", null))
       assert(dimensionValues("e10s_cohort")       contains dimensions.getOrElse("e10s_cohort", null))
       assert(dimensionValues("gfx_compositor")    contains dimensions.getOrElse("gfx_compositor", null))
+      assert(profile_ages                         contains dimensions.getOrElse("profile_age", null))
     }
   }
 


### PR DESCRIPTION
We suspect that crashiness in the first little while of a user's experience
with Firefox has a disproportionate effect on engagement and retention.

To test this hypothesis, we need to see how crashy things are based on the ages
of the profiles experiencing the crashes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/140)
<!-- Reviewable:end -->
