### PR TITLE
Bug 1331082 - Add stub attribution fields to main summary

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/utils/MainPing.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/MainPing.scala
@@ -19,6 +19,11 @@ case class Addon(id: Option[String],
                  signedState: Option[Integer],
                  isSystem: Option[Boolean])
 
+case class Attribution(source: Option[String],
+                       medium: Option[String],
+                       campaign: Option[String],
+                       content: Option[String])
+
 object MainPing{
   // Count the number of keys inside a JSON Object
   def countKeys(o: JValue): Option[Long] = {

--- a/src/test/scala/com/mozilla/telemetry/MainSummaryViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/MainSummaryViewTest.scala
@@ -919,4 +919,52 @@ class MainSummaryViewTest extends FlatSpec with Matchers{
       sc.stop
     }
   }
+
+  "Stub attribution" can "be extracted" in {
+    // Contains a single attribute
+    val json1 = parse(
+      """
+        |{
+        | "environment": {
+        |  "settings": {
+        |   "attribution": {
+        |     "source": "sample_source"
+        |   }
+        |  }
+        | }
+        |}
+      """.stripMargin)
+    MainSummaryView.getAttribution(json1 \ "environment" \ "settings" \ "attribution") should be (
+      Some(Row("sample_source", null, null, null)))
+
+    // Contains no attributes
+    val json2 = parse(
+      """
+        |{
+        | "environment": {
+        |  "settings": {}
+        | }
+        |}
+      """.stripMargin)
+    MainSummaryView.getAttribution(json2 \ "environment" \ "settings" \ "attribution") should be (None)
+
+    // Contains all attributes, in no particular order
+    val json3 = parse(
+      """
+        |{
+        | "environment": {
+        |  "settings": {
+        |   "attribution": {
+        |     "content": "sample_content",
+        |     "source": "sample_source",
+        |     "medium": "sample_medium",
+        |     "campaign": "sample_campaign"
+        |   }
+        |  }
+        | }
+        |}
+      """.stripMargin)
+    MainSummaryView.getAttribution(json3 \ "environment" \ "settings" \ "attribution") should be (
+      Some(Row("sample_source", "sample_medium", "sample_campaign", "sample_content")))
+  }
 }


### PR DESCRIPTION
This patch adds a new column called `attribution` along with the related tests for [bug 1331082](https://bugzilla.mozilla.org/show_bug.cgi?id=1331082). These fields will be used in retention analysis.

r? @sunahsuh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-batch-view/165)
<!-- Reviewable:end -->
