### PR TITLE
Allow cast from JSON [Numeric|Bools] to String

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/avro/JSON2Avro.scala
+++ b/src/main/scala/com/mozilla/telemetry/avro/JSON2Avro.scala
@@ -57,6 +57,14 @@ object JSON2Avro{
   def parseString(schema: Schema, json: JValue): Option[String] = json match {
     case JString(value) =>
       Some(value)
+    case JInt(value) =>
+      Some(value.toString)
+    case JDecimal(value) =>
+      Some(value.toString)
+    case JDouble(value) =>
+      Some(value.toString)
+    case JBool(value) =>
+      Some(value.toString)
     case _ =>
       None
   }


### PR DESCRIPTION
Bug 1274008: In longitudinal, there are probably-incorrect results in
settings.user_prefs

In the `Longitudinal` table, `settings.userPrefs` is parsed as a
`Map[String, String]`. However, `userPrefs` has non-string valued fields:
`browser.zoom.full` and `browser.startup.page`, for example. This change
allows these Boolean, Integer, Decimal, and Double types to be parsed as Strings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/142)
<!-- Reviewable:end -->
