### PR TITLE
Add top distribution ids to client_count dataset

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,8 @@ javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint")
 resolvers += "Spark Packages Repo" at "https://dl.bintray.com/spark-packages/maven/"
 resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 
+val sparkVersion = "2.0.2"
+
 lazy val root = (project in file(".")).
   settings(
     name := "telemetry-batch-view",
@@ -20,10 +22,10 @@ lazy val root = (project in file(".")).
     libraryDependencies += "org.apache.hadoop" % "hadoop-aws" % "2.7.1" excludeAll(ExclusionRule(organization = "javax.servlet")),
     libraryDependencies += "com.github.nscala-time" %% "nscala-time" % "2.10.0",
     libraryDependencies += "org.rogach" %% "scallop" % "1.0.2",
-    libraryDependencies += "org.apache.spark" %% "spark-core" % "2.0.0",
-    libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.0.0",
-    libraryDependencies += "org.apache.spark" %% "spark-mllib" % "2.0.0",
-    libraryDependencies += "org.apache.spark" %% "spark-hive" % "2.0.0",
+    libraryDependencies += "org.apache.spark" %% "spark-core" % sparkVersion,
+    libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion,
+    libraryDependencies += "org.apache.spark" %% "spark-mllib" % sparkVersion,
+    libraryDependencies += "org.apache.spark" %% "spark-hive" % sparkVersion,
     libraryDependencies += "org.apache.hbase" % "hbase-server" % "1.2.3",
     libraryDependencies += "org.apache.hbase" % "hbase-common" % "1.2.3",
     libraryDependencies += "org.apache.hbase" % "hbase-hadoop-compat" % "1.2.3",

--- a/src/main/scala/com/mozilla/telemetry/views/ClientCountView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/ClientCountView.scala
@@ -36,9 +36,16 @@ object ClientCountView {
     "substr(subsession_start_date, 0, 10) as activity_date" ::
     "devtools_toolbox_opened_count > 0 as devtools_toolbox_opened" ::
     "loop_activity_counter.open_panel > 0 as loop_activity_open_panel" ::
+    "case when distribution_id in ('canonical', 'MozillaOnline', 'yandex') " +
+      "then distribution_id else null end as top_distribution_id" ::
     base
 
-  val dimensions = "activity_date" :: "devtools_toolbox_opened" :: "loop_activity_open_panel" :: base
+  val dimensions =
+    "activity_date" ::
+    "devtools_toolbox_opened" ::
+    "loop_activity_open_panel" ::
+    "top_distribution_id" ::
+    base
 
   def aggregate(frame: DataFrame): DataFrame = {
     frame


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1339308 for context.
This PR adds the top 3 distributions, which account for nearly 70%
of values.