### PR TITLE
Restrict travis push builds to master branch only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,6 @@ script:
   - sbt coverage slow:test coverageReport
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+branches:
+  only:
+    - master


### PR DESCRIPTION
If this worked correctly we'll only have the PR build and not the push build on this PR