### PR TITLE
Bug 1329023 - Fix parquet decode errors in SyncView via repartition

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/SyncView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/SyncView.scala
@@ -107,7 +107,7 @@ object SyncView {
         val s3prefix = s"$jobName/$schemaVersion/submission_date_s3=$currentDateString"
         val s3path = s"s3://${conf.outputBucket()}/$s3prefix"
 
-        records.write.mode("error").parquet(s3path)
+        records.repartition(10).write.mode("overwrite").parquet(s3path)
 
         // Then remove the _SUCCESS file so we don't break Spark partition discovery.
         S3Store.deleteKey(conf.outputBucket(), s"$s3prefix/_SUCCESS")


### PR DESCRIPTION
This patch repartitions the dataframe before writing to s3 to prevent
client (Spark, Presto)  parquet decoding errors. This patch also enable
overwriting old data, which makes this fix available by applying a
backfill to a date.

The sync_summary dataset generated by SyncView occassionally has invalid
parquet data in `engines.list.element.name` (column 14). The two
occurances that were caught and fixed with this patch are where
`submission_date_s3` is is equal to `20161204` and `20161208`.

The specific decode error is `java.lang.IllegalArgumentException:
Reading past RLE/BitPacking stream`. It was found that repartitioning
the data before writing out to s3 fixes decoding errors (for 2/2 cases).
An issue with parquet encoding is suspected, but there are many
potential causes.

This patch has been used to fix two broken partitions identified by a [repair notebook](https://gist.github.com/acmiyaguchi/e319fc2af5c61bd5229a3e13bcde67c1). The two broken dates were 20161204 and 20161208.

r? @vitillo @thomcc 