### PR TITLE
Fix coverage status.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ scala:
   - 2.11.8
 sbt_args: -J-Xss2M
 script:
-  - sbt coverage slow:test
+  - sbt coverage slow:test coverageReport
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/maven/"
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.1.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.3")
 
 libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.5.47"

--- a/src/main/scala/com/mozilla/telemetry/views/AddonsView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/AddonsView.scala
@@ -82,8 +82,9 @@ object AddonsView {
 
       println(s"JOB $jobName COMPLETED SUCCESSFULLY FOR $currentDateString")
       println("=======================================================================================")
-      sc.stop()
     }
+
+    sc.stop()
   }
 
   def addonsFromMain(mainSummaryData: DataFrame): DataFrame = {

--- a/src/test/scala/com/mozilla/telemetry/AddonsViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/AddonsViewTest.scala
@@ -28,14 +28,10 @@ case class PartialMain(document_id: String,
 
 class AddonsViewTest extends FlatSpec with Matchers{
   "Addon records" can "be extracted from MainSummary" in {
-    val sparkConf = new SparkConf().setAppName("AddonsViewTest")
-    sparkConf.setMaster(sparkConf.get("spark.master", "local[1]"))
-    val sc = new SparkContext(sparkConf)
-    sc.setLogLevel("WARN")
-
     val spark = SparkSession
       .builder()
       .appName("AddonsViewTest")
+      .master("local[1]")
       .getOrCreate()
 
     import spark.implicits._


### PR DESCRIPTION
Some tests stopped running after the introduction of the slow tag which
caused the coverage to drop.