### PR TITLE
Bug 1314864 - Update SyncView to contain new updated and new fields from the sync ping.

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/SyncView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/SyncView.scala
@@ -170,6 +170,23 @@ object SyncPingConverter {
     StructField("os", StringType, nullable = false)
   ))
 
+  // Data about a single validation problem found
+  private val validationProblemType = StructType(List(
+    StructField("name", StringType, nullable = false),
+    StructField("count", LongType, nullable = false)
+  ))
+
+  // Data about a validation run on an engine
+  private val validationType = StructType(List(
+    // Validator version, optional per spec, but we fill in 0 where it was missing.
+    StructField("version", LongType, nullable = false),
+    StructField("checked", LongType, nullable = false), // # records checked
+    StructField("took", LongType, nullable = false), // milliseconds
+    StructField("problems", ArrayType(validationProblemType, containsNull = false), nullable = true),
+    // present if the validator failed for some reason.
+    StructField("failureReason", failureType, nullable = true)
+  ))
+
   // The schema for an engine.
   private val engineType = StructType(List(
     StructField("name", StringType, nullable = false),
@@ -177,7 +194,8 @@ object SyncPingConverter {
     StructField("status", StringType, nullable = true),
     StructField("failureReason", failureType, nullable = true),
     StructField("incoming", incomingType, nullable = true),
-    StructField("outgoing", ArrayType(outgoingType, containsNull = false), nullable = true)
+    StructField("outgoing", ArrayType(outgoingType, containsNull = false), nullable = true),
+    StructField("validation", validationType, nullable = true)
   ))
 
   // The status for the Sync itself (ie, not the status for an engine - that's just a string)
@@ -304,6 +322,45 @@ object SyncPingConverter {
     case _ => null
   }
 
+  private def validationToRow(validation: JValue): Row = validation match {
+    case JObject(_) =>
+      Row(
+        validation \ "version" match {
+          case JInt(x) => x.toLong
+          case _ => 0L
+        },
+        validation \ "checked" match {
+          case JInt(x) => x.toLong
+          case _ => 0L
+        },
+        validation \ "took" match {
+          case JInt(x) => x.toLong
+          case _ => 0L
+        },
+        validation \ "problems" match {
+          case JArray(problems) =>
+            problems.flatMap(validationProblemToRow)
+          case _ => null
+        },
+        failureReasonToRow(validation \ "failureReason")
+      )
+    case _ => null
+  }
+
+  private def validationProblemToRow(problem: JValue): Option[Row] = problem match {
+    case JObject(_) =>
+      Some(Row(
+        problem \ "name" match {
+          case JString(x) => x
+          case _ => return None
+        },
+        problem \ "count" match {
+          case JInt(x) => x.toLong
+          case _ => return None
+        }
+      ))
+    case _ => None
+  }
 
   // Parse an element of "engines" elt in a sync object
   private def engineToRow(engine: JValue): Row = {
@@ -322,7 +379,8 @@ object SyncPingConverter {
       },
       failureReasonToRow(engine \ "failureReason"),
       incomingToRow(engine \ "incoming"),
-      outgoingToRow(engine \ "outgoing")
+      outgoingToRow(engine \ "outgoing"),
+      validationToRow(engine \ "validation")
     )
   }
 

--- a/src/main/scala/com/mozilla/telemetry/views/SyncView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/SyncView.scala
@@ -193,6 +193,7 @@ object SyncPingConverter {
     StructField("app_display_version", StringType, nullable = true), // application/displayVersion
     StructField("app_name", StringType, nullable = true), // application/name
     StructField("app_version", StringType, nullable = true), // application/version
+    StructField("app_channel", StringType, nullable = true), // application/channel
     // XXX - how do we record the "platform"?
 
     // These fields are unique to the sync pings.
@@ -387,6 +388,10 @@ object SyncPingConverter {
         case _ => return None // a required field.
       },
       application \ "version" match {
+        case JString(x) => x
+        case _ => return None // a required field.
+      },
+      application \ "channel" match {
         case JString(x) => x
         case _ => return None // a required field.
       },

--- a/src/main/scala/com/mozilla/telemetry/views/SyncView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/SyncView.scala
@@ -225,6 +225,7 @@ object SyncPingConverter {
           case "autherror" => (failure \ "from").extract[String]
           case "othererror" => (failure \ "error").extract[String]
           case "unexpectederror" => (failure \ "error").extract[String]
+          case "sqlerror" => (failure \ "code").extract[String]
           case _ => null
         }
       )

--- a/src/test/scala/com/mozilla/telemetry/SyncViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/SyncViewTest.scala
@@ -33,6 +33,7 @@ class SyncViewTest extends FlatSpec with Matchers{
       checkRow.getAs[String]("app_display_version") should be ((ping \ "application" \ "displayVersion").extract[String])
       checkRow.getAs[String]("app_name") should be ((ping \ "application" \ "name").extract[String])
       checkRow.getAs[String]("app_version") should be ((ping \ "application" \ "version").extract[String])
+      checkRow.getAs[String]("app_channel") should be ((ping \ "application" \ "channel").extract[String])
 
       val payload = ping \ "payload"
       checkRow.getAs[Long]("when") should be ((payload \ "when").extract[Long])
@@ -162,6 +163,7 @@ class SyncViewTest extends FlatSpec with Matchers{
     firstSync.getAs[String]("app_display_version") should be ((ping \ "application" \ "displayVersion").extract[String])
     firstSync.getAs[String]("app_name") should be ((ping \ "application" \ "name").extract[String])
     firstSync.getAs[String]("app_version") should be ((ping \ "application" \ "version").extract[String])
+    firstSync.getAs[String]("app_channel") should be ((ping \ "application" \ "channel").extract[String])
 
     val firstPing = (ping \ "payload" \ "syncs")(0)
     firstSync.getAs[Long]("when") should be ((firstPing \ "when").extract[Long])
@@ -180,6 +182,7 @@ class SyncViewTest extends FlatSpec with Matchers{
     secondSync.getAs[String]("app_display_version") should be ((ping \ "application" \ "displayVersion").extract[String])
     secondSync.getAs[String]("app_name") should be ((ping \ "application" \ "name").extract[String])
     secondSync.getAs[String]("app_version") should be ((ping \ "application" \ "version").extract[String])
+    secondSync.getAs[String]("app_channel") should be ((ping \ "application" \ "channel").extract[String])
 
     val secondPing = (ping \ "payload" \ "syncs")(1)
 

--- a/src/test/scala/com/mozilla/telemetry/SyncViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/SyncViewTest.scala
@@ -93,13 +93,13 @@ class SyncViewTest extends FlatSpec with Matchers{
   }
 
 
-  "SyncPing records with device data" can "be round-tripped to parquet" in {
+  "SyncPing records with validation and device data" can "be round-tripped to parquet" in {
     val sparkConf = new SparkConf().setAppName("SyncPing")
     sparkConf.setMaster(sparkConf.get("spark.master", "local[1]"))
     val sc = new SparkContext(sparkConf)
     sc.setLogLevel("WARN")
     try {
-      val row = SyncPingConverter.pingToRows(SyncViewTestPayloads.syncPingWithDevices)
+      val row = SyncPingConverter.pingToRows(SyncViewTestPayloads.complexSyncPing)
       // Write a parquet file with the rows.
       val sqlContext = new SQLContext(sc)
       val rdd = sc.parallelize(row.toSeq)
@@ -110,7 +110,7 @@ class SyncViewTest extends FlatSpec with Matchers{
       val localDataset = sqlContext.read.load(tempFile.toString)
       localDataset.registerTempTable("sync")
       val localDataframe = sqlContext.sql("SELECT * FROM sync")
-      validateDevicesSyncPing(localDataframe.collect(), SyncViewTestPayloads.syncPingWithDevices)
+      validateComplexSyncPing(localDataframe.collect(), SyncViewTestPayloads.complexSyncPing)
     } finally {
       sc.stop()
     }
@@ -198,8 +198,8 @@ class SyncViewTest extends FlatSpec with Matchers{
   }
 
 
-  // A helper to check the contents of the sync ping with devices
-  private def validateDevicesSyncPing(rows: Array[Row], ping: JValue) {
+  // A helper to check the contents of the sync ping with devices and validation data.
+  private def validateComplexSyncPing(rows: Array[Row], ping: JValue) {
     implicit val formats = DefaultFormats
     rows.length should be (1)
 
@@ -229,6 +229,26 @@ class SyncViewTest extends FlatSpec with Matchers{
     }
 
     val engines = sync.getAs[mutable.WrappedArray[GenericRowWithSchema]]("engines")
-    validateEngines(engines, (pingPayload \ "engines").extract[List[JValue]])
+    val pingEngines = (pingPayload \ "engines").extract[List[JValue]]
+    validateEngines(engines, pingEngines)
+
+    validateEngines(engines , pingEngines)
+    // Check the validation data on the bookmark engine in the first sync.
+    val bmarkValidationRow = engines.find(x => x.getAs[String]("name") == "bookmarks").get
+      .getAs[GenericRowWithSchema]("validation")
+    val bmarkValidationJson = pingEngines.find(x => (x \ "name").extract[String] == "bookmarks").get \ "validation"
+
+    bmarkValidationRow.getAs[Long]("version") should be ((bmarkValidationJson \ "version").extract[Long])
+    bmarkValidationRow.getAs[Long]("took") should be ((bmarkValidationJson \ "took").extract[Long])
+    bmarkValidationRow.getAs[Long]("checked") should be ((bmarkValidationJson \ "checked").extract[Long])
+    val bmarkProblems = bmarkValidationRow.getAs[mutable.WrappedArray[GenericRowWithSchema]]("problems")
+    val bmarkProblemsJson= (bmarkValidationJson \ "problems").extract[List[JValue]]
+
+    bmarkProblems.length should be (bmarkProblemsJson.length)
+
+    for (i <- 0 to 1) {
+      bmarkProblems(i).getAs[String]("name") should be ((bmarkProblemsJson(i) \ "name").extract[String])
+      bmarkProblems(i).getAs[Long]("count") should be ((bmarkProblemsJson(i) \ "count").extract[Long])
+    }
   }
 }

--- a/src/test/scala/com/mozilla/telemetry/SyncViewTestPayloads.scala
+++ b/src/test/scala/com/mozilla/telemetry/SyncViewTestPayloads.scala
@@ -196,8 +196,8 @@ object SyncViewTestPayloads {
     |}
     """.stripMargin)
 
-  // Sync ping payload with devices.
-  def syncPingWithDevices = parse(
+  // Sync ping payload with devices and validation data.
+  def complexSyncPing = parse(
     """
       |{
       |  "type": "sync",
@@ -248,7 +248,23 @@ object SyncViewTestPayloads {
       |            "took": 16
       |          },
       |          {
-      |            "name": "bookmarks"
+      |            "name": "bookmarks",
+      |            "took": 1000,
+      |            "validation": {
+      |              "version": 1,
+      |              "checked": 290,
+      |              "took": 723,
+      |              "problems": [
+      |                {
+      |                  "name": "serverMissing",
+      |                  "count": 20
+      |                },
+      |                {
+      |                  "name": "rootOnServer",
+      |                  "count": 1
+      |                }
+      |              ]
+      |            }
       |          },
       |          {
       |            "name": "forms"

--- a/src/test/scala/com/mozilla/telemetry/SyncViewTestPayloads.scala
+++ b/src/test/scala/com/mozilla/telemetry/SyncViewTestPayloads.scala
@@ -110,6 +110,7 @@ object SyncViewTestPayloads {
     |      {
     |        "when": 1473313854446,
     |        "uid": "12345678912345678912345678912345",
+    |        "deviceID": "2222222222222222222222222222222222222222222222222222222222222222",
     |        "took": 2277,
     |        "engines": [
     |          {
@@ -167,6 +168,7 @@ object SyncViewTestPayloads {
     |      {
     |        "when": 1473313890947,
     |        "uid": "12345678912345678912345678912345",
+    |        "deviceID": "2222222222222222222222222222222222222222222222222222222222222222",
     |        "took": 484,
     |        "engines": [
     |          {
@@ -278,4 +280,116 @@ object SyncViewTestPayloads {
       |  }
       |}
     """.stripMargin)
+
+  def multiSyncPingWithTopLevelIds = parse(
+    """
+      |{
+      |  "type": "sync",
+      |  "id": "a1d969b7-0084-4a78-a841-2abaf887f1b4",
+      |  "creationDate": "2016-09-08T18:19:09.808Z",
+      |  "version": 4,
+      |  "application": {
+      |    "architecture": "x86-64",
+      |    "buildId": "20160907030427",
+      |    "name": "Firefox",
+      |    "version": "51.0a1",
+      |    "displayVersion": "51.0a1",
+      |    "vendor": "Mozilla",
+      |    "platformVersion": "51.0a1",
+      |    "xpcomAbi": "x86_64-msvc",
+      |    "channel": "nightly"
+      |  },
+      |  "payload": {
+      |    "why": "schedule",
+      |    "version": 1,
+      |    "uid": "12345678912345678912345678912345",
+      |    "deviceID": "2222222222222222222222222222222222222222222222222222222222222222",
+      |    "syncs": [
+      |      {
+      |        "when": 1473313854446,
+      |        "took": 2277,
+      |        "engines": [
+      |          {
+      |            "name": "clients",
+      |            "outgoing": [
+      |              {
+      |                "sent": 1
+      |              }
+      |            ],
+      |            "took": 468
+      |          },
+      |          {
+      |            "name": "passwords",
+      |            "took": 16
+      |          },
+      |          {
+      |            "name": "tabs",
+      |            "incoming": {
+      |              "applied": 2,
+      |              "reconciled": 1
+      |            },
+      |            "outgoing": [
+      |              {
+      |                "sent": 1
+      |              }
+      |            ],
+      |            "took": 795
+      |          },
+      |          {
+      |            "name": "bookmarks"
+      |          },
+      |          {
+      |            "name": "forms",
+      |            "outgoing": [
+      |              {
+      |                "sent": 2
+      |              }
+      |            ],
+      |            "took": 266
+      |          },
+      |          {
+      |            "name": "history",
+      |            "incoming": {
+      |              "applied": 2
+      |            },
+      |            "outgoing": [
+      |              {
+      |                "sent": 2
+      |              }
+      |            ],
+      |            "took": 514
+      |          }
+      |        ]
+      |      },
+      |      {
+      |        "when": 1473313890947,
+      |        "took": 484,
+      |        "engines": [
+      |          {
+      |            "name": "clients",
+      |            "took": 249
+      |          },
+      |          {
+      |            "name": "passwords"
+      |          },
+      |          {
+      |            "name": "tabs",
+      |            "took": 16
+      |          },
+      |          {
+      |            "name": "bookmarks"
+      |          },
+      |          {
+      |            "name": "forms"
+      |          },
+      |          {
+      |            "name": "history"
+      |          }
+      |        ]
+      |      }
+      |    ]
+      |  }
+      |}
+    """.stripMargin)
+
 }

--- a/src/test/scala/com/mozilla/telemetry/SyncViewTestPayloads.scala
+++ b/src/test/scala/com/mozilla/telemetry/SyncViewTestPayloads.scala
@@ -196,4 +196,70 @@ object SyncViewTestPayloads {
     |}
     """.stripMargin)
 
+  // Sync ping payload with devices.
+  def syncPingWithDevices = parse(
+    """
+      |{
+      |  "type": "sync",
+      |  "id": "a1d969b7-0084-4a78-a841-2abaf887f1b4",
+      |  "creationDate": "2016-09-08T18:19:09.808Z",
+      |  "version": 4,
+      |  "application": {
+      |    "architecture": "x86-64",
+      |    "buildId": "20160907030427",
+      |    "name": "Firefox",
+      |    "version": "51.0a1",
+      |    "displayVersion": "51.0a1",
+      |    "vendor": "Mozilla",
+      |    "platformVersion": "51.0a1",
+      |    "xpcomAbi": "x86_64-msvc",
+      |    "channel": "nightly"
+      |  },
+      |  "payload": {
+      |    "why": "schedule",
+      |    "version": 1,
+      |    "syncs": [
+      |      {
+      |        "when": 1473313854446,
+      |        "uid": "12345678912345678912345678912345",
+      |        "took": 2277,
+      |        "devices": [
+      |          {
+      |            "os": "iOS",
+      |            "version": "0.1",
+      |            "id": "1111111111111111111111111111111111111111111111111111111111111111"
+      |          },
+      |          {
+      |            "os": "WINNT",
+      |            "version": "52.0a1",
+      |            "id": "2222222222222222222222222222222222222222222222222222222222222222"
+      |          }
+      |        ],
+      |        "engines": [
+      |          {
+      |            "name": "clients",
+      |            "took": 249
+      |          },
+      |          {
+      |            "name": "passwords"
+      |          },
+      |          {
+      |            "name": "tabs",
+      |            "took": 16
+      |          },
+      |          {
+      |            "name": "bookmarks"
+      |          },
+      |          {
+      |            "name": "forms"
+      |          },
+      |          {
+      |            "name": "history"
+      |          }
+      |        ]
+      |      }
+      |    ]
+      |  }
+      |}
+    """.stripMargin)
 }


### PR DESCRIPTION
This updates the sync ping view to handle changes to the sync ping as well as adds support for recording new data.

This encompasses the work for [bug 1314864](https://bugzilla.mozilla.org/show_bug.cgi?id=1314864). Specific set of data changes, in no order:

1. The device constellation for a user, [from bug 1308567](https://bugzilla.mozilla.org/show_bug.cgi?id=1308567).
2. Bookmark validation data, [from bug 1267917](https://bugzilla.mozilla.org/show_bug.cgi?id=1267917) and is present in a very small number of cases. (This is currently something like 1 sync per day, for 10% of nightly users who have fewer than 100 bookmarks, although those numbers are subject to change).
3. Reporting an updated error type added in [Bug 1312320](https://bugzilla.mozilla.org/show_bug.cgi?id=1312320).
4. The ping's `application.channel` property is now recorded. No bug tracking this but it's been requested several times by e.g. adavis.
5. The server-side portion of [bug 1301389](https://bugzilla.mozilla.org/show_bug.cgi?id=1301389), which hasn't landed (I've added a patch to it so that you can see the equivalent documentation/schema changes on that bug). This is a necessary step for [bug 1289536](https://bugzilla.mozilla.org/show_bug.cgi?id=1289536).

Let me know if you have any questions.

P.S. (Apologies in advance if I messed up the copy/paste for any of the bugs listed here. Tried to be thorough, but that does lead to a large number of them)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/145)
<!-- Reviewable:end -->
