### PR TITLE
Bug 1336488 - Add profile.creationDate to CrashSummaryView

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/CrashSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/CrashSummaryView.scala
@@ -52,6 +52,10 @@ case class Settings(
     locale: String,
     telemetryEnabled: Boolean)
 
+case class Profile(
+    creationDate: Option[Int],
+    resetDate: Option[Int])
+
 case class Meta(
     Host: Option[String],
     Hostname: Option[String],
@@ -79,6 +83,7 @@ case class Meta(
     `environment.build`: Build,
     `environment.settings`: Settings,
     `environment.system`: System,
+    `environment.profile`: Profile,
     `environment.addons`: Addons)
 
 case class Payload(
@@ -115,6 +120,7 @@ case class CrashSummary (
     e10s_enabled: Option[Boolean],
     e10s_cohort: Option[String],
     gfx_compositor: Option[String],
+    profile_created: Option[Int],
     payload: Payload) {
 
   def this(ping: CrashPing) = {
@@ -142,6 +148,7 @@ case class CrashSummary (
         y <-  x.features
         z <- y.compositor
       } yield z,
+      profile_created = ping.meta.`environment.profile`.creationDate,
       payload = ping.payload
     )
   }
@@ -176,6 +183,7 @@ object CrashSummaryView {
     "environment.build",
     "environment.settings",
     "environment.system",
+    "environment.profile",
     "environment.addons"
     )
     val jsonObj = Extraction.decompose(fields)

--- a/src/test/resources/crash_ping_indented.json
+++ b/src/test/resources/crash_ping_indented.json
@@ -24,7 +24,8 @@
    "environment.system": "{\"memoryMB\":724,\"os\":{\"locale\":\"pt-BR\",\"kernelVersion\":\"2.6.36.3\",\"version\":13,\"name\":\"Linux\"},\"device\":{\"hardware\":\"p3\",\"manufacturer\":\"samsung\",\"isTablet\":true,\"model\":\"GT-P7300\"},\"cpu\":{\"count\":2,\"extensions\":[\"hasEDSP\",\"hasARMv6\",\"hasARMv7\"]},\"hdd\":{\"profile\":{},\"binary\":{},\"system\":{}},\"gfx\":{\"features\": {\"compositor\":\"opengl\"},\"adapters\":[{\"deviceID\":\"NVIDIA Tegra\",\"description\":\"Model: GT-P7300, Product: GT-P7300, Manufacturer: samsung, Hardware: p3, OpenGL: NVIDIA Corporation -- NVIDIA Tegra -- OpenGL ES 2.0\",\"GPUActive\":true,\"driverVersion\":\"OpenGL ES 2.0\",\"vendorID\":\"NVIDIA Corporation\"}]}}",
    "sampleId": 26.0,
    "Host": "incoming.telemetry.mozilla.org",
-   "docType": "crash"
+   "docType": "crash",
+   "environment.profile": "{\"creationDate\": 16446, \"resetDate\": 16446}"
   },
   "payload": {
     "creationDate": "2017-01-05T04:41:27.796Z",

--- a/src/test/scala/com/mozilla/telemetry/CrashSummaryViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/CrashSummaryViewTest.scala
@@ -103,6 +103,7 @@ class CrashSummaryViewTest extends FlatSpec with Matchers {
       assert(x.e10s_cohort == Some("test"))
       assert(x.e10s_enabled == Some(true))
       assert(x.gfx_compositor == Some("opengl"))
+      assert(x.profile_created == Some(16446))
       assert(x.payload.processType == Some("main"))
     })
   }


### PR DESCRIPTION
When during a profile's life do crashes happen? And what effect might they
have on the churn of users who might only just have started trying Firefox
for the first time?

Currently testing this on a day's data.