### PR TITLE
Rename the System case class to SystemData

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/CrashSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/CrashSummaryView.scala
@@ -38,7 +38,7 @@ case class SystemGfx(
     features: Option[SystemGfxFeatures])
 
 
-case class System(os: SystemOs, gfx: Option[SystemGfx])
+case class SystemData(os: SystemOs, gfx: Option[SystemGfx])
 
 case class ActiveExperiment(id: String, branch: String)
 
@@ -78,7 +78,7 @@ case class Meta(
     telemetryEnabled: Option[Boolean],
     `environment.build`: Build,
     `environment.settings`: Settings,
-    `environment.system`: System,
+    `environment.system`: SystemData,
     `environment.addons`: Addons)
 
 case class Payload(


### PR DESCRIPTION
This is needed as, otherwise, we're not able to call functions from System.* (setProperty, getProperty, out, ...). Using some of these functions is needed to develop and test on Windows.

Unless there's another way to call System.* stuff, even if there's a name clash, I'd suggest renaming the case class. Feel free to suggest a different solution if available! (I'm no Scala guru :D)

r?@mdoglio