### PR TITLE
Sync events view

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/utils/Events.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/Events.scala
@@ -27,33 +27,46 @@ case class Event(timestamp: Long,
 
 object Event {
   def fromList(event: List[Any]): Option[Event] = {
+    // TODO: this is getting really ugly -- maybe try a per-param match?
     event match {
-      case _@List(
-      timestamp: BigInt,
-      category: String,
-      method: String,
-      obj: String,
-      strValue: String,
-      mapValues: Map[String@unchecked, Any@unchecked])
-      => Some(Event(timestamp.toLong, category, method, obj, Some(strValue), Some(mapValues.map {
-        // Bug 1339130
-        case (k: String, null) => (k, "null")
-        case (k: String, v: Any) => (k, v.toString)
-      })
+      case _ @ List(
+        timestamp: BigInt,
+        category: String,
+        method: String,
+        obj: String,
+        strValue: String,
+        mapValues: Map[String@unchecked, Any@unchecked])
+        => Some(Event(timestamp.toLong, category, method, obj, Some(strValue), Some(mapValues.map {
+          // Bug 1339130
+          case (k: String, null) => (k, "null")
+          case (k: String, v: Any) => (k, v.toString)
+        })
       ))
-      case _@List(
-      timestamp: BigInt,
-      category: String,
-      method: String,
-      obj: String,
-      strValue: String)
-      => Some(Event(timestamp.toLong, category, method, obj, Some(strValue)))
-      case _@List(
-      timestamp: BigInt,
-      category: String,
-      method: String,
-      obj: String)
-      => Some(Event(timestamp.toLong, category, method, obj))
+      case _ @ List(
+        timestamp: BigInt,
+        category: String,
+        method: String,
+        obj: String,
+        null,
+        mapValues: Map[String@unchecked, Any@unchecked])
+        => Some(Event(timestamp.toLong, category, method, obj, None, Some(mapValues.map {
+          case (k: String, null) => (k, "null")
+          case (k: String, v: Any) => (k, v.toString)
+        })
+      ))
+      case _ @ List(
+        timestamp: BigInt,
+        category: String,
+        method: String,
+        obj: String,
+        strValue: String)
+        => Some(Event(timestamp.toLong, category, method, obj, Some(strValue)))
+      case _ @ List(
+        timestamp: BigInt,
+        category: String,
+        method: String,
+        obj: String)
+        => Some(Event(timestamp.toLong, category, method, obj))
       case _ => None
     }
   }

--- a/src/main/scala/com/mozilla/telemetry/utils/Events.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/Events.scala
@@ -1,0 +1,95 @@
+package com.mozilla.telemetry.utils
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+import org.json4s.{DefaultFormats, JValue}
+
+import scala.util.{Success, Try}
+
+case class Event(timestamp: Long,
+                 category:  String,
+                 method:    String,
+                 obj:       String,
+                 strValue:  Option[String] = None,
+                 mapValues: Option[Map[String, Any]] = None) {
+
+  def toList: List[Any] = List(
+    timestamp,
+    category,
+    method,
+    obj,
+    strValue.orNull,
+    mapValues.orNull
+  )
+
+  def toRow: Row = Row.fromSeq(toList)
+}
+
+object Event {
+  def fromList(event: List[Any]): Option[Event] = {
+    event match {
+      case _@List(
+      timestamp: BigInt,
+      category: String,
+      method: String,
+      obj: String,
+      strValue: String,
+      mapValues: Map[String@unchecked, Any@unchecked])
+      => Some(Event(timestamp.toLong, category, method, obj, Some(strValue), Some(mapValues.map {
+        // Bug 1339130
+        case (k: String, null) => (k, "null")
+        case (k: String, v: Any) => (k, v.toString)
+      })
+      ))
+      case _@List(
+      timestamp: BigInt,
+      category: String,
+      method: String,
+      obj: String,
+      strValue: String)
+      => Some(Event(timestamp.toLong, category, method, obj, Some(strValue)))
+      case _@List(
+      timestamp: BigInt,
+      category: String,
+      method: String,
+      obj: String)
+      => Some(Event(timestamp.toLong, category, method, obj))
+      case _ => None
+    }
+  }
+}
+
+object Events {
+  def getEvents(events: JValue): Option[List[Row]] = {
+    extractEvents(events).flatMap(eventToRow) match {
+      case Nil => None
+      case x => Some(x)
+    }
+  }
+
+  def extractEvents(events: JValue): List[List[Any]] = {
+    implicit val formats = DefaultFormats
+    Try(events.extract[List[List[Any]]]) match {
+      case Success(eventList) => eventList
+      case _ => List(List())
+    }
+  }
+
+  def eventToRow(event: List[Any]): Option[Row] = {
+    Event.fromList(event) match {
+      case Some(e) => Some(e.toRow)
+      case _ => None
+    }
+  }
+
+
+  def buildEventSchema = StructType(List(
+    StructField("timestamp",    LongType, nullable = false),
+    StructField("category",     StringType, nullable = false),
+    StructField("method",       StringType, nullable = false),
+    StructField("object",       StringType, nullable = false),
+    StructField("string_value", StringType, nullable = true),
+    StructField("map_values",   MapType(StringType, StringType), nullable = true)
+  ))
+}
+

--- a/src/main/scala/com/mozilla/telemetry/views/MainEventsView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainEventsView.scala
@@ -1,6 +1,6 @@
 package com.mozilla.telemetry.views
 
-import com.mozilla.telemetry.utils.S3Store
+import com.mozilla.telemetry.utils.{S3Store, Events}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.{SparkConf, SparkContext}
@@ -88,7 +88,7 @@ object MainEventsView {
   }
 
   def eventsFromMain(mainSummaryData: DataFrame, sampleId: Option[String]): DataFrame = {
-    val eventsSchema = MainSummaryView.buildEventSchema
+    val eventsSchema = Events.buildEventSchema
     val partialDataFrame = mainSummaryData
       .select("document_id", "client_id", "normalized_channel", "country", "locale", "app_name", "app_version", "os",
         "os_version", "e10s_enabled", "e10s_cohort", "subsession_start_date", "subsession_length", "sync_configured",

--- a/src/main/scala/com/mozilla/telemetry/views/SyncEventView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/SyncEventView.scala
@@ -1,0 +1,233 @@
+package com.mozilla.telemetry.views
+
+import com.mozilla.telemetry.heka.{Dataset, Message}
+import com.mozilla.telemetry.utils.{Event, Events, S3Store}
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.{SparkConf, SparkContext}
+import org.joda.time.{DateTime, Days, format}
+import org.json4s.{JValue, string2JsonInput}
+import org.json4s.JsonAST._
+import org.json4s.jackson.JsonMethods.parse
+import org.rogach.scallop._
+
+object SyncEventView {
+  def schemaVersion: String = "v1"
+  def jobName: String = "sync_events"
+
+  // Configuration for command line arguments
+  private class Conf(args: Array[String]) extends ScallopConf(args) {
+    val from = opt[String]("from", descr = "From submission date", required = false)
+    val to = opt[String]("to", descr = "To submission date", required = false)
+    val outputBucket = opt[String]("bucket", descr = "Destination bucket for parquet data", required = false)
+    val outputFilename = opt[String]("outputFilename", descr = "Destination local filename for parquet data", required = false)
+    val limit = opt[Int]("limit", descr = "Maximum number of files to read from S3", required = false)
+    verify()
+  }
+
+  def main(args: Array[String]) {
+    val conf = new Conf(args) // parse command line arguments
+    if (!conf.outputBucket.supplied && !conf.outputFilename.supplied)
+      conf.errorMessageHandler("One of outputBucket or outputFilename must be specified")
+    val fmt = format.DateTimeFormat.forPattern("yyyyMMdd")
+    val to = conf.to.get match {
+      case Some(t) => fmt.parseDateTime(t)
+      case _ => DateTime.now.minusDays(1)
+    }
+    val from = conf.from.get match {
+      case Some(f) => fmt.parseDateTime(f)
+      case _ => DateTime.now.minusDays(1)
+    }
+
+    // Set up Spark
+    val sparkConf = new SparkConf().setAppName(jobName)
+    sparkConf.setMaster(sparkConf.get("spark.master", "local[*]"))
+    implicit val sc = new SparkContext(sparkConf)
+    val spark = SparkSession
+      .builder()
+      .appName("SyncEventView")
+      .getOrCreate()
+    val hadoopConf = sc.hadoopConfiguration
+
+    // We want to end up with reasonably large parquet files on S3.
+    val parquetSize = 512 * 1024 * 1024
+
+    hadoopConf.setInt("dfs.blocksize", parquetSize)
+    hadoopConf.set("parquet.enable.summary-metadata", "false")
+
+    for (offset <- 0 to Days.daysBetween(from, to).getDays) {
+      val currentDate = from.plusDays(offset)
+      val currentDateString = currentDate.toString("yyyyMMdd")
+
+      println("=======================================================================================")
+      println(s"BEGINNING JOB $jobName FOR $currentDateString")
+
+      val ignoredCount = sc.longAccumulator("Number of Records Ignored")
+      val processedCount = sc.longAccumulator("Number of Records Processed")
+
+      val messages = Dataset("telemetry")
+        .where("sourceName") {
+          case "telemetry" => true
+        }.where("sourceVersion") {
+          case "4" => true
+        }.where("docType") {
+          case "sync" => true
+        }.where("appName") {
+          case "Firefox" => true
+        }.where("submissionDate") {
+          case date if date == currentDate.toString("yyyyMMdd") => true
+        }.records(conf.limit.get)
+
+      val rowRDD = messages.flatMap(m => {
+        messageToRow(m) match {
+          case Nil =>
+            ignoredCount.add(1)
+            None
+          case x =>
+            processedCount.add(1)
+            x
+        }
+      })
+      val records = spark.createDataFrame(rowRDD, SyncEventConverter.syncEventSchema)
+
+      if (conf.outputBucket.supplied) {
+        // Note we cannot just use 'partitionBy' below to automatically populate
+        // the submission_date partition, because none of the write modes do
+        // quite what we want:
+        //  - "overwrite" causes the entire vX partition to be deleted and replaced with
+        //    the current day's data, so doesn't work with incremental jobs
+        //  - "append" would allow us to generate duplicate data for the same day, so
+        //    we would need to add some manual checks before running
+        //  - "error" (the default) causes the job to fail after any data is
+        //    loaded, so we can't do single day incremental updates.
+        //  - "ignore" causes new data not to be saved.
+        // So we manually add the "submission_date_s3" parameter to the s3path.
+        val s3prefix = s"$jobName/$schemaVersion/submission_date_s3=$currentDateString"
+        val s3path = s"s3://${conf.outputBucket()}/$s3prefix"
+
+        records.repartition(1).write.mode("overwrite").parquet(s3path)
+
+        // Then remove the _SUCCESS file so we don't break Spark partition discovery.
+        S3Store.deleteKey(conf.outputBucket(), s"$s3prefix/_SUCCESS")
+        println(s"Wrote data to s3 path $s3path")
+      } else {
+        // Write the data to a local file.
+        records.write.parquet(conf.outputFilename())
+        println(s"Wrote data to local file ${conf.outputFilename()}")
+      }
+
+      println(s"JOB $jobName COMPLETED SUCCESSFULLY FOR $currentDateString")
+      println(s"     RECORDS SEEN:    ${ignoredCount.value + processedCount.value}")
+      println(s"     RECORDS IGNORED: ${ignoredCount.value}")
+      println("=======================================================================================")
+    }
+
+    sc.stop()
+  }
+
+  // Convert the given Heka message containing a "sync" ping with event data
+  // to a list of rows containing relevant fields
+  def messageToRow(message: Message): List[Row] = {
+    val payload = parse(string2JsonInput(message.payload.getOrElse(message.fieldsAsMap.getOrElse("submission", "{}")).asInstanceOf[String]))
+    SyncEventConverter.pingToRows(payload)
+  }
+}
+
+// Convert Sync Events, which are defined by the schema at:
+// https://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/data/sync-ping.html#events-in-the-sync-ping
+object SyncEventConverter {
+  def eventFields: Array[StructField] = Events.buildEventSchema.fields.map(
+    f => f.copy(name = "event_" + f.name) // prepends `event_` to event schema column names for clarity
+  )
+
+  def syncEventSchema: StructType = StructType(List(
+    // These field names are the same as used by MainSummaryView
+    StructField("document_id", StringType, nullable = false), // id
+    StructField("app_build_id", StringType, nullable = true), // application/buildId
+    StructField("app_display_version", StringType, nullable = true), // application/displayVersion
+    StructField("app_name", StringType, nullable = true), // application/name
+    StructField("app_version", StringType, nullable = true), // application/version
+    StructField("app_channel", StringType, nullable = true), // application/channel
+
+    // These fields are unique to the sync pings.
+    StructField("uid", StringType, nullable = false), // payload/uid
+    StructField("why", StringType, nullable = true),  // payload/why
+    StructField("device_id", StringType, nullable = true) // payload/deviceID
+  ) ++ eventFields
+    ++ List(
+      StructField("event_device_id", StringType, nullable = true), // present in most events
+      StructField("event_flow_id", StringType, nullable = true) // present in most events
+    )
+  )
+
+  def pingToRows(ping: JValue): List[Row] = {
+    Events.extractEvents(ping \ "payload" \ "events") match {
+      case Nil => List()
+      case events => eventsToRows(ping, events)
+    }
+  }
+
+  private def eventsToRows(ping: JValue, events: List[List[Any]]): List[Row] = {
+    events.flatMap(event => eventToRow(ping, event))
+  }
+
+  private def eventToRow(ping: JValue, event: List[Any]): Option[Row] = {
+    val application = ping \ "application"
+    val payload = ping \ "payload"
+
+    val common = List(
+      ping \ "id" match {
+        case null => return None // a required field.
+        case JString(x) => x
+      },
+      application \ "buildId" match {
+        case JString(x) => x
+        case _ => return None // a required field.
+      },
+      application \ "displayVersion" match {
+        case JString(x) => x
+        case _ => return None // a required field.
+      },
+      application \ "name" match {
+        case JString(x) => x
+        case _ => return None // a required field.
+      },
+      application \ "version" match {
+        case JString(x) => x
+        case _ => return None // a required field.
+      },
+      application \ "channel" match {
+        case JString(x) => x
+        case _ => return None // a required field.
+      },
+
+      // Info about the sync.
+      payload \ "uid" match {
+        case null => return None // a required field.
+        case JString(x) => x
+      },
+      payload \ "why" match {
+        case JString(x) => x
+        case _ => null
+      },
+      payload \ "deviceID" match {
+        case JString(x) => x
+        case _ => null
+      }
+    )
+    val eventObject = Event.fromList(event) match {
+      case None => return None
+      case Some(x) => x
+    }
+
+    val values = eventObject.mapValues match {
+      case Some(x: Map[String, String]) => List(
+        x getOrElse ("deviceID", null),
+        x getOrElse ("flowID", null)
+      )
+      case _ => List(null, null)
+    }
+
+    Some(Row.fromSeq(common ++ eventObject.toList ++ values))
+  }
+}

--- a/src/test/scala/com/mozilla/telemetry/EventsTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/EventsTest.scala
@@ -1,0 +1,72 @@
+package com.mozilla.telemetry
+
+import com.mozilla.telemetry.utils.Events
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.{SparkConf, SparkContext}
+import org.json4s.jackson.JsonMethods.parse
+import org.scalatest.{FlatSpec, Matchers}
+
+class EventsTest extends FlatSpec with Matchers{
+  "Events" can "be extracted" in {
+    val events = parse(
+      """[
+           [533352, "navigation", "search", "urlbar", "enter", {"engine": "other-StartPage - English"}],
+           [533352, "navigation", "search", "urlbar", "enter", {"engine": "other-StartPage - English"}, "random extra"],
+           [85959, "navigation", "search", "urlbar", "enter"],
+           [81994404, "navigation", "search", "searchbar"],
+           ["malformed"]
+         ]""")
+
+    val eventRows = Events.getEvents(events)
+
+    eventRows should be (
+      Some(List(
+        Row(533352, "navigation", "search", "urlbar", "enter", Map("engine" -> "other-StartPage - English")),
+        Row(85959, "navigation", "search", "urlbar", "enter", null),
+        Row(81994404, "navigation", "search", "searchbar", null, null)
+      )
+      ))
+    Events.getEvents(parse("{}") \ "events") should be (None)
+    Events.getEvents(parse("""[]""")) should be (None)
+
+    val eventMapTypeTest = parse(
+      """[
+           [533352, "navigation", "search", "urlbar", "enter", {
+             "string": "hello world",
+             "int": 0,
+             "float": 1.0,
+             "null": null,
+             "boolean": true}
+           ]
+         ]""")
+
+    val eventMapTypeTestRows = Events.getEvents(eventMapTypeTest)
+
+    eventMapTypeTestRows should be (
+      Some(List(
+        Row(533352, "navigation", "search", "urlbar", "enter", Map(
+          "string" -> "hello world",
+          "int" -> "0",
+          "float" -> "1.0",
+          "null" -> "null",
+          "boolean" -> "true"
+        ))
+      ))
+    )
+
+    // Apply events schema to event rows
+    val schema = Events.buildEventSchema
+    val sparkConf = new SparkConf().setAppName("MainSummary")
+    sparkConf.setMaster(sparkConf.get("spark.master", "local[1]"))
+    val sc = new SparkContext(sparkConf)
+    val spark = SparkSession
+      .builder()
+      .appName("MainSummary")
+      .getOrCreate()
+    try {
+      noException should be thrownBy spark.createDataFrame(sc.parallelize(eventRows.get), schema).count()
+    } finally {
+      sc.stop
+    }
+  }
+}

--- a/src/test/scala/com/mozilla/telemetry/EventsTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/EventsTest.scala
@@ -14,6 +14,7 @@ class EventsTest extends FlatSpec with Matchers{
            [533352, "navigation", "search", "urlbar", "enter", {"engine": "other-StartPage - English"}, "random extra"],
            [85959, "navigation", "search", "urlbar", "enter"],
            [81994404, "navigation", "search", "searchbar"],
+           [1234, "navigation", "search", "urlbar", null, {"engine": "other-StartPage - English"}],
            ["malformed"]
          ]""")
 
@@ -23,7 +24,8 @@ class EventsTest extends FlatSpec with Matchers{
       Some(List(
         Row(533352, "navigation", "search", "urlbar", "enter", Map("engine" -> "other-StartPage - English")),
         Row(85959, "navigation", "search", "urlbar", "enter", null),
-        Row(81994404, "navigation", "search", "searchbar", null, null)
+        Row(81994404, "navigation", "search", "searchbar", null, null),
+        Row(1234, "navigation", "search", "urlbar", null, Map("engine" -> "other-StartPage - English"))
       )
       ))
     Events.getEvents(parse("{}") \ "events") should be (None)

--- a/src/test/scala/com/mozilla/telemetry/SyncEventViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/SyncEventViewTest.scala
@@ -1,0 +1,181 @@
+package com.mozilla.telemetry
+
+import com.mozilla.telemetry.views.SyncEventConverter
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.{SparkConf, SparkContext}
+import org.json4s.jackson.JsonMethods.parse
+import org.json4s.DefaultFormats
+import org.scalatest.{FlatSpec, Matchers}
+
+class SyncEventViewTest extends FlatSpec with Matchers{
+  def sync_payload = parse(
+    """
+      |{
+      |  "type": "sync",
+      |  "id": "a1d969b7-0084-4a78-a841-2abaf887f1b4",
+      |  "creationDate": "2016-09-08T18:19:09.808Z",
+      |  "version": 4,
+      |  "application": {
+      |    "architecture": "x86-64",
+      |    "buildId": "20160907030427",
+      |    "name": "Firefox",
+      |    "version": "51.0a1",
+      |    "displayVersion": "51.0a1",
+      |    "vendor": "Mozilla",
+      |    "platformVersion": "51.0a1",
+      |    "xpcomAbi": "x86_64-msvc",
+      |    "channel": "nightly"
+      |  },
+      |  "payload": {
+      |    "why": "schedule",
+      |    "version": 1,
+      |    "uid": "12345678912345678912345678912345",
+      |    "deviceID": "2222222222222222222222222222222222222222222222222222222222222222",
+      |    "syncs": [
+      |      {
+      |        "when": 1473313854446,
+      |        "took": 2277,
+      |        "engines": [
+      |          {
+      |            "name": "clients",
+      |            "outgoing": [
+      |              {
+      |                "sent": 1
+      |              }
+      |            ],
+      |            "took": 468
+      |          },
+      |          {
+      |            "name": "passwords",
+      |            "took": 16
+      |          },
+      |          {
+      |            "name": "tabs",
+      |            "incoming": {
+      |              "applied": 2,
+      |              "reconciled": 1
+      |            },
+      |            "outgoing": [
+      |              {
+      |                "sent": 1
+      |              }
+      |            ],
+      |            "took": 795
+      |          },
+      |          {
+      |            "name": "bookmarks"
+      |          },
+      |          {
+      |            "name": "forms",
+      |            "outgoing": [
+      |              {
+      |                "sent": 2
+      |              }
+      |            ],
+      |            "took": 266
+      |          },
+      |          {
+      |            "name": "history",
+      |            "incoming": {
+      |              "applied": 2
+      |            },
+      |            "outgoing": [
+      |              {
+      |                "sent": 2
+      |              }
+      |            ],
+      |            "took": 514
+      |          }
+      |        ]
+      |      },
+      |      {
+      |        "when": 1473313890947,
+      |        "took": 484,
+      |        "engines": [
+      |          {
+      |            "name": "clients",
+      |            "took": 249
+      |          },
+      |          {
+      |            "name": "passwords"
+      |          },
+      |          {
+      |            "name": "tabs",
+      |            "took": 16
+      |          },
+      |          {
+      |            "name": "bookmarks"
+      |          },
+      |          {
+      |            "name": "forms"
+      |          },
+      |          {
+      |            "name": "history"
+      |          }
+      |        ]
+      |      }
+      |    ],
+      |    "events": [
+      |      [1234, "sync", "displayURI", "sendcommand", null,
+      |        {
+      |          "deviceID": "3333333333333333333333333333333333333333333333333333333333333333",
+      |          "flowID": "aaaaaaaaaaaaa"
+      |        }
+      |      ],
+      |      [2345, "sync", "displayURI", "processcommand", null,
+      |       {
+      |          "deviceID": "4444444444444444444444444444444444444444444444444444444444444444",
+      |          "flowID": "bbbbbbbbbbbbbb"
+      |        }
+      |      ]
+      |    ]
+      |  }
+      |}
+    """.stripMargin)
+
+  "Sync Events" can "be serialized" in {
+    val sparkConf = new SparkConf().setAppName("SyncEventViewTest")
+    sparkConf.setMaster(sparkConf.get("spark.master", "local[1]"))
+    val sc = new SparkContext(sparkConf)
+    implicit val formats = DefaultFormats
+    sc.setLogLevel("WARN")
+    try {
+      val row = SyncEventConverter.pingToRows(sync_payload)
+      val spark = SparkSession
+        .builder()
+        .appName("SyncEventsViewTest")
+        .getOrCreate()
+      val rdd = sc.parallelize(row)
+
+      val dataframe = spark.createDataFrame(rdd, SyncEventConverter.syncEventSchema)
+
+      // verify the contents.
+      dataframe.count() should be (2)
+      val checkRow = dataframe.first()
+
+      checkRow.getAs[String]("document_id") should be ((sync_payload \ "id").extract[String])
+      checkRow.getAs[String]("app_build_id") should be ((sync_payload \ "application" \ "buildId").extract[String])
+      checkRow.getAs[String]("app_display_version") should be ((sync_payload \ "application" \ "displayVersion").extract[String])
+      checkRow.getAs[String]("app_name") should be ((sync_payload \ "application" \ "name").extract[String])
+      checkRow.getAs[String]("app_version") should be ((sync_payload \ "application" \ "version").extract[String])
+      checkRow.getAs[String]("app_channel") should be ((sync_payload \ "application" \ "channel").extract[String])
+
+      val payload = sync_payload \ "payload"
+      checkRow.getAs[String]("why") should be ((payload \ "why").extract[String])
+      checkRow.getAs[String]("uid") should be ((payload \ "uid").extract[String])
+      checkRow.getAs[String]("device_id") should be ((payload \ "deviceID").extract[String])
+
+      val event = (payload \ "events")(0)
+      checkRow.getAs[Long]("event_timestamp") should be (event(0).extract[Long])
+      checkRow.getAs[String]("event_category") should be (event(1).extract[String])
+      checkRow.getAs[String]("event_method") should be (event(2).extract[String])
+      checkRow.getAs[String]("event_object") should be (event(3).extract[String])
+      checkRow.getAs[String]("event_string_value") should be (null)
+      checkRow.getAs[Map[String, String]]("event_map_values") should be (event(5).extract[Map[String, String]])
+      checkRow.getAs[String]("event_device_id") should be ((event(5) \ "deviceID").extract[String])
+      checkRow.getAs[String]("event_flow_id") should be ((event(5) \ "flowID").extract[String])
+    } finally {
+      sc.stop()
+    }
+  }
+}


### PR DESCRIPTION
- Moves Events out of MainSummaryView into a utility class
- Adds a job to output Sync Events into a flattened view

No timestamp column yet since I feel like it'd be confusing if we don't use the session start date, which we'll add once it's added to the sync ping.