### PR TITLE
Remove opt-in histograms from Longitudinal View

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/histograms/Histogram.scala
+++ b/src/main/scala/com/mozilla/telemetry/histograms/Histogram.scala
@@ -53,6 +53,7 @@ object Histograms {
               case "true" => Some(true)
               case _ => Some(false)
             }
+            case ("releaseChannelCollection", JString(x)) => Some(x)
             case _ => None
           }
         } catch {
@@ -69,6 +70,7 @@ object Histograms {
 
       val pretty = for {
         (k, v) <- result
+        if v.getOrElse("releaseChannelCollection", Some("opt-in")) == Some("opt-out")
       } yield {
         val kind = v("kind").get.asInstanceOf[String]
         val keyed = v.getOrElse("keyed", Some(false)).get.asInstanceOf[Boolean]

--- a/src/main/scala/com/mozilla/telemetry/views/Longitudinal.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/Longitudinal.scala
@@ -693,7 +693,7 @@ object LongitudinalView {
       definition <- Histograms.definitions.get(key)
     } yield (key, definition)
 
-    val histogramSchema = getElemType(schema, "gc_ms")
+    val histogramSchema = getElemType(schema, "fx_tab_switch_total_ms")
 
     for ((key, definition) <- validKeys) {
       val keyedHistogramsList = histogramsList.map{x =>
@@ -728,7 +728,7 @@ object LongitudinalView {
       definition <- Histograms.definitions.get(key)
     } yield (key, definition)
 
-    val histogramSchema = getElemType(schema, "gc_ms")
+    val histogramSchema = getElemType(schema, "fx_tab_switch_total_ms")
 
     for ((key, definition) <- validKeys) {
       root.set(key.toLowerCase, vectorizeHistogram(key, definition, histogramsList, histogramSchema))


### PR DESCRIPTION
Bug 1313151 - Remove opt-in histograms from longitudinal dataset

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/148)
<!-- Reviewable:end -->
