### PR TITLE
Bug 1331702 - Add is_wow64 to main summary

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -258,13 +258,6 @@ object MainSummaryView {
     asInt(scalars \ (prefix + engagementMetric))
   }
 
-  def getWow64(system: JValue): Option[Row] = {
-    system \ "isWow64" match {
-      case JBool(wow64) => Some(Row(wow64))
-      case _ => None
-    }
-  }
-
   def asInt(v: JValue): Integer = v match {
     case JInt(x) => x.toInt
     case _ => null
@@ -371,7 +364,10 @@ object MainSummaryView {
           case JInt(x) => x.toLong
           case _ => null
         },
-        getWow64(system).orNull,
+        system \ "isWow64" match {
+          case JBool(x) => x
+          case _ => null
+        },
         profile \ "creationDate" match {
           case JInt(x) => x.toLong
           case _ => null

--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -258,6 +258,13 @@ object MainSummaryView {
     asInt(scalars \ (prefix + engagementMetric))
   }
 
+  def getWow64(system: JValue): Option[Row] = {
+    system \ "isWow64" match {
+      case JBool(wow64) => Some(Row(wow64))
+      case _ => None
+    }
+  }
+
   def asInt(v: JValue): Integer = v match {
     case JInt(x) => x.toInt
     case _ => null
@@ -364,6 +371,7 @@ object MainSummaryView {
           case JInt(x) => x.toLong
           case _ => null
         },
+        getWow64(system).orNull,
         profile \ "creationDate" match {
           case JInt(x) => x.toLong
           case _ => null
@@ -627,6 +635,7 @@ object MainSummaryView {
 
       // Note: Windows only!
       StructField("install_year", LongType, nullable = true), // environment/system/os/installYear
+      StructField("is_wow64", BooleanType, nullable = true), // environment/system/isWow64
 
       // TODO: use proper 'date' type for date columns.
       StructField("profile_creation_date", LongType, nullable = true), // environment/profile/creationDate

--- a/src/test/scala/com/mozilla/telemetry/MainSummaryViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/MainSummaryViewTest.scala
@@ -992,4 +992,33 @@ class MainSummaryViewTest extends FlatSpec with Matchers{
     MainSummaryView.getAttribution(json3 \ "environment" \ "settings" \ "attribution") should be (
       Some(Row("sample_source", "sample_medium", "sample_campaign", "sample_content")))
   }
+
+  // bug 1331702
+  "Wow64" can "be extracted" in {
+    // Ping contains wow64
+    val json1 = parse(
+      """
+        |{
+        | "environment": {
+        |  "system": {
+        |   "isWow64": true
+        |  }
+        | }
+        |}
+      """.stripMargin)
+
+    MainSummaryView.getWow64(json1 \ "environment" \ "system") should be (Some(Row(true)))
+
+    // Ping does not contain wow64
+    val json2 = parse(
+      """
+        |{
+        | "environment": {
+        |  "system": {
+        |  }
+        | }
+        |}
+      """.stripMargin)
+    MainSummaryView.getWow64(json2 \ "environment" \ "system") should be (None)
+  }
 }

--- a/src/test/scala/com/mozilla/telemetry/MainSummaryViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/MainSummaryViewTest.scala
@@ -992,33 +992,4 @@ class MainSummaryViewTest extends FlatSpec with Matchers{
     MainSummaryView.getAttribution(json3 \ "environment" \ "settings" \ "attribution") should be (
       Some(Row("sample_source", "sample_medium", "sample_campaign", "sample_content")))
   }
-
-  // bug 1331702
-  "Wow64" can "be extracted" in {
-    // Ping contains wow64
-    val json1 = parse(
-      """
-        |{
-        | "environment": {
-        |  "system": {
-        |   "isWow64": true
-        |  }
-        | }
-        |}
-      """.stripMargin)
-
-    MainSummaryView.getWow64(json1 \ "environment" \ "system") should be (Some(Row(true)))
-
-    // Ping does not contain wow64
-    val json2 = parse(
-      """
-        |{
-        | "environment": {
-        |  "system": {
-        |  }
-        | }
-        |}
-      """.stripMargin)
-    MainSummaryView.getWow64(json2 \ "environment" \ "system") should be (None)
-  }
 }


### PR DESCRIPTION
[Bug 1331702](https://bugzilla.mozilla.org/show_bug.cgi?id=1331702)

Wow64 is used to tell the CPU architecture of Windows machines apart. This adds `is_wow64` field to main summary.