### PR TITLE
Add events to MainSummaryView

### DIFF
--- a/docs/MainSummary.md
+++ b/docs/MainSummary.md
@@ -181,6 +181,16 @@ root
  |-- unique_domains_count: integer (nullable = true)
  |-- submission_date_s3: string (nullable = true)
  |-- sample_id: string (nullable = true)
+ |-- events: array (nullable = true)
+ |    |-- element: struct (containsNull = true)
+ |    |    |-- timestamp: long (nullable = false)
+ |    |    |-- category: string (nullable = false)
+ |    |    |-- method: string (nullable = false)
+ |    |    |-- object: string (nullable = false)
+ |    |    |-- string_value: string (nullable = true)
+ |    |    |-- map_values: map (nullable = true)
+ |    |    |    |-- key: string
+ |    |    |    |-- value: string
 ```
 For more detail on where these fields come from in the
 [raw data](https://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/data/main-ping.html),

--- a/docs/MainSummary.md
+++ b/docs/MainSummary.md
@@ -104,7 +104,7 @@ root
  |-- client_submission_date: string (nullable = true)
  |-- places_bookmarks_count: integer (nullable = true)
  |-- places_pages_count: integer (nullable = true)
- |-- push_api_notification_received: integer (nullable = true)
+ |-- push_api_notify: integer (nullable = true)
  |-- web_notification_shown: integer (nullable = true)
  |-- popup_notification_stats: map (nullable = true)
  |    |-- key: string

--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -186,6 +186,43 @@ object MainSummaryView {
     }
   }
 
+  def getEvents(events: JValue): Option[List[Row]] = {
+    implicit val formats = DefaultFormats
+    Try(events.extract[List[List[Any]]]) match {
+      case Success(eventList) => {
+        val rows = eventList.flatMap {
+          case _ @ List(
+            timestamp: BigInt,
+            category:  String,
+            method:    String,
+            obj:       String,
+            strValue:  String,
+            mapValues: Map[String @unchecked, String @unchecked])
+            => List(Row(timestamp.toLong, category, method, obj, strValue, mapValues))
+          case _ @ List(
+            timestamp: BigInt,
+            category:  String,
+            method:    String,
+            obj:       String,
+            strValue:  String)
+            => List(Row(timestamp.toLong, category, method, obj, strValue))
+          case _ @ List(
+            timestamp: BigInt,
+            category:  String,
+            method:    String,
+            obj:       String)
+            => List(Row(timestamp.toLong, category, method, obj))
+          case _ => None
+        }
+        rows match {
+          case Nil => None
+          case x => Some(x)
+        }
+      }
+      case _ => None
+    }
+  }
+
   def getUserPrefs(prefs: JValue): Option[Row] = {
     prefs \ "dom.ipc.processCount" match {
       case JInt(pc) => Some(Row(pc.toInt))
@@ -226,6 +263,7 @@ object MainSummaryView {
     lazy val weaveDesktop = MainPing.enumHistogramToCount(histograms \ "WEAVE_DEVICE_COUNT_DESKTOP")
     lazy val weaveMobile = MainPing.enumHistogramToCount(histograms \ "WEAVE_DEVICE_COUNT_MOBILE")
     lazy val parentScalars = payload \ "payload" \ "processes" \ "parent" \ "scalars"
+    lazy val parentEvents = payload \ "payload" \ "processes" \ "parent" \ "events"
 
     val loopActivityCounterKeys = (0 to 4).map(_.toString)
 
@@ -453,7 +491,8 @@ object MainSummaryView {
       getBrowserEngagement(parentScalars, "window_open_event_count"),
       getBrowserEngagement(parentScalars, "total_uri_count"),
       getBrowserEngagement(parentScalars, "unfiltered_uri_count"),
-      getBrowserEngagement(parentScalars, "unique_domains_count")
+      getBrowserEngagement(parentScalars, "unique_domains_count"),
+      getEvents(parentEvents).orNull
     )
     Some(row)
   }
@@ -519,6 +558,15 @@ object MainSummaryView {
       StructField("signed_state",          IntegerType, nullable = true),
       StructField("is_system",             BooleanType, nullable = true)
     ))
+
+  def buildEventSchema = StructType(List(
+    StructField("timestamp",    LongType, nullable = false),
+    StructField("category",     StringType, nullable = false),
+    StructField("method",       StringType, nullable = false),
+    StructField("object",       StringType, nullable = false),
+    StructField("string_value", StringType, nullable = true),
+    StructField("map_values",   MapType(StringType, StringType), nullable = true)
+  ))
 
   // Data for user prefs
   def buildUserPrefsSchema = StructType(List(
@@ -644,7 +692,8 @@ object MainSummaryView {
       StructField("window_open_event_count", IntegerType, nullable = true),
       StructField("total_uri_count", IntegerType, nullable = true),
       StructField("unfiltered_uri_count", IntegerType, nullable = true),
-      StructField("unique_domains_count", IntegerType, nullable = true)
+      StructField("unique_domains_count", IntegerType, nullable = true),
+      StructField("events", ArrayType(buildEventSchema, containsNull = false), nullable = true) // payload.processes.parent.events
     ))
   }
 }

--- a/src/test/scala/com/mozilla/telemetry/MainSummaryViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/MainSummaryViewTest.scala
@@ -878,4 +878,43 @@ class MainSummaryViewTest extends FlatSpec with Matchers{
     val jBogusScalars = parse("""[10, "ten"]""")
     MainSummaryView.getBrowserEngagement(jBogusScalars, "anything") should be (null)
   }
+
+  "Events" can "be extracted" in {
+    val events = parse(
+      """[
+           [533352, "navigation", "search", "urlbar", "enter", {"engine": "other-StartPage - English"}],
+           [533352, "navigation", "search", "urlbar", "enter", {"engine": "other-StartPage - English"}, "random extra"],
+           [85959, "navigation", "search", "urlbar", "enter"],
+           [81994404, "navigation", "search", "searchbar"],
+           ["malformed"]
+         ]""")
+
+    val eventRows = MainSummaryView.getEvents(events)
+
+    eventRows should be (
+      Some(List(
+        Row(533352, "navigation", "search", "urlbar", "enter", Map("engine" -> "other-StartPage - English")),
+        Row(85959, "navigation", "search", "urlbar", "enter"),
+        Row(81994404, "navigation", "search", "searchbar")
+      )
+    ))
+    MainSummaryView.getEvents(parse(testPayload) \ "events") should be (None)
+    MainSummaryView.getEvents(parse("""[]""")) should be (None)
+
+    // Apply events schema to event rows
+    val schema = MainSummaryView.buildEventSchema
+    val sparkConf = new SparkConf().setAppName("MainSummary")
+    sparkConf.setMaster(sparkConf.get("spark.master", "local[1]"))
+    val sc = new SparkContext(sparkConf)
+    val spark = SparkSession
+      .builder()
+      .appName("MainSummary")
+      .getOrCreate()
+
+    try {
+      noException should be thrownBy spark.createDataFrame(sc.parallelize(eventRows.get), schema)
+    } finally {
+      sc.stop
+    }
+  }
 }


### PR DESCRIPTION
Since we're getting events in nightly and aurora now, we need to start presenting them for analysis.

I'm not 100% sure that Main Summary is the right place for this, but if we're processing main pings anyway adding a new column shouldn't be a huge deal, if I understand how Parquet works correctly. My next step after this would be to pull out an events dataset much like we do with addons.

Extracting the parameters is kind of ugly since events are a list of lists instead of a list of objects, so we can't use json4s's case class extractors. I attempted to write a custom deserializer for an Events case class but it ended up just looking like this anyway, just in a different file. Open to suggestions for how to get this looking more idiomatic -- working with variable-length heterogeneous lists in Scala has proved to be.. difficult.

I've successfully run this on recently nightly pings and read in events from the resultant files in a jupyter notebook.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/160)
<!-- Reviewable:end -->
