### PR TITLE
Mark HBase tests as slow.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 target/
 lib_managed/
-project/
 .ipynb_checkpoints/
 metastore_db/
 .idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ scala:
   - 2.11.8
 sbt_args: -J-Xss2M
 script:
-  - sbt coverage test
+  - sbt coverage slow:test
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ If you run into memory issues during compilation time or running the test suite,
 export _JAVA_OPTIONS="-Xms4G -Xmx4G -Xss4M -XX:MaxMetaspaceSize=256M"
 ```
 
+**Slow tests**
+By default slow tests are not run when using `sbt test`. To run slow tests use `sbt slow:test`.
+
 **Running on Windows**
 
 Executing scala/Spark jobs could be particularly problematic on this platform. Here's a list of common issues and the relative solutions:

--- a/build.sbt
+++ b/build.sbt
@@ -45,3 +45,11 @@ mergeStrategy in assembly := {
   case "reference.conf"              => MergeStrategy.concat
   case x => MergeStrategy.first
 }
+
+lazy val Slow = config("slow").extend(Test)
+configs(Slow)
+inConfig(Slow)(Defaults.testTasks)
+
+testOptions in Test += Tests.Argument("-l", "org.scalatest.tags.Slow")
+testOptions in Slow -= Tests.Argument("-l", "org.scalatest.tags.Slow")
+testOptions in Slow += Tests.Argument("-n", "org.scalatest.tags.Slow")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.13

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,15 @@
+# Change this to set Spark log level
+log4j.logger.org.apache.spark=WARN
+
+# Silence akka remoting
+log4j.logger.Remoting=WARN
+
+# Ignore messages below warning level from Jetty, because it's a bit verbose
+log4j.logger.org.eclipse.jetty=WARN
+
+# Silence HBase
+log4j.logger.org.apache.zookeeper=WARN
+log4j.logger.org.apache.hadoop.hbase.zookeeper=WARN
+log4j.logger.org.apache.hadoop.hbase.client=WARN
+log4j.logger.org.apache.hadoop.hbase.mapreduce.TableInputFormatBase=WARN
+log4j.logger.org.apache.hadoop.mapred.FileOutputCommitter=WARN


### PR DESCRIPTION
This patch labels HBase tests as slow and disables their execution when
running `sbt test`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/162)
<!-- Reviewable:end -->
