### PR TITLE
Bug 1342817 - Use `submission` instead of `payload` to get ping content

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/CrashSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/CrashSummaryView.scala
@@ -170,7 +170,7 @@ object CrashSummaryView {
     verify()
   }
 
-  def transformPayload(fields: Map[String, Any], payload: Option[String]): Option[CrashPing] = {
+  def transformPayload(fields: Map[String, Any]): Option[CrashPing] = {
     implicit val formats = DefaultFormats
     val jsonFieldNames = List(
     "environment.build",
@@ -183,7 +183,7 @@ object CrashSummaryView {
     val meta = jsonObj transformField {
       case JField(key, JString(s)) if jsonFieldNames contains key => (key, parse(s))
     }
-    val jsonPayload = payload match {
+    val jsonPayload = fields.get("submission") match {
       case Some(value: String) => parse(value) ++ JObject(List(JField("meta", meta)))
       case _ => JObject()
     }
@@ -226,7 +226,7 @@ object CrashSummaryView {
       val processedPings = spark.sparkContext.longAccumulator("processedPings")
       val discardedPings = spark.sparkContext.longAccumulator("discardedPings")
       val crashPings = messages.records()
-        .map(x => this.transformPayload(x.fieldsAsMap, x.payload))
+        .map(x => this.transformPayload(x.fieldsAsMap))
       crashPings.foreach(x => {
         if (!x.isDefined) {
           discardedPings.add(1)

--- a/src/test/resources/crash_ping_indented.json
+++ b/src/test/resources/crash_ping_indented.json
@@ -24,40 +24,7 @@
    "environment.system": "{\"memoryMB\":724,\"os\":{\"locale\":\"pt-BR\",\"kernelVersion\":\"2.6.36.3\",\"version\":13,\"name\":\"Linux\"},\"device\":{\"hardware\":\"p3\",\"manufacturer\":\"samsung\",\"isTablet\":true,\"model\":\"GT-P7300\"},\"cpu\":{\"count\":2,\"extensions\":[\"hasEDSP\",\"hasARMv6\",\"hasARMv7\"]},\"hdd\":{\"profile\":{},\"binary\":{},\"system\":{}},\"gfx\":{\"features\": {\"compositor\":\"opengl\"},\"adapters\":[{\"deviceID\":\"NVIDIA Tegra\",\"description\":\"Model: GT-P7300, Product: GT-P7300, Manufacturer: samsung, Hardware: p3, OpenGL: NVIDIA Corporation -- NVIDIA Tegra -- OpenGL ES 2.0\",\"GPUActive\":true,\"driverVersion\":\"OpenGL ES 2.0\",\"vendorID\":\"NVIDIA Corporation\"}]}}",
    "sampleId": 26.0,
    "Host": "incoming.telemetry.mozilla.org",
-   "docType": "crash"
-  },
-  "payload": {
-    "creationDate": "2017-01-05T04:41:27.796Z",
-    "type": "crash",
-    "version": 4,
-    "payload": {
-      "hasCrashEnvironment": true,
-      "metadata": {
-        "EventLoopNestingLevel": "1",
-        "IsGarbageCollecting": "1",
-        "Version": "40.0",
-        "ReleaseChannel": "beta",
-        "BuildID": "20150702172253",
-        "ProductName": "Fennec",
-        "ProductID": "{aa3c5121-dab2-40e2-81ca-7ea25febc110}",
-        "SecondsSinceLastCrash": "868004"
-      },
-      "version": 1,
-      "crashDate": "2017-01-05",
-      "processType": "main"
-    },
-    "id": "482183c3-7281-4d96-a464-8d033f0c27e2",
-    "environment": {},
-    "clientId": "my-client-id",
-    "application": {
-      "platformVersion": "40.0",
-      "xpcomAbi": "arm-eabi-gcc3",
-      "name": "Fennec",
-      "channel": "beta",
-      "version": "40.0",
-      "buildId": "20150702172253",
-      "vendor": "Mozilla",
-      "architecture": "arm"
-    }
+   "docType": "crash",
+   "submission": "{\"clientId\": \"my-client-id\", \"payload\": {\"processType\": \"main\", \"metadata\": {\"IsGarbageCollecting\": \"1\", \"SecondsSinceLastCrash\": \"868004\", \"ProductName\": \"Fennec\", \"BuildID\": \"20150702172253\", \"Version\": \"40.0\", \"EventLoopNestingLevel\": \"1\", \"ReleaseChannel\": \"beta\", \"ProductID\": \"{aa3c5121-dab2-40e2-81ca-7ea25febc110}\"}, \"crashDate\": \"2017-01-05\", \"version\": 1, \"hasCrashEnvironment\": true}, \"environment\": {}, \"application\": {\"vendor\": \"Mozilla\", \"name\": \"Fennec\", \"buildId\": \"20150702172253\", \"version\": \"40.0\", \"architecture\": \"arm\", \"platformVersion\": \"40.0\", \"xpcomAbi\": \"arm-eabi-gcc3\", \"channel\": \"beta\"}, \"version\": 4, \"creationDate\": \"2017-01-05T04:41:27.796Z\", \"type\": \"crash\", \"id\": \"482183c3-7281-4d96-a464-8d033f0c27e2\"}"
   }
 }

--- a/src/test/scala/com/mozilla/telemetry/CrashSummaryViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/CrashSummaryViewTest.scala
@@ -20,33 +20,22 @@ class CrashSummaryViewTest extends FlatSpec with Matchers {
         case Some(m: Map[_,_]) => m.asInstanceOf[Map[String,Any]]
         case _  => Map[String, Any]()
       }
-      val payload = ping.getOrElse("payload", Map[String, Any]())
-      val payloadStr = compact(render(Extraction.decompose(payload)))
     }
   }
 
   "A well formed ping" should "return a CrashPing" in {
-    val maybeCrashPing = CrashSummaryView.transformPayload(
-      fixture.fields,
-      Some(fixture.payloadStr)
-    )
+    val maybeCrashPing = CrashSummaryView.transformPayload(fixture.fields)
     assert(maybeCrashPing.isDefined)
   }
 
   "A malformed ping" should "return an undefined option" in {
     val malformedFields = fixture.fields - "geoCountry"
-    val maybeCrashPing = CrashSummaryView.transformPayload(
-      malformedFields,
-      Some(fixture.payloadStr)
-    )
+    val maybeCrashPing = CrashSummaryView.transformPayload(malformedFields)
     assert(! maybeCrashPing.isDefined)
   }
 
   "A CrashSummary" can "be created from a CrashPing" in {
-    val maybeCrashPing = CrashSummaryView.transformPayload(
-      fixture.fields,
-      Some(fixture.payloadStr)
-    )
+    val maybeCrashPing = CrashSummaryView.transformPayload(fixture.fields)
     assert(maybeCrashPing.isDefined)
     val crashSummary = maybeCrashPing match {
       case Some(ping: CrashPing) => Some(new CrashSummary(ping))


### PR DESCRIPTION
The CEP recently changed the name/place where the ping content is stored.