### PR TITLE
Bug 1325974 - Use processType='main' to identify main crashes

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/CrashAggregateView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/CrashAggregateView.scala
@@ -154,7 +154,7 @@ object CrashAggregateView {
       m.get("docType") match {
         case Some("crash") => m.get("payload") match {
           case Some(payload: JValue) => payload \ "payload" \ "processType" match {
-            case JString("browser") | JNothing => true
+            case JString("main") | JNothing => true
             case _ => {
               contentCrashIgnoredAccumulator.add(1)
               false

--- a/src/test/scala/com/mozilla/telemetry/CrashAggregateViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/CrashAggregateViewTest.scala
@@ -122,7 +122,7 @@ class CrashAggregateViewTest extends FlatSpec with Matchers with BeforeAndAfterA
       val payload = if (isMain) "{}" else compact(render(
           "payload" ->
             ("crashDate" -> dimensions("activity_date").asInstanceOf[String].substring(0, 10)) ~
-            ("processType" -> "browser")))
+            ("processType" -> "main")))
 
 
       implicit val formats = DefaultFormats
@@ -271,9 +271,9 @@ class CrashAggregateViewTest extends FlatSpec with Matchers with BeforeAndAfterA
     assert(contentCrashIgnoredAccumulator.value == contentCrashPings.length)
   }
 
-  "browser crash pings" must "not be ignored"  in {
+  "main crash pings" must "not be ignored"  in {
     val browserCrashPings = fixture.sampleCrashPings.map(
-      p => p + ("processType" -> "browser")
+      p => p + ("processType" -> "main")
     )
     val (
       rowRDD,


### PR DESCRIPTION
'main' is the right identifier to use instead of 'browser'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/157)
<!-- Reviewable:end -->
