### PR TITLE
Bug 1316860 - Add CrashSummary batch view

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/CrashSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/CrashSummaryView.scala
@@ -1,0 +1,255 @@
+package com.mozilla.telemetry.views
+
+import com.mozilla.telemetry.heka.Dataset
+import org.apache.spark.sql.{SaveMode, SparkSession}
+import org.joda.time.{DateTime, Days, format}
+import org.json4s._
+import org.json4s.jackson.Serialization
+import org.json4s.jackson.JsonMethods._
+import org.rogach.scallop.ScallopConf
+
+case class Application(
+    architecture: String,
+    buildId: String,
+    channel: String,
+    name: String,
+    platformVersion: String,
+    vendor: String,
+    version: String,
+    xpcomAbi: String)
+
+case class Build(
+    applicationId: Option[String],
+    applicationName: Option[String],
+    architecture: Option[String],
+    buildId: String,
+    platformVersion: String,
+    vendor: String,
+    version: String,
+    xpcomAbi: String)
+
+case class SystemOs(name: String, version: String)
+
+case class SystemGfxFeatures(compositor: Option[String])
+
+case class SystemGfx(
+    D2DEnabled: Option[Boolean],
+    DWriteEnabled: Option[Boolean],
+    features: Option[SystemGfxFeatures])
+
+
+case class System(os: SystemOs, gfx: Option[SystemGfx])
+
+case class ActiveExperiment(id: String, branch: String)
+
+case class Addons(activeExperiment: Option[ActiveExperiment])
+
+case class Settings(
+    blocklistEnabled: Option[Boolean],
+    isDefaultBrowser: Option[Boolean],
+    e10sEnabled: Option[Boolean],
+    e10sCohort: Option[String],
+    locale: String,
+    telemetryEnabled: Boolean)
+
+case class Meta(
+    Host: Option[String],
+    Hostname: Option[String],
+    Size: Option[Double],
+    Timestamp: Option[Int],
+    Type: Option[String],
+    appBuildId: Option[String],
+    appName: Option[String],
+    appUpdateChannel: Option[String],
+    appVendor: Option[String],
+    appVersion: Option[Double],
+    clientId: Option[String],
+    creationTimestamp: Option[Float],
+    docType: Option[String],
+    documentId: Option[String],
+    geoCity: Option[String],
+    geoCountry: String,
+    normalizedChannel: String,
+    os: Option[String],
+    sampleId: Option[Double],
+    sourceName: Option[String],
+    sourceVersion: Option[Int],
+    submissionDate: Option[String],
+    telemetryEnabled: Option[Boolean],
+    `environment.build`: Build,
+    `environment.settings`: Settings,
+    `environment.system`: System,
+    `environment.addons`: Addons)
+
+case class Payload(
+    crashDate: String,
+    processType: Option[String],
+    hasCrashEnvironment: Boolean,
+    metadata: Map[String, String],
+    version: Int)
+
+case class CrashPing(
+    application: Application,
+    clientId: Option[String],
+    creationDate: String,
+    meta: Meta,
+    id: String,
+    // TODO: verify the use of reserved words for members' name
+    `type`: String,
+    version: Int,
+    payload: Payload)
+
+case class CrashSummary (
+    client_id: Option[String],
+    normalized_channel: String,
+    build_version: String,
+    build_id: String,
+    channel: String,
+    application: String,
+    os_name: String,
+    os_version: String,
+    architecture: String,
+    country: String,
+    experiment_id: Option[String],
+    experiment_branch: Option[String],
+    e10s_enabled: Option[Boolean],
+    e10s_cohort: Option[String],
+    gfx_compositor: Option[String],
+    payload: Payload) {
+
+  def this(ping: CrashPing) = {
+    this(
+      client_id = ping.clientId,
+      normalized_channel = ping.meta.normalizedChannel,
+      build_version = ping.meta.`environment.build`.version,
+      build_id = ping.meta.`environment.build`.buildId,
+      channel = ping.application.channel,
+      application = ping.application.name,
+      os_name = ping.meta.`environment.system`.os.name,
+      os_version = ping.meta.`environment.system`.os.version,
+      architecture = ping.application.architecture,
+      country = ping.meta.geoCountry,
+      experiment_id = for {
+        x <- ping.meta.`environment.addons`.activeExperiment
+      } yield x.id,
+      experiment_branch = for {
+        x <- ping.meta.`environment.addons`.activeExperiment
+      } yield x.branch,
+      e10s_enabled = ping.meta.`environment.settings`.e10sEnabled,
+      e10s_cohort = ping.meta.`environment.settings`.e10sCohort,
+      gfx_compositor = for {
+        x <- ping.meta.`environment.system`.gfx
+        y <-  x.features
+        z <- y.compositor
+      } yield z,
+      payload = ping.payload
+    )
+  }
+}
+
+object CrashSummaryView {
+  private class Opts(args: Array[String]) extends ScallopConf(args) {
+    val outputBucket = opt[String](
+      "outputBucket",
+      descr = "Bucket in which to save data",
+      required = false,
+      default = Some("telemetry-test-bucket"))
+    val from = opt[String](
+      "from",
+      descr = "From submission date",
+      required = false)
+    val to = opt[String](
+      "to",
+      descr = "To submission date",
+      required = false)
+    val dryRun = opt[Boolean](
+      "dryRun",
+      descr = "Calculate the dataset, but do not write to S3",
+      required = false,
+      default=Some(false))
+    verify()
+  }
+
+  def transformPayload(fields: Map[String, Any], payload: Option[String]): Option[CrashPing] = {
+    implicit val formats = DefaultFormats
+    val jsonFieldNames = List(
+    "environment.build",
+    "environment.settings",
+    "environment.system",
+    "environment.addons"
+    )
+    val jsonObj = Extraction.decompose(fields)
+    // Transform json fields into JValues
+    val meta = jsonObj transformField {
+      case JField(key, JString(s)) if jsonFieldNames contains key => (key, parse(s))
+    }
+    val jsonPayload = payload match {
+      case Some(value: String) => parse(value) ++ JObject(List(JField("meta", meta)))
+      case _ => JObject()
+    }
+    jsonPayload.extractOpt[CrashPing]
+  }
+
+  def main(args: Array[String]): Unit = {
+    // Setup spark contexts
+    val spark = SparkSession
+      .builder()
+      .appName(this.getClass.getName)
+      .config("spark.master", "local[*]")
+      .getOrCreate()
+    implicit val sc = spark.sparkContext
+    import spark.implicits._
+    implicit val formats = Serialization.formats(NoTypeHints)
+
+    // Parse command line options
+    val opts = new Opts(args)
+    val fmt = format.DateTimeFormat.forPattern("yyyyMMdd")
+    val to = opts.to.get match {
+      case Some(t) => fmt.parseDateTime(t)
+      case _ => DateTime.now.minusDays(1)
+    }
+    val from = opts.from.get match {
+      case Some(f) => fmt.parseDateTime(f)
+      case _ => DateTime.now.minusDays(1)
+    }
+
+    for (offset <- 0 to Days.daysBetween(from, to).getDays) {
+      val currentDate = from.plusDays(offset)
+      val currentDateString = currentDate.toString("yyyy-MM-dd")
+
+      val messages = Dataset("telemetry")
+        .where("sourceName") { case "telemetry" => true }
+        .where("sourceVersion") { case "4" => true }
+        .where("docType") { case "crash" => true }
+        .where("submissionDate") { case date if date == currentDate.toString("yyyyMMdd") => true }
+
+      val processedPings = spark.sparkContext.longAccumulator("processedPings")
+      val discardedPings = spark.sparkContext.longAccumulator("discardedPings")
+      val crashPings = messages.records()
+        .map(x => this.transformPayload(x.fieldsAsMap(), x.payload))
+      crashPings.foreach(x => {
+        if (!x.isDefined) {
+          discardedPings.add(1)
+        } else {
+          processedPings.add(1)
+        }
+      })
+      val crashSummary = crashPings.flatMap(identity[Option[CrashPing]]).map(new CrashSummary(_))
+      val dataset = spark.createDataset(crashSummary)
+
+      // Save to S3
+      if (!opts.dryRun()) {
+        val prefix = s"crash_summary/v1"
+        val outputBucket = opts.outputBucket()
+        val path = s"s3://${outputBucket}/${prefix}/submission_date=${currentDateString}"
+        dataset.write.mode(SaveMode.Overwrite).parquet(path)
+      }
+      println("************************************")
+      println(s"Total pings: ${dataset.count()}")
+      println(s"Processed pings: ${processedPings.value}")
+      println(s"Discarded pings: ${discardedPings.value}")
+      println("************************************")
+    }
+    sc.stop()
+  }
+}

--- a/src/test/resources/crash_ping_indented.json
+++ b/src/test/resources/crash_ping_indented.json
@@ -1,0 +1,63 @@
+{
+  "fields": {
+   "clientId": "my-client-id",
+   "creationTimestamp": 1.483495356792E18,
+   "appName": "Fennec",
+   "environment.settings": "{\"locale\":\"pt-BR\",\"telemetryEnabled\":true,\"userPrefs\":{\"browser.cache.disk.capacity\":204800},\"update\":{\"enabled\":false,\"autoDownload\":true,\"channel\":\"beta\"},\"e10sEnabled\":true,\"e10sCohort\":\"test\",\"blocklistEnabled\":true}",
+   "geoCity": "Santo Ângelo",
+   "appUpdateChannel": "beta",
+   "appVersion": "40.0",
+   "Size": 2286.0,
+   "normalizedChannel": "beta",
+   "os": "Linux",
+   "submissionDate": "20170105",
+   "telemetryEnabled": true,
+   "sourceName": "telemetry",
+   "appVendor": "Mozilla",
+   "environment.build": "{\"platformVersion\":\"40.0\",\"applicationId\":\"{aa3c5121-dab2-40e2-81ca-7ea25febc110}\",\"buildId\":\"20150706171725\",\"vendor\":\"Mozilla\",\"version\":\"40.0\",\"applicationName\":\"Fennec\",\"xpcomAbi\":\"arm-eabi-gcc3\",\"architecture\":\"arm\"}",
+   "environment.addons": "{\"activeGMPlugins\":{\"gmp-gmpopenh264\":{\"userDisabled\":false,\"version\":\"1.5.3\",\"applyBackgroundUpdates\":1}},\"activeAddons\":{},\"activeExperiment\":{},\"activePlugins\":{},\"theme\":{},\"activeExperiment\":{\"id\":1,\"branch\":\"control\"}}",
+   "appBuildId": "20150706171725",
+   "documentId": "1a72f638-ce92-4b71-beef-3bb0a0a2f012",
+   "geoCountry": "BR",
+   "environment.partner": "{\"partnerNames\":{}}",
+   "sourceVersion": "4",
+   "environment.system": "{\"memoryMB\":724,\"os\":{\"locale\":\"pt-BR\",\"kernelVersion\":\"2.6.36.3\",\"version\":13,\"name\":\"Linux\"},\"device\":{\"hardware\":\"p3\",\"manufacturer\":\"samsung\",\"isTablet\":true,\"model\":\"GT-P7300\"},\"cpu\":{\"count\":2,\"extensions\":[\"hasEDSP\",\"hasARMv6\",\"hasARMv7\"]},\"hdd\":{\"profile\":{},\"binary\":{},\"system\":{}},\"gfx\":{\"features\": {\"compositor\":\"opengl\"},\"adapters\":[{\"deviceID\":\"NVIDIA Tegra\",\"description\":\"Model: GT-P7300, Product: GT-P7300, Manufacturer: samsung, Hardware: p3, OpenGL: NVIDIA Corporation -- NVIDIA Tegra -- OpenGL ES 2.0\",\"GPUActive\":true,\"driverVersion\":\"OpenGL ES 2.0\",\"vendorID\":\"NVIDIA Corporation\"}]}}",
+   "sampleId": 26.0,
+   "Host": "incoming.telemetry.mozilla.org",
+   "docType": "crash"
+  },
+  "payload": {
+    "creationDate": "2017-01-05T04:41:27.796Z",
+    "type": "crash",
+    "version": 4,
+    "payload": {
+      "hasCrashEnvironment": true,
+      "metadata": {
+        "EventLoopNestingLevel": "1",
+        "IsGarbageCollecting": "1",
+        "Version": "40.0",
+        "ReleaseChannel": "beta",
+        "BuildID": "20150702172253",
+        "ProductName": "Fennec",
+        "ProductID": "{aa3c5121-dab2-40e2-81ca-7ea25febc110}",
+        "SecondsSinceLastCrash": "868004"
+      },
+      "version": 1,
+      "crashDate": "2017-01-05",
+      "processType": "main"
+    },
+    "id": "482183c3-7281-4d96-a464-8d033f0c27e2",
+    "environment": {},
+    "clientId": "my-client-id",
+    "application": {
+      "platformVersion": "40.0",
+      "xpcomAbi": "arm-eabi-gcc3",
+      "name": "Fennec",
+      "channel": "beta",
+      "version": "40.0",
+      "buildId": "20150702172253",
+      "vendor": "Mozilla",
+      "architecture": "arm"
+    }
+  }
+}

--- a/src/test/scala/com/mozilla/telemetry/CrashSummaryViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/CrashSummaryViewTest.scala
@@ -1,0 +1,75 @@
+package com.mozilla.telemetry
+
+import scala.io.Source
+import org.scalatest._
+import org.json4s.jackson.JsonMethods._
+import org.json4s.Extraction
+import org.json4s.DefaultFormats
+import com.mozilla.telemetry.views.{CrashSummaryView, CrashSummary, CrashPing}
+
+class CrashSummaryViewTest extends FlatSpec with Matchers {
+
+  def fixture = {
+    val crashPingsPath = getClass.getResource("/crash_ping_indented.json").getPath()
+    val crashPingsJson = Source.fromFile(crashPingsPath).mkString
+    implicit val formats = DefaultFormats
+    val crashPingsMap = parse(crashPingsJson)
+    new {
+      val ping = crashPingsMap.extract[Map[String, Any]]
+      val fields = ping.get("fields") match {
+        case Some(m: Map[_,_]) => m.asInstanceOf[Map[String,Any]]
+        case _  => Map[String, Any]()
+      }
+      val payload = ping.getOrElse("payload", Map[String, Any]())
+      val payloadStr = compact(render(Extraction.decompose(payload)))
+    }
+  }
+
+  "A well formed ping" should "return a CrashPing" in {
+    val maybeCrashPing = CrashSummaryView.transformPayload(
+      fixture.fields,
+      Some(fixture.payloadStr)
+    )
+    assert(maybeCrashPing.isDefined)
+  }
+
+  "A malformed ping" should "return an undefined option" in {
+    val malformedFields = fixture.fields - "geoCountry"
+    val maybeCrashPing = CrashSummaryView.transformPayload(
+      malformedFields,
+      Some(fixture.payloadStr)
+    )
+    assert(! maybeCrashPing.isDefined)
+  }
+
+  "A CrashSummary" can "be created from a CrashPing" in {
+    val maybeCrashPing = CrashSummaryView.transformPayload(
+      fixture.fields,
+      Some(fixture.payloadStr)
+    )
+    assert(maybeCrashPing.isDefined)
+    val crashSummary = maybeCrashPing match {
+      case Some(ping: CrashPing) => Some(new CrashSummary(ping))
+      case _ => None
+    }
+    assert(crashSummary.isDefined)
+    crashSummary.foreach(x => {
+      assert(x.client_id == Some("my-client-id"))
+      assert(x.normalized_channel == "beta")
+      assert(x.build_version == "40.0")
+      assert(x.build_id == "20150706171725")
+      assert(x.channel == "beta")
+      assert(x.application == "Fennec")
+      assert(x.os_name == "Linux")
+      assert(x.os_version == "13")
+      assert(x.architecture == "arm")
+      assert(x.country == "BR")
+      assert(x.experiment_id == Some("1"))
+      assert(x.experiment_branch == Some("control"))
+      assert(x.e10s_cohort == Some("test"))
+      assert(x.e10s_enabled == Some(true))
+      assert(x.gfx_compositor == Some("opengl"))
+      assert(x.payload.processType == Some("main"))
+    })
+  }
+}


### PR DESCRIPTION
The first version of CrashSummaryView is based on what's required by CrashAggregates. More fields can be easily added modifying the various case classes. ~It's still missing some tests for `CrashSummary.transformPayload`, but~ it's ready for a first look. I wrote a few tests to cover the few lines of logic in `transformPayload`, the compiler should cover the rest. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/161)
<!-- Reviewable:end -->
