### PR TITLE
Bug 13490813 - Create Prerelease Longitudinal

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/scalars/Scalars.scala
+++ b/src/main/scala/com/mozilla/telemetry/scalars/Scalars.scala
@@ -16,8 +16,7 @@ class ScalarsClass {
   protected val getURL: (String, String) => scala.io.BufferedSource = Source.fromURL
 
   def definitions(includeOptin: Boolean = false): Map[String, ScalarDefinition] = {
-    // TODO: Scalars are not on release yet! Uncomment the line below once they hit Release.
-    val uris = Map(// "https://hg.mozilla.org/releases/mozilla-release/raw-file/tip/toolkit/components/telemetry/Scalars.yaml",
+    val uris = Map("release" -> "https://hg.mozilla.org/releases/mozilla-release/raw-file/tip/toolkit/components/telemetry/Scalars.yaml",
                    "beta" -> "https://hg.mozilla.org/releases/mozilla-beta/raw-file/tip/toolkit/components/telemetry/Scalars.yaml",
                    "aurora" -> "https://hg.mozilla.org/releases/mozilla-aurora/raw-file/tip/toolkit/components/telemetry/Scalars.yaml",
                    "nightly" -> "https://hg.mozilla.org/mozilla-central/raw-file/tip/toolkit/components/telemetry/Scalars.yaml")

--- a/src/main/scala/com/mozilla/telemetry/views/Longitudinal.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/Longitudinal.scala
@@ -104,9 +104,13 @@ object LongitudinalView {
   }
 
   private class Opts(args: Array[String]) extends ScallopConf(args) {
-    val from = opt[String]("from", descr = "From submission date", required = false)
+    val from = opt[String]("from", descr = "From submission date. Defaults to 6 months before `to`.", required = false)
     val to = opt[String]("to", descr = "To submission date", required = true)
     val outputBucket = opt[String]("bucket", descr = "bucket", required = true)
+    val includeOptin = opt[String]("optin-only", descr = "Boolean, whether to include opt-in data only. Defaults to false.", required = false)
+    val channels = opt[String]("channels", descr = "Comma separated string, which channels to include. Defaults to the four main channels.", required = false)
+    val samples = opt[String]("samples", descr = "Comma separated string, which samples to include. Defaults to 42.", required = false)
+    val telemetrySource = opt[String]("source", descr = "Source for Dataset.from_source. Defaults to telemetry-sample.", required = false)
     verify()
   }
 
@@ -120,22 +124,39 @@ object LongitudinalView {
       case _ => fmt.print(fmt.parseDateTime(to).minusMonths(6))
     }
 
+    val channels = opts.channels.get match {
+        case Some(c) => c.split(",")
+        case _ => Array("nightly", "aurora", "beta", "release")
+    }
+
+    val samples = opts.samples.get match {
+        case Some(s) => s.split(",")
+        case _ => Array("42")
+    }
+
+    val telemetrySource = opts.telemetrySource.get match {
+        case Some(ts) => ts
+        case _ => "telemetry-sample"
+    }
+
     val sparkConf = new SparkConf().setAppName("Longitudinal")
     sparkConf.setMaster(sparkConf.get("spark.master", "local[*]"))
     implicit val sc = new SparkContext(sparkConf)
 
-    val messages = Dataset("telemetry-sample")
+    val messages = Dataset(telemetrySource)
       .where("sourceName") {
         case "telemetry" => true
       }.where("sourceVersion") {
-      case "4" => true
-    }.where("docType") {
-      case "main" => true
-    }.where("submissionDate") {
-      case date if date <= to && date >= from => true
-    }.where("sampleId") {
-      case "42" => true
-    }
+        case "4" => true
+      }.where("docType") {
+        case "main" => true
+      }.where("submissionDate") {
+        case date if date <= to && date >= from => true
+      }.where("sampleId") {
+        case sample if samples.contains(sample) => true
+      }.where("appUpdateChannel") {
+        case channel if channels.contains(channel) => true
+      }
 
     run(opts: Opts, messages)
     sc.stop()
@@ -146,6 +167,11 @@ object LongitudinalView {
     val prefix = s"${clsName}/v${opts.to()}"
     val outputBucket = opts.outputBucket()
     val lockfileName = "RUNNING"
+
+    val includeOptin = opts.includeOptin.get match {
+        case Some(v) => v.toBoolean // fail loudly on invalid string
+        case _ => false
+    }
 
     require(S3Store.isPrefixEmpty(outputBucket, prefix), s"s3://${outputBucket}/${prefix} already exists!")
 
@@ -182,14 +208,17 @@ object LongitudinalView {
        to keep all workers busy. Since the cluster typically used for this job has
        8 workers and 20 executors, 320 partitions provide a good compromise. */
 
+    val histogramDefinitions = Histograms.definitions(includeOptin)
+    val scalarDefinitions = Scalars.definitions(includeOptin)
+
     val partitionCounts = clientMessages
       .mapPartitions{ case it =>
         val clientIterator = new ClientIterator(it)
-        val schema = buildSchema
+        val schema = buildSchema(histogramDefinitions, scalarDefinitions)
 
         val allRecords = for {
           client <- clientIterator
-          record = buildRecord(client, schema)
+          record = buildRecord(client, schema, histogramDefinitions, scalarDefinitions)
         } yield record
 
         var ignoredCount = 0
@@ -222,7 +251,7 @@ object LongitudinalView {
     S3Store.deleteKey(outputBucket,  s"${prefix}/${lockfileName}")
   }
 
-  private def buildSchema: Schema = {
+  private def buildSchema(histogramDefinitions: Map[String, HistogramDefinition], scalarDefinitions: Map[String, ScalarDefinition]): Schema = {
     // The $PROJECT_ROOT/scripts/generate-ping-schema.py script can be used to
     // generate these SchemaBuilder definitions, and the output of that script is
     // combined with data from http://gecko.readthedocs.org/en/latest/toolkit/components/telemetry/telemetry
@@ -501,7 +530,7 @@ object LongitudinalView {
         .name("thread_hang_stacks").`type`().optional().array().items().map().values().map().values(histogramType)
         .name("simple_measurements").`type`().optional().array().items(simpleMeasurementsType)
 
-    Histograms.definitions.foreach{ case (k, value) =>
+    histogramDefinitions.foreach{ case (k, value) =>
       val key = k.toLowerCase
       value match {
         case h: FlagHistogram if !h.keyed =>
@@ -533,8 +562,8 @@ object LongitudinalView {
       }
     }
 
-    Scalars.definitions.foreach{ case (k, value) =>
-      val key = getParquetFriendlyScalarName(k.toLowerCase, "parent")
+    scalarDefinitions.foreach{ case (k, value) =>
+      val key = getParquetFriendlyScalarName(k.toLowerCase)
       value match {
         case s: UintScalar if !s.keyed =>
           // TODO: After migrating to Spark 2.1.0, change this and the next
@@ -684,21 +713,25 @@ object LongitudinalView {
     root.set(avroField, fieldValues.asJava)
   }
 
+  def getStandardHistogramSchema(schema: Schema): Schema = {
+    getElemType(schema, "fx_tab_switch_total_ms")
+  }
+
   def getElemType(schema: Schema, field: String): Schema = {
     schema.getField(field).schema.getTypes.get(1).getElementType
   }
 
-  private def keyedHistograms2Avro(payloads: List[Map[String, Any]], root: GenericRecordBuilder, schema: Schema) {
+  private def keyedHistograms2Avro(payloads: List[Map[String, Any]], root: GenericRecordBuilder, schema: Schema, histogramDefinitions: Map[String, HistogramDefinition]) {
     val histogramsList = payloads.map(Histograms.stripKeyedHistograms)
 
     val uniqueKeys = histogramsList.flatMap(x => x.keys).distinct.toSet
 
     val validKeys = for {
       key <- uniqueKeys
-      definition <- Histograms.definitions.get(key)
+      definition <- histogramDefinitions.get(key)
     } yield (key, definition)
 
-    val histogramSchema = getElemType(schema, "fx_tab_switch_total_ms")
+    val histogramSchema = getStandardHistogramSchema(schema)
 
     for ((key, definition) <- validKeys) {
       val keyedHistogramsList = histogramsList.map{x =>
@@ -718,17 +751,17 @@ object LongitudinalView {
     }
   }
 
-  private def histograms2Avro(payloads: List[Map[String, Any]], root: GenericRecordBuilder, schema: Schema) {
+  private def histograms2Avro(payloads: List[Map[String, Any]], root: GenericRecordBuilder, schema: Schema, histogramDefinitions: Map[String, HistogramDefinition]) {
     val histogramsList = payloads.map(Histograms.stripHistograms)
-        
+
     val uniqueKeys = histogramsList.flatMap(x => x.keys).distinct.toSet
 
     val validKeys = for {
       key <- uniqueKeys
-      definition <- Histograms.definitions.get(key)
+      definition <- histogramDefinitions.get(key)
     } yield (key, definition)
 
-    val histogramSchema = getElemType(schema, "fx_tab_switch_total_ms")
+    val histogramSchema = getStandardHistogramSchema(schema)
 
     for ((key, definition) <- validKeys) {
       root.set(key.toLowerCase, vectorizeHistogram(key, definition, histogramsList, histogramSchema))
@@ -787,7 +820,7 @@ object LongitudinalView {
     }
   }
 
-  private def getParquetFriendlyScalarName(scalarName: String, processName: String): String = {
+  private def getParquetFriendlyScalarName(scalarName: String, processName: String = "parent"): String = {
     // Scalar group and probe names can contain dots ('.'). But we don't
     // want them to get into the Parquet column names, so replace them with
     // underscores ('_'). Additionally, to prevent name clashing, we prefix
@@ -795,7 +828,7 @@ object LongitudinalView {
     ScalarColumnNamePrefix + (processName + '_' + scalarName).replace('.', '_')
   }
 
-  private def scalars2Avro(payloads: List[Map[String, Any]], root: GenericRecordBuilder) {
+  private def scalars2Avro(payloads: List[Map[String, Any]], root: GenericRecordBuilder, scalarDefinitions: Map[String, ScalarDefinition]) {
     implicit val formats = DefaultFormats
 
     // Get a list of the scalars in the ping.
@@ -819,16 +852,16 @@ object LongitudinalView {
     // ... and that the keys (scalar names) are valid.
     val validKeys = for {
       key <- uniqueKeys
-      definition <- Scalars.definitions.get(key)
+      definition <- scalarDefinitions.get(key)
     } yield (key, definition)
 
     for ((key, definition) <- validKeys) {
-      val prefixedKeyName = getParquetFriendlyScalarName(key.toLowerCase, "parent")
+      val prefixedKeyName = getParquetFriendlyScalarName(key.toLowerCase)
       root.set(prefixedKeyName, vectorizeScalar(key, definition, scalarList))
     }
   }
 
-  private def keyedScalars2Avro(payloads: List[Map[String, Any]], root: GenericRecordBuilder) {
+  private def keyedScalars2Avro(payloads: List[Map[String, Any]], root: GenericRecordBuilder, scalarDefinitions: Map[String, ScalarDefinition]) {
     implicit val formats = DefaultFormats
 
     val scalarsList = payloads.map{ case (x) =>
@@ -843,7 +876,7 @@ object LongitudinalView {
 
     val validKeys = for {
       key <- uniqueKeys
-      definition <- Scalars.definitions.get(key)
+      definition <- scalarDefinitions.get(key)
     } yield (key, definition)
 
     for ((key, definition) <- validKeys) {
@@ -860,7 +893,7 @@ object LongitudinalView {
         vector = vectorizeScalar(label, definition, keyedScalarsList)
       } yield (label, vector)
 
-      val prefixedKeyName = getParquetFriendlyScalarName(key.toLowerCase, "parent")
+      val prefixedKeyName = getParquetFriendlyScalarName(key.toLowerCase)
       root.set(prefixedKeyName, vectorized.toMap.asJava)
     }
   }
@@ -918,7 +951,7 @@ object LongitudinalView {
     }
   }
 
-  private def buildRecord(history: Iterable[Map[String, Any]], schema: Schema): Option[GenericRecord] = {
+  private def buildRecord(history: Iterable[Map[String, Any]], schema: Schema, histogramDefinitions: Map[String, HistogramDefinition], scalarDefinitions: Map[String, ScalarDefinition]): Option[GenericRecord] = {
     // De-dupe records
     val sorted = history.foldLeft((List[Map[String, Any]](), Set[String]()))(
       { case ((submissions, seen), current) =>
@@ -974,10 +1007,10 @@ object LongitudinalView {
       JSON2Avro("payload.info",               List("subsessionId"),             "subsession_id", sorted, root, schema)
       JSON2Avro("payload.info",               List("subsessionLength"),         "subsession_length", sorted, root, schema)
       JSON2Avro("payload.info",               List("timezoneOffset"),           "timezone_offset", sorted, root, schema)
-      histograms2Avro(sorted, root, schema)
-      keyedHistograms2Avro(sorted, root, schema)
-      scalars2Avro(sorted, root)
-      keyedScalars2Avro(sorted, root)
+      histograms2Avro(sorted, root, schema, histogramDefinitions)
+      keyedHistograms2Avro(sorted, root, schema, histogramDefinitions)
+      scalars2Avro(sorted, root, scalarDefinitions)
+      keyedScalars2Avro(sorted, root, scalarDefinitions)
       subsessionStartDate2Avro(sorted, root, schema)
       profileDates2Avro(sorted, root, schema)
     } catch {

--- a/src/test/resources/Histograms.json
+++ b/src/test/resources/Histograms.json
@@ -1,0 +1,11055 @@
+
+{
+  "A11Y_INSTANTIATED_FLAG": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "has accessibility support been instantiated"
+  },
+  "A11Y_CONSUMERS": {
+    "expires_in_version": "default",
+    "kind": "enumerated",
+    "n_values": 11,
+    "description": "Accessibility client by enum id"
+  },
+  "A11Y_ISIMPLEDOM_USAGE_FLAG": {
+    "expires_in_version": "default",
+    "kind": "flag",
+    "description": "have the ISimpleDOM* accessibility interfaces been used"
+  },
+  "A11Y_IATABLE_USAGE_FLAG": {
+    "expires_in_version": "default",
+    "kind": "flag",
+    "description": "has the IAccessibleTable accessibility interface been used"
+  },
+  "A11Y_UPDATE_TIME": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "time spent updating accessibility (ms)"
+  },
+  "ADDON_CONTENT_POLICY_SHIM_BLOCKING_LOADING_MS": {
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 20,
+    "keyed": true,
+    "description": "The amount of time the content process blocked processing shouldLoad shims for an add-on (keyed by add-on ID) prior to the load event, for each document load.",
+    "bug_numbers": [1331684],
+    "alert_emails": ["kmaglione@mozilla.com"]
+  },
+  "ADDON_CONTENT_POLICY_SHIM_BLOCKING_LOADED_MS": {
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 20,
+    "keyed": true,
+    "description": "The amount of time the content process blocked processing shouldLoad shims for an add-on (keyed by add-on ID) after the load event, for each document load.",
+    "bug_numbers": [1331684],
+    "alert_emails": ["kmaglione@mozilla.com"]
+  },
+  "ADDON_MANAGER_UPGRADE_UI_SHOWN": {
+    "expires_in_version": "53",
+    "kind": "count",
+    "description": "Recorded when the addon manager shows the modal upgrade UI. Should only be recorded once per upgrade.",
+    "releaseChannelCollection": "opt-out",
+    "bug_numbers": [1268548],
+    "alert_emails": ["kev@mozilla.com"]
+  },
+  "ADDON_SHIM_USAGE": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 15,
+    "keyed": true,
+    "description": "Reasons why add-on shims were used, keyed by add-on ID."
+  },
+  "ADDON_FORBIDDEN_CPOW_USAGE": {
+    "expires_in_version": "never",
+    "kind": "count",
+    "keyed": true,
+    "description": "Counts the number of times a given add-on used CPOWs when it was marked as e10s compatible.",
+    "bug_numbers": [1214824],
+    "alert_emails": ["wmccloskey@mozilla.com"]
+  },
+  "BROWSER_SHIM_USAGE_BLOCKED": {
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Counts the number of times a CPOW shim was blocked from being created by browser code.",
+    "releaseChannelCollection": "opt-out",
+    "bug_numbers": [1245901],
+    "alert_emails": ["benjamin@smedbergs.us"]
+  },
+  "APPLICATION_REPUTATION_SHOULD_BLOCK": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Overall (local or remote) application reputation verdict (shouldBlock=false is OK)."
+  },
+  "APPLICATION_REPUTATION_LOCAL": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 3,
+    "description": "Application reputation local results (0=ALLOW, 1=BLOCK, 2=NONE)"
+  },
+  "APPLICATION_REPUTATION_SERVER": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 3,
+    "description": "Status of the application reputation remote lookup (0=OK, 1=failed, 2=invalid protobuf response)"
+  },
+  "APPLICATION_REPUTATION_SERVER_VERDICT": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "56",
+    "releaseChannelCollection": "opt-out",
+    "bug_numbers": [1272788],
+    "kind": "enumerated",
+    "n_values": 8,
+    "description": "Application reputation remote verdict (0=SAFE, 1=DANGEROUS, 2=UNCOMMON, 3=POTENTIALLY_UNWANTED, 4=DANGEROUS_HOST, 5=UNKNOWN)"
+  },
+  "APPLICATION_REPUTATION_COUNT": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Application reputation query count (both local and remote)"
+  },
+  "APPLICATION_REPUTATION_REMOTE_LOOKUP_TIMEOUT": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "56",
+    "kind": "boolean",
+    "bug_numbers": [1172689],
+    "description": "Recorded when application reputation remote lookup is performed, `true` is recorded if the lookup times out."
+  },
+  "APPLICATION_REPUTATION_BLOCKLIST_MATCH": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "60",
+    "kind": "enumerated",
+    "n_values": 4,
+    "bug_numbers": [1331139],
+    "description": "For each Application Reputation lookup against both the V2 and V4 Google lists, note which version of block list returned a match (0 = no match, 1 = match only V2, 2 = match only V4, 3 = match both V2 and V4)"
+  },
+  "APPLICATION_REPUTATION_ALLOWLIST_MATCH": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "60",
+    "kind": "enumerated",
+    "n_values": 4,
+    "bug_numbers": [1331139],
+    "description": "For each Application Reputation lookup against both the V2 and V4 Google lists, note which version of the allow list returned a match (0 = no match, 1 = match only V2, 2 = match only V4, 3 = match both V2 and V4)"
+  },
+  "AUDIOSTREAM_FIRST_OPEN_MS": {
+    "expires_in_version": "50",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "The length of time (in milliseconds) for the first open of AudioStream."
+  },
+  "AUDIOSTREAM_LATER_OPEN_MS": {
+    "expires_in_version": "50",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "The length of time (in milliseconds) for the subsequent opens of AudioStream."
+  },
+  "AUDIOSTREAM_BACKEND_USED": {
+    "alert_emails": ["padenot@mozilla.com", "kinetik@flim.org"],
+    "bug_numbers": [1280630],
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 16,
+    "description": "The operating system audio back-end used when successfully opening an audio stream, or whether the failure occurred on the first try or not <https://dxr.mozilla.org/mozilla-central/search?q=AUDIOSTREAM_BACKEND_ID_STR>",
+    "releaseChannelCollection": "opt-out"
+  },
+  "AUSHELPER_CPU_ERROR_CODE": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1296630],
+    "expires_in_version": "60",
+    "kind": "enumerated",
+    "n_values": 16,
+    "releaseChannelCollection": "opt-out",
+    "description": "The error code from the aushelper system add-on when querying the registry for CPU information for bug 1296630 (see browser/extensions/aushelper/bootstrap.js)."
+  },
+  "AUSHELPER_CPU_RESULT_CODE": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1296630],
+    "expires_in_version": "60",
+    "kind": "enumerated",
+    "n_values": 5,
+    "releaseChannelCollection": "opt-out",
+    "description": "Whether the system is affected by bug 1296630 (1=No, 2=Yes, 3=Error, and 4=Unknown)."
+  },
+  "AUSHELPER_WEBSENSE_ERROR_CODE": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1305847],
+    "expires_in_version": "60",
+    "kind": "enumerated",
+    "n_values": 8,
+    "releaseChannelCollection": "opt-out",
+    "description": "The error code from the aushelper system add-on when gathering information on Websense (see browser/extensions/aushelper/bootstrap.js)."
+  },
+  "AUSHELPER_WEBSENSE_REG_EXISTS": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1305847],
+    "expires_in_version": "60",
+    "kind": "boolean",
+    "releaseChannelCollection": "opt-out",
+    "description": "Whether the system has a Websense InstallVersion registry value (see browser/extensions/aushelper/bootstrap.js)."
+  },
+  "BACKGROUNDFILESAVER_THREAD_COUNT": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 21,
+    "description": "Maximum number of concurrent threads reached during a given download session"
+  },
+  "BLOCKLIST_SYNC_FILE_LOAD": {
+    "alert_emails": ["rvitillo@mozilla.com"],
+    "expires_in_version": "35",
+    "kind": "boolean",
+    "description": "blocklist.xml has been loaded synchronously *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "CHECKERBOARD_DURATION": {
+    "alert_emails": ["kgupta@mozilla.com"],
+    "bug_numbers": [1238040],
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "high": 100000,
+    "n_buckets": 50,
+    "description": "Duration of a checkerboard event in milliseconds"
+  },
+  "CHECKERBOARD_PEAK": {
+    "alert_emails": ["kgupta@mozilla.com"],
+    "bug_numbers": [1238040],
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "high": 66355200,
+    "n_buckets": 50,
+    "description": "Peak number of CSS pixels checkerboarded during a checkerboard event (the high value is the size of a 4k display with max APZ zooming)"
+  },
+  "CHECKERBOARD_POTENTIAL_DURATION": {
+    "alert_emails": ["kgupta@mozilla.com"],
+    "bug_numbers": [1238040],
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "high": 1000000,
+    "n_buckets": 50,
+    "description": "Duration of a chunk of time (in ms) that could reasonably have had checkerboarding"
+  },
+  "CHECKERBOARD_SEVERITY": {
+    "alert_emails": ["kgupta@mozilla.com"],
+    "bug_numbers": [1238040],
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "high": 1073741824,
+    "n_buckets": 50,
+    "description": "Opaque measure of the severity of a checkerboard event"
+  },
+  "COMPOSITE_TIME" : {
+    "expires_in_version": "never",
+    "description": "Composite times in milliseconds",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 50
+  },
+  "COMPOSITE_FRAME_ROUNDTRIP_TIME" : {
+    "expires_in_version": "never",
+    "description": "Time from vsync to finishing a composite in milliseconds.",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 50
+  },
+  "COMPOSITOR_ANIMATION_DURATION" : {
+    "expires_in_version": "58",
+    "description": "Duration of animations running on the compositor in milliseconds",
+    "kind": "exponential",
+    "high": 20000,
+    "n_buckets": 50,
+    "alert_emails": ["kgupta@mozilla.com"],
+    "bug_numbers": [1339220]
+  },
+  "COMPOSITOR_ANIMATION_MAX_LAYER_AREA" : {
+    "expires_in_version": "58",
+    "description": "High-watermark of layer area affected during a compositor animation. Units are layer pixels squared.",
+    "kind": "exponential",
+    "high": 8294400,
+    "n_buckets": 50,
+    "alert_emails": ["kgupta@mozilla.com"],
+    "bug_numbers": [1339220]
+  },
+  "CONTENT_PROCESS_LAUNCH_TIME_MS" : {
+    "alert_emails": ["bsmedberg@mozilla.com", "mconley@mozilla.com"],
+    "expires_in_version": "57",
+    "bug_numbers": [1304790],
+    "kind": "exponential",
+    "high": 64000,
+    "n_buckets": 100,
+    "releaseChannelCollection": "opt-out",
+    "description": "Content process launch time until the GetXPCOMProcessAttributes message is received, in milliseconds"
+  },
+  "CONTENT_RESPONSE_DURATION" : {
+    "alert_emails": ["kgupta@mozilla.com"],
+    "bug_numbers": [1261373],
+    "expires_in_version": "58",
+    "description": "Main thread response times for APZ notifications about input events (ms)",
+    "kind" : "exponential",
+    "high": 60000,
+    "n_buckets": 50
+  },
+  "CREATE_EVENT_BEFOREUNLOADEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"beforeunloadevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_COMMANDEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"commandevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_COMMANDEVENTS" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"commandevents\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_COMPOSITIONEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"compositionevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_CUSTOMEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"customevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_DATACONTAINEREVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"datacontainerevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_DATACONTAINEREVENTS" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"datacontainerevents\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_DEVICEMOTIONEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"devicemotionevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_DEVICEORIENTATIONEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"deviceorientationevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_DRAGEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"dragevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_DRAGEVENTS" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"dragevents\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_ERROREVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"errorevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198, 1333901]
+  },
+  "CREATE_EVENT_EVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"event\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_EVENTS" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"events\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_HASHCHANGEEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"hashchangeevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_HTMLEVENTS" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"htmlevents\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_KEYBOARDEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"keyboardevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_KEYEVENTS" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"keyevents\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_MESSAGEEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"messageevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_MOUSEEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"mouseevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_MOUSEEVENTS" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"mouseevents\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_MOUSESCROLLEVENTS" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"mousescrollevents\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_MUTATIONEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"mutationevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_MUTATIONEVENTS" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"mutationevents\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_NOTIFYPAINTEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"notifypaintevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_PAGETRANSITION" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"pagetransition\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_POPSTATEEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"popstateevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_POPUPEVENTS" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"popupevents\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_SCROLLAREAEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"scrollareaevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_SIMPLEGESTUREEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"simplegestureevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_STORAGEEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"storageevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_SVGEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"svgevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_SVGEVENTS" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"svgevents\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_SVGZOOMEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"svgzoomevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_SVGZOOMEVENTS" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"svgzoomevents\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_TEXTEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"textevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_TEXTEVENTS" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"textevents\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_TIMEEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"timeevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_TIMEEVENTS" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"timeevents\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_TOUCHEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"touchevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_UIEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"uievent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_UIEVENTS" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"uievents\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_XULCOMMANDEVENT" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"xulcommandevent\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CREATE_EVENT_XULCOMMANDEVENTS" : {
+    "alert_emails": ["ayg@aryeh.name"],
+    "description": "Was document.createEvent(\"xulcommandevents\") ever called",
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1295588, 1251198]
+  },
+  "CYCLE_COLLECTOR": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent on one cycle collection (ms)"
+  },
+  "CYCLE_COLLECTOR_WORKER": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent on one cycle collection in a worker (ms)"
+  },
+  "CYCLE_COLLECTOR_FULL": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Full pause time for one cycle collection, including preparation (ms)"
+  },
+  "CYCLE_COLLECTOR_MAX_PAUSE": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Longest pause for an individual slice of one cycle collection, including preparation (ms)"
+  },
+  "CYCLE_COLLECTOR_FINISH_IGC": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Cycle collection finished an incremental GC"
+  },
+  "CYCLE_COLLECTOR_SYNC_SKIPPABLE": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Cycle collection synchronously ran forget skippable"
+  },
+  "CYCLE_COLLECTOR_VISITED_REF_COUNTED": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 300000,
+    "n_buckets": 50,
+    "description": "Number of ref counted objects visited by the cycle collector"
+  },
+  "CYCLE_COLLECTOR_WORKER_VISITED_REF_COUNTED": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 300000,
+    "n_buckets": 50,
+    "description": "Number of ref counted objects visited by the cycle collector in a worker"
+  },
+  "CYCLE_COLLECTOR_VISITED_GCED": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 300000,
+    "n_buckets": 50,
+    "description": "Number of JS objects visited by the cycle collector"
+  },
+  "CYCLE_COLLECTOR_WORKER_VISITED_GCED": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 300000,
+    "n_buckets": 50,
+    "description": "Number of JS objects visited by the cycle collector in a worker"
+  },
+  "CYCLE_COLLECTOR_COLLECTED": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 100000,
+    "n_buckets": 50,
+    "description": "Number of objects collected by the cycle collector"
+  },
+  "CYCLE_COLLECTOR_WORKER_COLLECTED": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 100000,
+    "n_buckets": 50,
+    "description": "Number of objects collected by the cycle collector in a worker"
+  },
+  "CYCLE_COLLECTOR_NEED_GC": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Needed garbage collection before cycle collection."
+  },
+  "CYCLE_COLLECTOR_WORKER_NEED_GC": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Needed garbage collection before cycle collection in a worker."
+  },
+  "CYCLE_COLLECTOR_TIME_BETWEEN": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 120,
+    "n_buckets": 50,
+    "description": "Time spent in between cycle collections (seconds)"
+  },
+  "CYCLE_COLLECTOR_OOM": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Set if the cycle collector ran out of memory at some point"
+  },
+  "CYCLE_COLLECTOR_WORKER_OOM": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Set if the cycle collector in a worker ran out of memory at some point"
+  },
+  "CYCLE_COLLECTOR_ASYNC_SNOW_WHITE_FREEING": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent on one asynchronous SnowWhite freeing (ms)"
+  },
+  "DEFERRED_FINALIZE_ASYNC": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Pause time for asynchronous deferred finalization (ms)"
+  },
+  "DEVICE_RESET_REASON": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "GPU Device Reset Reason (ok, hung, removed, reset, internal error, invalid call, out of memory)"
+  },
+  "FAMILY_SAFETY": {
+    "alert_emails": ["seceng@mozilla.org"],
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 16,
+    "bug_numbers": [1239166],
+    "description": "Status of Family Safety detection and remediation. See nsNSSComponent.cpp."
+  },
+  "FEED_PROTOCOL_USAGE": {
+    "alert_emails": ["jkt@mozilla.com"],
+    "bug_numbers": [1345546],
+    "expires_in_version": "60",
+    "kind": "enumerated",
+    "n_values": 8,
+    "description": "Usage counts of feed protocols used to load a page. (1=feed, 2=feed:http, 3=feed:https, 4=feed:brokenScheme, 5=pcast, 6=pcast:http, 7=pcast:https, 8=pcast:brokenScheme)"
+  },
+  "FETCH_IS_MAINTHREAD": {
+    "expires_in_version": "50",
+    "kind": "boolean",
+    "description": "Was Fetch request initiated from the main thread?"
+  },
+  "FORCED_DEVICE_RESET_REASON": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 50,
+    "releaseChannelCollection": "opt-out",
+    "description": "GPU Forced Device Reset Reason (OpenSharedHandle)"
+  },
+  "FORGET_SKIPPABLE_MAX": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Max time spent on one forget skippable (ms)"
+  },
+  "FULLSCREEN_TRANSITION_BLACK_MS": {
+    "alert_emails": ["xquan@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 100,
+    "high": 5000,
+    "n_buckets": 50,
+    "bug_numbers": [1271160],
+    "description": "The time spent in the fully-black screen in fullscreen transition"
+  },
+  "FULLSCREEN_CHANGE_MS": {
+    "alert_emails": ["xquan@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 100,
+    "high": 5000,
+    "n_buckets": 50,
+    "bug_numbers": [1271160],
+    "description": "The time content uses to enter/exit fullscreen regardless of fullscreen transition timeout"
+  },
+  "GC_REASON_2": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 100,
+    "description": "Reason (enum value) for initiating a GC"
+  },
+  "GC_IS_COMPARTMENTAL": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Is it a zone GC?"
+  },
+  "GC_MS": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent running JS GC (ms)"
+  },
+  "GC_BUDGET_MS": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 100,
+    "n_buckets": 10,
+    "description": "Requested GC slice budget (ms)"
+  },
+  "GC_ANIMATION_MS": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent running JS GC when animating (ms)"
+  },
+  "GC_MAX_PAUSE_MS": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 1000,
+    "n_buckets": 50,
+    "description": "Longest GC slice in a GC (ms)"
+  },
+  "GC_MARK_MS": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent running JS GC mark phase (ms)"
+  },
+  "GC_SWEEP_MS": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent running JS GC sweep phase (ms)"
+  },
+  "GC_COMPACT_MS": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent running JS GC compact phase (ms)"
+  },
+  "GC_MARK_ROOTS_MS": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 200,
+    "n_buckets": 50,
+    "description": "Time spent marking GC roots (ms)"
+  },
+  "GC_MARK_GRAY_MS": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 200,
+    "n_buckets": 50,
+    "description": "Time spent marking gray GC objects (ms)"
+  },
+  "GC_SLICE_MS": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent running a JS GC slice (ms)"
+  },
+  "GC_SLOW_PHASE": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 75,
+    "description": "The longest phase in any slice that goes over 2x the budget"
+  },
+  "GC_MMU_50": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 100,
+    "n_buckets": 20,
+    "description": "Minimum percentage of time spent outside GC over any 50ms window"
+  },
+  "GC_RESET": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Was an incremental GC canceled?"
+  },
+  "GC_RESET_REASON": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 20,
+    "description": "Reason for cancelling an ongoing GC (see js::gc::AbortReason)",
+    "bug_numbers": [1308116]
+  },
+  "GC_INCREMENTAL_DISABLED": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Is incremental GC permanently disabled?"
+  },
+  "GC_NON_INCREMENTAL": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Was the GC non-incremental?"
+  },
+  "GC_NON_INCREMENTAL_REASON": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 20,
+    "description": "Reason for performing a non-incremental GC (see js::gc::AbortReason)",
+    "bug_numbers": [1308116]
+  },
+  "GC_SCC_SWEEP_TOTAL_MS": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 500,
+    "n_buckets": 50,
+    "description": "Time spent sweeping compartment SCCs (ms)"
+  },
+  "GC_SCC_SWEEP_MAX_PAUSE_MS": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 500,
+    "n_buckets": 50,
+    "description": "Time spent sweeping slowest compartment SCC (ms)"
+  },
+  "GC_MINOR_REASON": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 100,
+    "description": "Reason (enum value) for initiating a minor GC"
+  },
+  "GC_MINOR_REASON_LONG": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 100,
+    "description": "Reason (enum value) that caused a long (>1ms) minor GC"
+  },
+  "GC_MINOR_US": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000000,
+    "n_buckets": 100,
+    "description": "Time spent running JS minor GC (us)"
+  },
+  "GC_NURSERY_BYTES": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 16777216,
+    "n_buckets": 16,
+    "bug_numbers": [1259347],
+    "description": "Size of the GC nursery (bytes)"
+  },
+  "GC_PRETENURE_COUNT": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "kind": "enumerated",
+    "n_values": 32,
+    "bug_numbers": [1293262],
+    "description": "How many objects groups were selected for pretenuring by a minor GC"
+  },
+  "GEOLOCATION_ACCURACY_EXPONENTIAL": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 100000,
+    "n_buckets": 50,
+    "description": "Location accuracy"
+  },
+  "GEOLOCATION_ERROR": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Has seen location error"
+  },
+  "GEOLOCATION_GETCURRENTPOSITION_SECURE_ORIGIN" : {
+    "alert_emails": ["mds@mozilla.com"],
+    "expires_in_version": "60",
+    "kind": "enumerated",
+    "n_values": 10,
+    "bug_numbers": [1230209],
+    "description" : "Number of navigator.geolocation.getCurrentPosition() calls (0=other, 1=http, 2=https)"
+  },
+  "GEOLOCATION_REQUEST_GRANTED": {
+    "alert_emails": ["mds@mozilla.com"],
+    "expires_in_version": "60",
+    "kind": "enumerated",
+    "n_values": 20,
+    "bug_numbers": [1230209],
+    "description": "Geolocation requests either granted or denied (0=denied/other, 1=denied/http, 2=denied/https, ..., 10=granted/other, 11=granted/http, 12=granted/https)"
+  },
+  "GEOLOCATION_WATCHPOSITION_SECURE_ORIGIN" : {
+    "alert_emails": ["mds@mozilla.com"],
+    "expires_in_version": "60",
+    "kind": "enumerated",
+    "n_values": 10,
+    "bug_numbers": [1230209],
+    "description" : "Number of navigator.geolocation.watchPosition() calls (0=other, 1=http, 2=https)"
+  },
+  "GEOLOCATION_WIN8_SOURCE_IS_MLS": {
+    "expires_in_version": "default",
+    "kind": "boolean",
+    "description": "Geolocation on Win8 is either MLS or native"
+  },
+  "GEOLOCATION_OSX_SOURCE_IS_MLS": {
+    "expires_in_version": "default",
+    "kind": "boolean",
+    "description": "Geolocation on OS X is either MLS or CoreLocation"
+  },
+  "GEOLOCATION_GETCURRENTPOSITION_VISIBLE": {
+    "alert_emails": ["mds@mozilla.com"],
+    "expires_in_version": "60",
+    "kind": "boolean",
+    "bug_numbers": [1255198],
+    "description": "This metric is recorded every time a navigator.geolocation.getCurrentPosition() request gets allowed/fulfilled. A false value is recorded if the owner is not visible according to document.isVisible."
+  },
+  "GEOLOCATION_WATCHPOSITION_VISIBLE": {
+    "alert_emails": ["mds@mozilla.com"],
+    "expires_in_version": "60",
+    "kind": "boolean",
+    "bug_numbers": [1255198],
+    "description": "This metric is recorded every time a navigator.geolocation.watchPosition() request gets allowed/fulfilled. A false value is recorded if the owner is not visible according to document.isVisible."
+  },
+  "GPU_PROCESS_LAUNCH_TIME_MS_2" : {
+    "alert_emails": ["danderson@mozilla.com"],
+    "expires_in_version": "never",
+    "bug_numbers": [1297790, 1317796],
+    "kind": "exponential",
+    "high": 64000,
+    "n_buckets": 100,
+    "releaseChannelCollection": "opt-out",
+    "description": "GPU process launch time in milliseconds"
+  },
+  "GPU_PROCESS_INITIALIZATION_TIME_MS" : {
+    "alert_emails": ["danderson@mozilla.com"],
+    "expires_in_version": "never",
+    "bug_numbers": [1324095],
+    "kind": "exponential",
+    "high": 64000,
+    "n_buckets": 100,
+    "releaseChannelCollection": "opt-out",
+    "description": "GPU process initialization (excluding XPCOM and fork time) time in milliseconds"
+  },
+  "JS_DEPRECATED_LANGUAGE_EXTENSIONS_IN_CONTENT": {
+    "alert_emails": ["jdemooij@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "Use of SpiderMonkey's deprecated language extensions in web content: ForEach=0, DestructuringForIn=1 (obsolete), LegacyGenerator=2, ExpressionClosure=3, LetBlock=4 (obsolete), LetExpression=5 (obsolete), NoSuchMethod=6 (obsolete), FlagsArgument=7 (obsolete), RegExpSourceProp=8 (obsolete), RestoredRegExpStatics=9 (obsolete), BlockScopeFunRedecl=10"
+  },
+  "JS_DEPRECATED_LANGUAGE_EXTENSIONS_IN_ADDONS": {
+    "alert_emails": ["jdemooij@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "Use of SpiderMonkey's deprecated language extensions in add-ons: ForEach=0, DestructuringForIn=1 (obsolete), LegacyGenerator=2, ExpressionClosure=3, LetBlock=4 (obsolete), LetExpression=5 (obsolete), NoSuchMethod=6 (obsolete), FlagsArgument=7 (obsolete), RegExpSourceProp=8 (obsolete), RestoredRegExpStatics=9 (obsolete), BlockScopeFunRedecl=10"
+  },
+  "JS_PRIVILEGED_PARSER_COMPILE_LAZY_AFTER_MS": {
+    "alert_emails": ["dteller@mozilla.com"],
+    "expires_in_version": "70",
+    "bug_numbers": [1343483],
+    "kind": "exponential",
+    "low": 10,
+    "high": 10000,
+    "n_buckets": 10,
+    "description": "Time elapsed between the moment a function is lazy-parsed (end of parsing of the ScriptSource) and the moment it is recompiled as non-lazy (start of compilation), in milliseconds, for privileged code."
+  },
+  "JS_WEB_PARSER_COMPILE_LAZY_AFTER_MS": {
+    "alert_emails": ["dteller@mozilla.com"],
+    "expires_in_version": "70",
+    "bug_numbers": [1343483],
+    "kind": "exponential",
+    "low": 10,
+    "high": 10000,
+    "n_buckets": 10,
+    "description": "Time elapsed between the moment a function is lazy-parsed (end of parsing of the ScriptSource) and the moment it is recompiled as non-lazy (start of compilation), in milliseconds, for web code."
+  },
+  "XUL_CACHE_DISABLED": {
+    "expires_in_version": "default",
+    "kind": "flag",
+    "description": "XUL cache was disabled"
+  },
+  "MEMORY_RESIDENT_FAST": {
+    "alert_emails": ["memshrink-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 32768,
+    "high": 16777216,
+    "n_buckets": 100,
+    "bug_numbers": [1226196],
+    "description": "Resident memory size (KB)"
+  },
+  "MEMORY_TOTAL": {
+    "alert_emails": ["memshrink-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1198209],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 32768,
+    "high": 16777216,
+    "n_buckets": 100,
+    "description": "Total Memory Across All Processes (KB)"
+  },
+  "MEMORY_UNIQUE": {
+    "alert_emails": ["memshrink-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1198209],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 32768,
+    "high": 16777216,
+    "n_buckets": 100,
+    "description": "Unique Set Size (KB)"
+  },
+  "MEMORY_VSIZE": {
+    "alert_emails": ["memshrink-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 32768,
+    "high": 16777216,
+    "n_buckets": 100,
+    "description": "Virtual memory size (KB)"
+  },
+  "MEMORY_VSIZE_MAX_CONTIGUOUS": {
+    "alert_emails": ["memshrink-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 32768,
+    "high": 16777216,
+    "n_buckets": 100,
+    "description": "Maximum-sized block of contiguous virtual memory (KB)"
+  },
+  "MEMORY_JS_COMPARTMENTS_SYSTEM": {
+    "alert_emails": ["memshrink-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 50,
+    "description": "Total JavaScript compartments used for add-ons and internals."
+  },
+  "MEMORY_JS_COMPARTMENTS_USER": {
+    "alert_emails": ["memshrink-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 50,
+    "description": "Total JavaScript compartments used for web pages"
+  },
+  "MEMORY_JS_GC_HEAP": {
+    "alert_emails": ["memshrink-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 1024,
+    "high": 16777216,
+    "n_buckets": 200,
+    "description": "Memory used by the garbage-collected JavaScript heap (KB)"
+  },
+  "MEMORY_STORAGE_SQLITE": {
+    "alert_emails": ["memshrink-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 1024,
+    "high": 524288,
+    "n_buckets": 50,
+    "description": "Memory used by SQLite (KB)"
+  },
+  "MEMORY_IMAGES_CONTENT_USED_UNCOMPRESSED": {
+    "alert_emails": ["memshrink-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 1024,
+    "high": 1048576,
+    "n_buckets": 50,
+    "description": "Memory used for uncompressed, in-use content images (KB)"
+  },
+  "MEMORY_HEAP_ALLOCATED": {
+    "alert_emails": ["memshrink-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 1024,
+    "high": 16777216,
+    "n_buckets": 200,
+    "description": "Heap memory allocated (KB)"
+  },
+  "MEMORY_HEAP_COMMITTED_UNUSED": {
+    "alert_emails": ["memshrink-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 1024,
+    "high": 524288,
+    "n_buckets": 50,
+    "description": "Committed, unused heap memory (KB)"
+  },
+  "MEMORY_HEAP_OVERHEAD_FRACTION": {
+    "alert_emails": ["memshrink-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1252375],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 100,
+    "n_buckets": 25,
+    "description": "Fraction of committed heap memory that is overhead (percentage)."
+  },
+  "GHOST_WINDOWS": {
+    "alert_emails": ["memshrink-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 128,
+    "n_buckets": 32,
+    "description": "Number of ghost windows"
+  },
+  "MEMORY_FREE_PURGED_PAGES_MS": {
+    "alert_emails": ["memshrink-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1024,
+    "n_buckets": 10,
+    "description": "Time(ms) to purge dirty heap pages."
+  },
+  "LOW_MEMORY_EVENTS_VIRTUAL": {
+    "alert_emails": ["memshrink-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1024,
+    "n_buckets": 21,
+    "description": "Number of low-virtual-memory events fired since last ping",
+    "cpp_guard": "XP_WIN"
+  },
+  "LOW_MEMORY_EVENTS_PHYSICAL": {
+    "alert_emails": ["memshrink-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1024,
+    "n_buckets": 21,
+    "description": "Number of low-physical-memory events fired since last ping",
+    "cpp_guard": "XP_WIN"
+  },
+  "LOW_MEMORY_EVENTS_COMMIT_SPACE": {
+    "alert_emails": ["memshrink-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1024,
+    "n_buckets": 21,
+    "description": "Number of low-commit-space events fired since last ping",
+    "cpp_guard": "XP_WIN"
+  },
+  "PAGE_FAULTS_HARD": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "low": 8,
+    "high": 65536,
+    "n_buckets": 13,
+    "description": "Hard page faults (since last telemetry ping)",
+    "cpp_guard": "XP_UNIX"
+  },
+  "FONTLIST_INITOTHERFAMILYNAMES": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "Time(ms) spent on reading other family names from all fonts"
+  },
+  "FONTLIST_INITFACENAMELISTS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "Time(ms) spent on reading family names from all fonts"
+  },
+  "DWRITEFONT_DELAYEDINITFONTLIST_TOTAL": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 10,
+    "description": "gfxDWriteFontList::DelayedInitFontList Total (ms)",
+    "cpp_guard": "XP_WIN"
+  },
+  "DWRITEFONT_DELAYEDINITFONTLIST_COUNT": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 10,
+    "description": "gfxDWriteFontList::DelayedInitFontList Font Family Count",
+    "cpp_guard": "XP_WIN"
+  },
+  "DWRITEFONT_DELAYEDINITFONTLIST_COLLECT": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 10,
+    "description": "gfxDWriteFontList::DelayedInitFontList GetSystemFontCollection (ms)",
+    "cpp_guard": "XP_WIN"
+  },
+  "DWRITEFONT_INIT_PROBLEM": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 8,
+    "description": "DirectWrite system fontlist initialization problem (1=GDI interop, 2=system font collection, 3=no fonts)",
+    "cpp_guard": "XP_WIN"
+  },
+  "GDI_INITFONTLIST_TOTAL": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 10,
+    "description": "gfxGDIFontList::InitFontList Total (ms)",
+    "cpp_guard": "XP_WIN"
+  },
+  "MAC_INITFONTLIST_TOTAL": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 10,
+    "description": "gfxMacPlatformFontList::InitFontList Total (ms)",
+    "cpp_guard": "XP_DARWIN"
+  },
+  "SYSTEM_FONT_FALLBACK": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 100000,
+    "n_buckets": 50,
+    "description": "System font fallback (us)"
+  },
+  "SYSTEM_FONT_FALLBACK_FIRST": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 40000,
+    "n_buckets": 20,
+    "description": "System font fallback, first call (ms)"
+  },
+  "SYSTEM_FONT_FALLBACK_SCRIPT": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 110,
+    "description": "System font fallback script"
+  },
+  "GRADIENT_DURATION": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 50000000,
+    "n_buckets": 20,
+    "description": "Gradient generation time (us)"
+  },
+  "GRADIENT_RETENTION_TIME": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 10000,
+    "n_buckets": 20,
+    "description": "Maximum retention time for the gradient cache. (ms)"
+  },
+  "WORD_CACHE_HITS_CONTENT": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 256,
+    "n_buckets": 30,
+    "description": "Word cache hits, content text (chars)"
+  },
+  "WORD_CACHE_HITS_CHROME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 256,
+    "n_buckets": 30,
+    "description": "Word cache hits, chrome text (chars)"
+  },
+  "WORD_CACHE_MISSES_CONTENT": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 256,
+    "n_buckets": 30,
+    "description": "Word cache misses, content text (chars)"
+  },
+  "WORD_CACHE_MISSES_CHROME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 256,
+    "n_buckets": 30,
+    "description": "Word cache misses, chrome text (chars)"
+  },
+  "FONT_CACHE_HIT": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "font cache hit"
+  },
+  "BAD_FALLBACK_FONT": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "system fallback font can't be used"
+  },
+  "SHUTDOWN_OK": {
+    "expires_in_version": "default",
+    "kind": "boolean",
+    "description": "Did the browser start after a successful shutdown"
+  },
+  "IMAGE_DECODE_LATENCY_US": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 50,
+    "high": 5000000,
+    "n_buckets": 100,
+    "description": "Time spent decoding an image chunk (us)"
+  },
+  "IMAGE_DECODE_TIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 50,
+    "high": 50000000,
+    "n_buckets": 100,
+    "description": "Time spent decoding an image (us)"
+  },
+  "IMAGE_DECODE_ON_DRAW_LATENCY": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 50,
+    "high": 50000000,
+    "n_buckets": 100,
+    "description": "Time from starting a decode to it showing up on the screen (us)"
+  },
+  "IMAGE_DECODE_CHUNKS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 500,
+    "n_buckets": 50,
+    "description": "Number of chunks per decode attempt"
+  },
+  "IMAGE_DECODE_COUNT": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 500,
+    "n_buckets": 50,
+    "description": "Decode count"
+  },
+  "IMAGE_DECODE_SPEED_JPEG": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 500,
+    "high": 50000000,
+    "n_buckets": 50,
+    "description": "JPEG image decode speed (Kbytes/sec)"
+  },
+  "IMAGE_DECODE_SPEED_GIF": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 500,
+    "high": 50000000,
+    "n_buckets": 50,
+    "description": "GIF image decode speed (Kbytes/sec)"
+  },
+  "IMAGE_DECODE_SPEED_PNG": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 500,
+    "high": 50000000,
+    "n_buckets": 50,
+    "description": "PNG image decode speed (Kbytes/sec)"
+  },
+  "CANVAS_2D_USED": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "2D canvas used"
+  },
+  "CANVAS_WEBGL_ACCL_FAILURE_ID": {
+    "alert_emails": ["gfx-telemetry-alerts@mozilla.com","bgirard@mozilla.com","msreckovic@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "keyed": true,
+    "description": "Track the failure IDs that lead us to reject attempting to create an accelerated context. CANVAS_WEBGL_FAILURE_ID reports the overall WebGL status with the attempt to fallback.",
+    "bug_numbers": [1272808]
+  },
+  "CANVAS_WEBGL_FAILURE_ID": {
+    "alert_emails": ["gfx-telemetry-alerts@mozilla.com","bgirard@mozilla.com","msreckovic@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "keyed": true,
+    "description": "WebGL runtime and dynamic failure IDs. This will record a count for each context creation success or failure. Each failure id is a unique identifier that can be traced back to a particular failure branch or blocklist rule.",
+    "bug_numbers": [1272808]
+  },
+  "CANVAS_WEBGL_SUCCESS": {
+    "alert_emails": ["jmuizelaar@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "WebGL1 creation success",
+    "bug_numbers": [1247327]
+  },
+  "CANVAS_WEBGL_USED": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "WebGL canvas used"
+  },
+  "CANVAS_WEBGL2_SUCCESS": {
+    "alert_emails": ["jmuizelaar@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "WebGL2 creation success",
+    "bug_numbers": [1247327]
+  },
+  "TOTAL_CONTENT_PAGE_LOAD_TIME": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 100,
+    "high": 30000,
+    "n_buckets": 100,
+    "description": "HTTP: Total page load time (ms)"
+  },
+  "HTTP_SUBITEM_OPEN_LATENCY_TIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP subitem: Page start -> subitem open() (ms)"
+  },
+  "HTTP_SUBITEM_FIRST_BYTE_LATENCY_TIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP subitem: Page start -> first byte received for subitem reply (ms)"
+  },
+  "HTTP_REQUEST_PER_PAGE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 50,
+    "description": "HTTP: Requests per page (count)"
+  },
+  "HTTP_REQUEST_PER_PAGE_FROM_CACHE": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 101,
+    "description": "HTTP: Requests serviced from cache (%)"
+  },
+  "HTTP_REQUEST_PER_CONN": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 50,
+    "description": "HTTP: requests per connection"
+  },
+  "HTTP_KBREAD_PER_CONN": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 50,
+    "description": "HTTP: KB read per connection"
+  },
+  "HTTP_PAGE_DNS_ISSUE_TIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP page: open() -> DNS request issued (ms)"
+  },
+  "HTTP_PAGE_DNS_LOOKUP_TIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP page: DNS lookup time (ms)"
+  },
+  "HTTP_PAGE_TCP_CONNECTION": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP page: TCP connection setup (ms)"
+  },
+  "HTTP_PAGE_OPEN_TO_FIRST_SENT": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP page: Open -> first byte of request sent (ms)"
+  },
+  "HTTP_PAGE_FIRST_SENT_TO_LAST_RECEIVED": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP page: First byte of request sent -> last byte of response received (ms)"
+  },
+  "HTTP_PAGE_OPEN_TO_FIRST_RECEIVED": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP page: Open -> first byte of reply received (ms)"
+  },
+  "HTTP_PAGE_OPEN_TO_FIRST_FROM_CACHE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP page: Open -> cache read start (ms)"
+  },
+  "HTTP_PAGE_OPEN_TO_FIRST_FROM_CACHE_V2": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP page: Open -> cache read start (ms), [cache2]"
+  },
+  "HTTP_PAGE_CACHE_READ_TIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP page: Cache read time (ms)"
+  },
+  "HTTP_PAGE_CACHE_READ_TIME_V2": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP page: Cache read time (ms) [cache2]"
+  },
+  "HTTP_PAGE_REVALIDATION": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP page: Positive cache validation time (ms)"
+  },
+  "HTTP_PAGE_COMPLETE_LOAD": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP page: Overall load time - all (ms)"
+  },
+  "HTTP_PAGE_COMPLETE_LOAD_V2": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP page: Overall load time - all (ms) [cache2]"
+  },
+  "HTTP_PAGE_COMPLETE_LOAD_CACHED": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP page: Overall load time - cache hits (ms)"
+  },
+  "HTTP_PAGE_COMPLETE_LOAD_CACHED_V2": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP page: Overall load time - cache hits (ms) [cache2]"
+  },
+  "HTTP_PAGE_COMPLETE_LOAD_NET": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP page: Overall load time - network (ms)"
+  },
+  "HTTP_PAGE_COMPLETE_LOAD_NET_V2": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP page: Overall load time - network (ms) [cache2]"
+  },
+  "HTTP_SUB_DNS_ISSUE_TIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP subitem: open() -> DNS request issued (ms)"
+  },
+  "HTTP_SUB_DNS_LOOKUP_TIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP subitem: DNS lookup time (ms)"
+  },
+  "HTTP_SUB_TCP_CONNECTION": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP subitem: TCP connection setup (ms)"
+  },
+  "HTTP_SUB_OPEN_TO_FIRST_SENT": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP subitem: Open -> first byte of request sent (ms)"
+  },
+  "HTTP_SUB_FIRST_SENT_TO_LAST_RECEIVED": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP subitem: First byte of request sent -> last byte of response received (ms)"
+  },
+  "HTTP_SUB_OPEN_TO_FIRST_RECEIVED": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP subitem: Open -> first byte of reply received (ms)"
+  },
+  "HTTP_SUB_OPEN_TO_FIRST_FROM_CACHE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP subitem: Open -> cache read start (ms)"
+  },
+  "HTTP_SUB_OPEN_TO_FIRST_FROM_CACHE_V2": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP subitem: Open -> cache read start (ms) [cache2]"
+  },
+  "HTTP_SUB_CACHE_READ_TIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP subitem: Cache read time (ms)"
+  },
+  "HTTP_SUB_CACHE_READ_TIME_V2": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP subitem: Cache read time (ms) [cache2]"
+  },
+  "HTTP_SUB_REVALIDATION": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP subitem: Positive cache validation time (ms)"
+  },
+  "HTTP_SUB_COMPLETE_LOAD": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP subitem: Overall load time - all (ms)"
+  },
+  "HTTP_SUB_COMPLETE_LOAD_V2": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP subitem: Overall load time - all (ms) [cache2]"
+  },
+  "HTTP_SUB_COMPLETE_LOAD_CACHED": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP subitem: Overall load time - cache hits (ms)"
+  },
+  "HTTP_SUB_COMPLETE_LOAD_CACHED_V2": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP subitem: Overall load time - cache hits (ms) [cache2]"
+  },
+  "HTTP_SUB_COMPLETE_LOAD_NET": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP subitem: Overall load time - network (ms)"
+  },
+  "HTTP_SUB_COMPLETE_LOAD_NET_V2": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 50,
+    "description": "HTTP subitem: Overall load time - network (ms) [cache2]"
+  },
+  "HTTP_PROXY_TYPE": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 8,
+    "description": "HTTP Proxy Type (none, http, socks)"
+  },
+  "HTTP_TRANSACTION_IS_SSL": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Whether a HTTP transaction was over SSL or not."
+  },
+  "HTTP_PAGELOAD_IS_SSL": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Whether a HTTP base page load was over SSL or not."
+  },
+  "HTTP_TRANSACTION_USE_ALTSVC": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Whether a HTTP transaction was routed via Alt-Svc or not."
+  },
+  "HTTP_TRANSACTION_USE_ALTSVC_OE": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Whether a HTTP transaction routed via Alt-Svc was scheme=http"
+  },
+  "HTTP_SCHEME_UPGRADE": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "Was the URL upgraded to HTTPS?  (0=already HTTPS, 1=no reason to upgrade, 2=STS upgrade blocked by pref, 3=upgraded with STS, 4=upgraded with CSP)"
+  },
+  "HTTP_RESPONSE_STATUS_CODE": {
+    "alert_emails": ["ckerschbaumer@mozilla.com"],
+    "bug_numbers": [1272345, 1296287],
+    "expires_in_version": "56",
+    "kind": "enumerated",
+    "n_values": 12,
+    "description": "Whether the URL gets redirected?  (0=200, 1=301, 2=302, 3=304, 4=307, 5=308, 6=400, 7=401, 8=403, 9=404, 10=500, 11=other)"
+  },
+  "HTTP_NET_VS_CACHE_ONSTART_QSMALL_NORMALPRI_V2": {
+    "expires_in_version": "58",
+      "alert_emails": ["necko@mozilla.com"],
+      "bug_numbers": [1325322],
+      "kind": "enumerated",
+      "n_values": 80,
+      "description": "Network vs cache time load (OnStartRequest) difference (ms) for requests with a normal priority and small queue. Cache wins: 41-50 for 1-100ms, 51-59 for 101-1000ms, 60-68 for 1-10s, 69-73 for 11-60s and 74 for > 1m. Network wins: 39-30 for 1-100ms, 29-21 for 101-1000ms, 20-12 for 1-10s, 11-7 for 11-60s and 6 for > 1m."
+  },
+  "HTTP_NET_VS_CACHE_ONSTART_QMED_NORMALPRI_V2": {
+    "expires_in_version": "58",
+      "alert_emails": ["necko@mozilla.com"],
+      "bug_numbers": [1325322],
+      "kind": "enumerated",
+      "n_values": 80,
+      "description": "Network vs cache time load (OnStartRequest) difference (ms) for requests with a normal priority and medium queue. Cache wins: 41-50 for 1-100ms, 51-59 for 101-1000ms, 60-68 for 1-10s, 69-73 for 11-60s and 74 for > 1m. Network wins: 39-30 for 1-100ms, 29-21 for 101-1000ms, 20-12 for 1-10s, 11-7 for 11-60s and 6 for > 1m."
+  },
+  "HTTP_NET_VS_CACHE_ONSTART_QBIG_NORMALPRI_V2": {
+    "expires_in_version": "58",
+      "alert_emails": ["necko@mozilla.com"],
+      "bug_numbers": [1325322],
+      "kind": "enumerated",
+      "n_values": 80,
+      "description": "Network vs cache time load (OnStartRequest) difference (ms) for requests with a normal priority and large queue. Cache wins: 41-50 for 1-100ms, 51-59 for 101-1000ms, 60-68 for 1-10s, 69-73 for 11-60s and 74 for > 1m. Network wins: 39-30 for 1-100ms, 29-21 for 101-1000ms, 20-12 for 1-10s, 11-7 for 11-60s and 6 for > 1m."
+  },
+  "HTTP_NET_VS_CACHE_ONSTART_QSMALL_HIGHPRI_V2": {
+    "expires_in_version": "58",
+      "alert_emails": ["necko@mozilla.com"],
+      "bug_numbers": [1325322],
+      "kind": "enumerated",
+      "n_values": 80,
+      "description": "Network vs cache time load (OnStartRequest) difference (ms) for requests with a high priority and small queue. Cache wins: 41-50 for 1-100ms, 51-59 for 101-1000ms, 60-68 for 1-10s, 69-73 for 11-60s and 74 for > 1m. Network wins: 39-30 for 1-100ms, 29-21 for 101-1000ms, 20-12 for 1-10s, 11-7 for 11-60s and 6 for > 1m."
+  },
+  "HTTP_NET_VS_CACHE_ONSTART_QMED_HIGHPRI_V2": {
+    "expires_in_version": "58",
+      "alert_emails": ["necko@mozilla.com"],
+      "bug_numbers": [1325322],
+      "kind": "enumerated",
+      "n_values": 80,
+      "description": "Network vs cache time load (OnStartRequest) difference (ms) for requests with a high priority and medium queue. Cache wins: 41-50 for 1-100ms, 51-59 for 101-1000ms, 60-68 for 1-10s, 69-73 for 11-60s and 74 for > 1m. Network wins: 39-30 for 1-100ms, 29-21 for 101-1000ms, 20-12 for 1-10s, 11-7 for 11-60s and 6 for > 1m."
+  },
+  "HTTP_NET_VS_CACHE_ONSTART_QBIG_HIGHPRI_V2": {
+    "expires_in_version": "58",
+      "alert_emails": ["necko@mozilla.com"],
+      "bug_numbers": [1325322],
+      "kind": "enumerated",
+      "n_values": 80,
+      "description": "Network vs cache time load (OnStartRequest) difference (ms) for requests with a high priority and large queue. Cache wins: 41-50 for 1-100ms, 51-59 for 101-1000ms, 60-68 for 1-10s, 69-73 for 11-60s and 74 for > 1m. Network wins: 39-30 for 1-100ms, 29-21 for 101-1000ms, 20-12 for 1-10s, 11-7 for 11-60s and 6 for > 1m."
+  },
+  "HTTP_NET_VS_CACHE_ONSTOP_QSMALL_NORMALPRI_V2": {
+    "expires_in_version": "58",
+      "alert_emails": ["necko@mozilla.com"],
+      "bug_numbers": [1325322],
+      "kind": "enumerated",
+      "n_values": 80,
+      "description": "Network vs cache time load (OnStopRequest) difference (ms) for requests with a normal priority and small queue. Cache wins: 41-50 for 1-100ms, 51-59 for 101-1000ms, 60-68 for 1-10s, 69-73 for 11-60s and 74 for > 1m. Network wins: 39-30 for 1-100ms, 29-21 for 101-1000ms, 20-12 for 1-10s, 11-7 for 11-60s and 6 for > 1m."
+  },
+  "HTTP_NET_VS_CACHE_ONSTOP_QMED_NORMALPRI_V2": {
+    "expires_in_version": "58",
+      "alert_emails": ["necko@mozilla.com"],
+      "bug_numbers": [1325322],
+      "kind": "enumerated",
+      "n_values": 80,
+      "description": "Network vs cache time load (OnStopRequest) difference (ms) for requests with a normal priority and medium queue. Cache wins: 41-50 for 1-100ms, 51-59 for 101-1000ms, 60-68 for 1-10s, 69-73 for 11-60s and 74 for > 1m. Network wins: 39-30 for 1-100ms, 29-21 for 101-1000ms, 20-12 for 1-10s, 11-7 for 11-60s and 6 for > 1m."
+  },
+  "HTTP_NET_VS_CACHE_ONSTOP_QBIG_NORMALPRI_V2": {
+    "expires_in_version": "58",
+      "alert_emails": ["necko@mozilla.com"],
+      "bug_numbers": [1325322],
+      "kind": "enumerated",
+      "n_values": 80,
+      "description": "Network vs cache time load (OnStopRequest) difference (ms) for requests with a normal priority and large queue. Cache wins: 41-50 for 1-100ms, 51-59 for 101-1000ms, 60-68 for 1-10s, 69-73 for 11-60s and 74 for > 1m. Network wins: 39-30 for 1-100ms, 29-21 for 101-1000ms, 20-12 for 1-10s, 11-7 for 11-60s and 6 for > 1m."
+  },
+  "HTTP_NET_VS_CACHE_ONSTOP_QSMALL_HIGHPRI_V2": {
+    "expires_in_version": "58",
+      "alert_emails": ["necko@mozilla.com"],
+      "bug_numbers": [1325322],
+      "kind": "enumerated",
+      "n_values": 80,
+      "description": "Network vs cache time load (OnStopRequest) difference (ms) for requests with a high priority and small queue. Cache wins: 41-50 for 1-100ms, 51-59 for 101-1000ms, 60-68 for 1-10s, 69-73 for 11-60s and 74 for > 1m. Network wins: 39-30 for 1-100ms, 29-21 for 101-1000ms, 20-12 for 1-10s, 11-7 for 11-60s and 6 for > 1m."
+  },
+  "HTTP_NET_VS_CACHE_ONSTOP_QMED_HIGHPRI_V2": {
+    "expires_in_version": "58",
+      "alert_emails": ["necko@mozilla.com"],
+      "bug_numbers": [1325322],
+      "kind": "enumerated",
+      "n_values": 80,
+      "description": "Network vs cache time load (OnStopRequest) difference (ms) for requests with a high priority and medium queue. Cache wins: 41-50 for 1-100ms, 51-59 for 101-1000ms, 60-68 for 1-10s, 69-73 for 11-60s and 74 for > 1m. Network wins: 39-30 for 1-100ms, 29-21 for 101-1000ms, 20-12 for 1-10s, 11-7 for 11-60s and 6 for > 1m."
+  },
+  "HTTP_NET_VS_CACHE_ONSTOP_QBIG_HIGHPRI_V2": {
+    "expires_in_version": "58",
+      "alert_emails": ["necko@mozilla.com"],
+      "bug_numbers": [1325322],
+      "kind": "enumerated",
+      "n_values": 80,
+      "description": "Network vs cache time load (OnStopRequest) difference (ms) for requests with a high priority and large queue. Cache wins: 41-50 for 1-100ms, 51-59 for 101-1000ms, 60-68 for 1-10s, 69-73 for 11-60s and 74 for > 1m. Network wins: 39-30 for 1-100ms, 29-21 for 101-1000ms, 20-12 for 1-10s, 11-7 for 11-60s and 6 for > 1m."
+  },
+  "HTTP_NET_VS_CACHE_ONSTOP_SMALL_V2": {
+    "expires_in_version": "58",
+      "alert_emails": ["necko@mozilla.com"],
+      "bug_numbers": [1325322],
+      "kind": "enumerated",
+      "n_values": 80,
+      "description": "Network vs cache time load (OnStopRequest) difference (ms) for cache files with a small size (<256K). Cache wins: 41-50 for 1-100ms, 51-59 for 101-1000ms, 60-68 for 1-10s, 69-73 for 11-60s and 74 for > 1m. Network wins: 39-30 for 1-100ms, 29-21 for 101-1000ms, 20-12 for 1-10s, 11-7 for 11-60s and 6 for > 1m."
+  },
+  "HTTP_NET_VS_CACHE_ONSTOP_LARGE_V2": {
+    "expires_in_version": "58",
+      "alert_emails": ["necko@mozilla.com"],
+      "bug_numbers": [1325322],
+      "kind": "enumerated",
+      "n_values": 80,
+      "description": "Network vs cache time load (OnStopRequest) difference (ms) for cache files with a large size (>=256K). Cache wins: 41-50 for 1-100ms, 51-59 for 101-1000ms, 60-68 for 1-10s, 69-73 for 11-60s and 74 for > 1m. Network wins: 39-30 for 1-100ms, 29-21 for 101-1000ms, 20-12 for 1-10s, 11-7 for 11-60s and 6 for > 1m."
+  },
+  "HTTP_NET_VS_CACHE_ONSTART_REVALIDATED_V2": {
+    "expires_in_version": "58",
+      "alert_emails": ["necko@mozilla.com"],
+      "bug_numbers": [1325322],
+      "kind": "enumerated",
+      "n_values": 80,
+      "description": "Network vs cache time load (OnStartRequest) difference revalidated cache entries. Cache wins: 41-50 for 1-100ms, 51-59 for 101-1000ms, 60-68 for 1-10s, 69-73 for 11-60s and 74 for > 1m. Network wins: 39-30 for 1-100ms, 29-21 for 101-1000ms, 20-12 for 1-10s, 11-7 for 11-60s and 6 for > 1m."
+  },
+  "HTTP_NET_VS_CACHE_ONSTART_NOTREVALIDATED_V2": {
+    "expires_in_version": "58",
+      "alert_emails": ["necko@mozilla.com"],
+      "bug_numbers": [1325322],
+      "kind": "enumerated",
+      "n_values": 80,
+      "description": "Network vs cache time load (OnStartRequest) difference (ms) not revalidated cache entries. Cache wins: 41-50 for 1-100ms, 51-59 for 101-1000ms, 60-68 for 1-10s, 69-73 for 11-60s and 74 for > 1m. Network wins: 39-30 for 1-100ms, 29-21 for 101-1000ms, 20-12 for 1-10s, 11-7 for 11-60s and 6 for > 1m."
+  },
+  "HTTP_NET_VS_CACHE_ONSTOP_REVALIDATED_V2": {
+    "expires_in_version": "58",
+      "alert_emails": ["necko@mozilla.com"],
+      "bug_numbers": [1325322],
+      "kind": "enumerated",
+      "n_values": 80,
+      "description": "Network vs cache time load (OnStopRequest) difference (ms) revalidated cache entries. Cache wins: 41-50 for 1-100ms, 51-59 for 101-1000ms, 60-68 for 1-10s, 69-73 for 11-60s and 74 for > 1m. Network wins: 39-30 for 1-100ms, 29-21 for 101-1000ms, 20-12 for 1-10s, 11-7 for 11-60s and 6 for > 1m."
+  },
+  "HTTP_NET_VS_CACHE_ONSTOP_NOTREVALIDATED_V2": {
+    "expires_in_version": "58",
+      "alert_emails": ["necko@mozilla.com"],
+      "bug_numbers": [1325322],
+      "kind": "enumerated",
+      "n_values": 80,
+      "description": "Network vs cache time load (OnStopRequest) difference (ms) not revalidated cache entries. Cache wins: 41-50 for 1-100ms, 51-59 for 101-1000ms, 60-68 for 1-10s, 69-73 for 11-60s and 74 for > 1m. Network wins: 39-30 for 1-100ms, 29-21 for 101-1000ms, 20-12 for 1-10s, 11-7 for 11-60s and 6 for > 1m."
+  },
+  "HTTP_AUTH_DIALOG_STATS": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 4,
+    "description": "Stats about what kind of resource requested http authentication. (0=top-level doc, 1=same origin subresources, 2=cross-origin subresources, 3=xhr)"
+  },
+  "HTTP_AUTH_TYPE_STATS": {
+    "alert_emails": ["rbarnes@mozilla.com"],
+    "bug_numbers": [1266571],
+    "expires_in_version": "52",
+    "kind": "enumerated",
+    "n_values": 8,
+    "releaseChannelCollection": "opt-out",
+    "description": "Recorded once for each HTTP 401 response. The value records the type of authentication and the TLS-enabled status. (0=basic/clear, 1=basic/tls, 2=digest/clear, 3=digest/tls, 4=ntlm/clear, 5=ntlm/tls, 6=negotiate/clear, 7=negotiate/tls)"
+  },
+  "TLS_EARLY_DATA_NEGOTIATED": {
+    "expires_in_version": "58",
+    "kind": "enumerated",
+    "n_values": 3,
+    "description": "Sending TLS early data was possible: 0 - not possible, 1 - possible but not used, 2 - possible and used.",
+    "alert_emails": ["necko@mozilla.com"],
+    "bug_numbers": [1296288]
+  },
+  "TLS_EARLY_DATA_ACCEPTED": {
+    "expires_in_version": "58",
+    "kind": "boolean",
+    "description": "TLS early data was used and it was accepted (true) or rejected (false) by the remote host.",
+    "alert_emails": ["necko@mozilla.com"],
+    "bug_numbers": [1296288]
+  },
+  "TLS_EARLY_DATA_BYTES_WRITTEN": {
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 100,
+    "description": "Amount of bytes sent using TLS early data at the start of a TLS connection for a given channel.",
+    "alert_emails": ["necko@mozilla.com"],
+    "bug_numbers": [1296288]
+  },
+  "SSL_HANDSHAKE_VERSION": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "bug_numbers": [1250568],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 16,
+    "description": "SSL Version (1=tls1, 2=tls1.1, 3=tls1.2, 4=tls1.3)"
+  },
+  "SSL_HANDSHAKE_RESULT": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "bug_numbers": [1331280],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 672,
+    "releaseChannelCollection": "opt-out",
+    "description": "SSL handshake result, 0=success, 1-255=NSS error offset, 256-511=SEC error offset + 256, 512-639=NSPR error offset + 512, 640-670=PKIX error, 671=unknown err"
+  },
+  "SSL_TIME_UNTIL_READY": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 200,
+    "description": "ms of SSL wait time including TCP and proxy tunneling"
+  },
+  "SSL_TIME_UNTIL_HANDSHAKE_FINISHED": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 200,
+    "description": "ms of SSL wait time for full handshake including TCP and proxy tunneling"
+  },
+  "SSL_BYTES_BEFORE_CERT_CALLBACK": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 32000,
+    "n_buckets": 64,
+    "description": "plaintext bytes read before a server certificate authenticated"
+  },
+  "SSL_NPN_TYPE": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 16,
+    "description": "NPN Results (0=none, 1=negotiated, 2=no-overlap, 3=selected(alpn))"
+  },
+  "SSL_RESUMED_SESSION": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "complete TLS connect that used TLS Sesison Resumption"
+  },
+  "CERT_VALIDATION_HTTP_REQUEST_RESULT": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 16,
+    "description": "HTTP result of OCSP, etc.. (0=canceled, 1=OK, 2=FAILED, 3=internal-error)"
+  },
+  "CERT_VALIDATION_HTTP_REQUEST_CANCELED_TIME": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 200,
+    "description": "ms elapsed time of OCSP etc.. that was canceled"
+  },
+  "CERT_VALIDATION_HTTP_REQUEST_SUCCEEDED_TIME": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 200,
+    "description": "ms elapsed time of OCSP etc.. that succeeded"
+  },
+  "CERT_VALIDATION_HTTP_REQUEST_FAILED_TIME": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 200,
+    "description": "ms elapsed time of OCSP etc.. that failed"
+  },
+  "SSL_KEY_EXCHANGE_ALGORITHM_FULL": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 16,
+    "description": "SSL Handshake Key Exchange Algorithm for full handshake (null=0, rsa=1, dh=2, fortezza=3, ecdh=4)"
+  },
+  "SSL_KEY_EXCHANGE_ALGORITHM_RESUMED": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 16,
+    "description": "SSL Handshake Key Exchange Algorithm for resumed handshake (null=0, rsa=1, dh=2, fortezza=3, ecdh=4)"
+  },
+  "SSL_OBSERVED_END_ENTITY_CERTIFICATE_LIFETIME": {
+    "expires_in_version": "55",
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "kind": "enumerated",
+    "n_values": 125,
+    "releaseChannelCollection": "opt-out",
+    "description": "The lifetime of accepted HTTPS server certificates, in weeks, up to 2 years. Bucket 105 is all end-entity HTTPS server certificates with a lifetime > 2 years."
+  },
+  "KEYGEN_GENERATED_KEY_TYPE": {
+    "expires_in_version": "55",
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "kind": "count",
+    "keyed": true,
+    "releaseChannelCollection": "opt-out",
+    "bug_numbers": [1191414,1284945],
+    "description": "The number of times we generate a key via keygen, keyed on algorithm and keysize. Keys include RSA with key size (512, 1024, 2048, possibly others), secp384r1, secp256r1, and 'other_ec'."
+  },
+  "WEBSOCKETS_HANDSHAKE_TYPE": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 16,
+    "description": "Websockets Handshake Results (ws-ok-plain, ws-ok-proxy, ws-failed-plain, ws-failed-proxy, wss-ok-plain, wss-ok-proxy, wss-failed-plain, wss-failed-proxy)"
+  },
+  "SPDY_VERSION2": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 48,
+    "description": "SPDY: Protocol Version Used"
+  },
+  "HTTP_RESPONSE_VERSION": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 48,
+    "description": "HTTP: Protocol Version Used on Response from nsHttp.h"
+  },
+  "HTTP_09_INFO": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 4,
+    "description": "HTTP 09 Response Breakdown: lowbit subresource, high bit nonstd port",
+    "bug_numbers": [1262572],
+    "alert_emails": ["necko@mozilla.com"]
+  },
+  "SPDY_PARALLEL_STREAMS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 50,
+    "description": "SPDY: Streams concurrent active per connection"
+  },
+  "SPDY_REQUEST_PER_CONN": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 50,
+    "description": "SPDY: Streams created per connection"
+  },
+  "SPDY_SERVER_INITIATED_STREAMS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 100000,
+    "n_buckets": 250,
+    "description": "SPDY: Streams recevied per connection"
+  },
+  "SPDY_CHUNK_RECVD": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 100,
+    "description": "SPDY: Recvd Chunk Size (rounded to KB)"
+  },
+  "SPDY_SYN_SIZE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 20,
+    "high": 20000,
+    "n_buckets": 50,
+    "description": "SPDY: SYN Frame Header Size"
+  },
+  "SPDY_SYN_RATIO": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 99,
+    "n_buckets": 20,
+    "description": "SPDY: SYN Frame Header Ratio (lower better)"
+  },
+  "SPDY_SYN_REPLY_SIZE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 16,
+    "high": 20000,
+    "n_buckets": 50,
+    "description": "SPDY: SYN Reply Header Size"
+  },
+  "SPDY_SYN_REPLY_RATIO": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 99,
+    "n_buckets": 20,
+    "description": "SPDY: SYN Reply Header Ratio (lower better)"
+  },
+  "SPDY_NPN_CONNECT": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "SPDY: NPN Negotiated"
+  },
+  "SPDY_NPN_JOIN": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "SPDY: Coalesce Succeeded"
+  },
+  "SPDY_KBREAD_PER_CONN": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 50,
+    "description": "SPDY: KB read per connection"
+  },
+  "SPDY_SETTINGS_UL_BW": {
+    "expires_in_version": "42",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 100,
+    "description": "SPDY: Settings Upload Bandwidth"
+  },
+  "SPDY_SETTINGS_DL_BW": {
+    "expires_in_version": "42",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 100,
+    "description": "SPDY: Settings Download Bandwidth"
+  },
+  "SPDY_SETTINGS_RTT": {
+    "expires_in_version": "42",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 100,
+    "description": "SPDY: Settings RTT"
+  },
+  "SPDY_SETTINGS_MAX_STREAMS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 5000,
+    "n_buckets": 100,
+    "description": "H2: Settings Max Streams parameter"
+  },
+  "SPDY_SETTINGS_CWND": {
+    "expires_in_version": "42",
+    "kind": "exponential",
+    "high": 500,
+    "n_buckets": 50,
+    "description": "SPDY: Settings CWND (packets)"
+  },
+  "SPDY_SETTINGS_RETRANS": {
+    "expires_in_version": "42",
+    "kind": "exponential",
+    "high": 100,
+    "n_buckets": 50,
+    "description": "SPDY: Retransmission Rate"
+  },
+  "SPDY_SETTINGS_IW": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 50,
+    "description": "H2: Settings Initial Window (rounded to KB)"
+  },
+  "SPDY_GOAWAY_LOCAL": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 32,
+    "description": "H2: goaway reason client sent from rfc 7540. 31 is none sent."
+  },
+  "SPDY_GOAWAY_PEER": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 32,
+    "description": "H2: goaway reason from peer from rfc 7540. 31 is none received."
+  },
+  "SPDY_CONTINUED_HEADERS": {
+    "expires_in_version": "59",
+    "alert_emails": ["necko@mozilla.com"],
+    "bug_numbers": [1324855],
+    "kind": "exponential",
+    "high": 32000000,
+    "n_buckets": 75,
+    "description": "Size of continued H2 headers in bytes."
+  },
+  "HPACK_ELEMENTS_EVICTED_DECOMPRESSOR": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 256,
+    "n_buckets": 50,
+    "description": "HPACK: Number of items removed from dynamic table to make room for 1 new item",
+    "alert_emails": ["necko@mozilla.com", "hurley@mozilla.com"],
+    "bug_numbers": [1296280]
+  },
+  "HPACK_BYTES_EVICTED_DECOMPRESSOR": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 8192,
+    "n_buckets": 50,
+    "description": "HPACK: Number of bytes removed from dynamic table to make room for 1 new item",
+    "alert_emails": ["necko@mozilla.com", "hurley@mozilla.com"],
+    "bug_numbers": [1296280]
+  },
+  "HPACK_BYTES_EVICTED_RATIO_DECOMPRESSOR": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 256,
+    "n_buckets": 50,
+    "description": "HPACK: Ratio of bytes evicted to bytes added (* 100)",
+    "alert_emails": ["necko@mozilla.com", "hurley@mozilla.com"],
+    "bug_numbers": [1296280]
+  },
+  "HPACK_PEAK_COUNT_DECOMPRESSOR": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1024,
+    "n_buckets": 50,
+    "description": "HPACK: peak number of items in the dynamic table",
+    "alert_emails": ["necko@mozilla.com", "hurley@mozilla.com"],
+    "bug_numbers": [1296280]
+  },
+  "HPACK_PEAK_SIZE_DECOMPRESSOR": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 16384,
+    "n_buckets": 100,
+    "description": "HPACK: peak size in bytes of the table",
+    "alert_emails": ["necko@mozilla.com", "hurley@mozilla.com"],
+    "bug_numbers": [1296280]
+  },
+  "HPACK_ELEMENTS_EVICTED_COMPRESSOR": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 256,
+    "n_buckets": 50,
+    "description": "HPACK: Number of items removed from dynamic table to make room for 1 new item",
+    "alert_emails": ["necko@mozilla.com", "hurley@mozilla.com"],
+    "bug_numbers": [1296280]
+  },
+  "HPACK_BYTES_EVICTED_COMPRESSOR": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 8192,
+    "n_buckets": 50,
+    "description": "HPACK: Number of bytes removed from dynamic table to make room for 1 new item",
+    "alert_emails": ["necko@mozilla.com", "hurley@mozilla.com"],
+    "bug_numbers": [1296280]
+  },
+  "HPACK_BYTES_EVICTED_RATIO_COMPRESSOR": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 256,
+    "n_buckets": 50,
+    "description": "HPACK: Ratio of bytes evicted to bytes added (* 100)",
+    "alert_emails": ["necko@mozilla.com", "hurley@mozilla.com"],
+    "bug_numbers": [1296280]
+  },
+  "HPACK_PEAK_COUNT_COMPRESSOR": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1024,
+    "n_buckets": 50,
+    "description": "HPACK: peak number of items in the dynamic table",
+    "alert_emails": ["necko@mozilla.com", "hurley@mozilla.com"],
+    "bug_numbers": [1296280]
+  },
+  "HPACK_PEAK_SIZE_COMPRESSOR": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 16384,
+    "n_buckets": 100,
+    "description": "HPACK: peak size in bytes of the table",
+    "alert_emails": ["necko@mozilla.com", "hurley@mozilla.com"],
+    "bug_numbers": [1296280]
+  },
+  "HTTP_CHANNEL_DISPOSITION" : {
+    "alert_emails": ["necko@mozilla.com"],
+    "bug_numbers": [1341128],
+    "expires_in_version": "60",
+    "kind": "enumerated",
+    "n_values": 16,
+    "releaseChannelCollection": "opt-out",
+    "description": "Channel Disposition: 0=Cancel, 1=Disk, 2=NetOK, 3=NetEarlyFail, 4=NetlateFail, +8 for HTTPS"
+  },
+  "HTTP_CONNECTION_ENTRY_CACHE_HIT_1" : {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Fraction of sockets that used a nsConnectionEntry with history - size 300."
+  },
+  "HTTP_CACHE_DISPOSITION_2": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 5,
+    "description": "HTTP Cache Hit, Reval, Failed-Reval, Miss"
+  },
+  "HTTP_CACHE_DISPOSITION_2_V2": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 5,
+    "description": "HTTP Cache v2 Hit, Reval, Failed-Reval, Miss"
+  },
+  "HTTP_DISK_CACHE_DISPOSITION_2": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 5,
+    "description": "HTTP Disk Cache Hit, Reval, Failed-Reval, Miss"
+  },
+  "HTTP_CACHE_MISS_HALFLIFE_EXPERIMENT_2": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 4,
+    "description": "HTTP Cache v2 Miss by half-life value (5 min, 15 min, 1 hour, 6 hours)"
+  },
+  "HTTP_CACHE_ENTRY_RELOAD_TIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 900000,
+    "n_buckets": 50,
+    "description": "Time before we reload an HTTP cache entry again to memory"
+  },
+  "HTTP_CACHE_ENTRY_ALIVE_TIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 7200000,
+    "n_buckets": 50,
+    "description": "Time for which an HTTP cache entry is kept warmed in memory"
+  },
+  "HTTP_CACHE_ENTRY_REUSE_COUNT": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 20,
+    "n_buckets": 19,
+    "description": "Reuse count of an HTTP cache entry warmed in memory"
+  },
+  "HTTP_MEMORY_CACHE_DISPOSITION_2": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 5,
+    "description": "HTTP Memory Cache Hit, Reval, Failed-Reval, Miss"
+  },
+  "HTTP_OFFLINE_CACHE_DISPOSITION_2": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 5,
+    "description": "HTTP Offline Cache Hit, Reval, Failed-Reval, Miss"
+  },
+  "HTTP_OFFLINE_CACHE_DOCUMENT_LOAD": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Rate of page load from offline cache"
+  },
+  "HTTP_CACHE_IO_QUEUE_2_OPEN_PRIORITY": {
+    "alert_emails": ["hbambas@mozilla.com"],
+    "bug_numbers": [1294183],
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "HTTP Cache IO queue length"
+  },
+  "HTTP_CACHE_IO_QUEUE_2_READ_PRIORITY": {
+    "alert_emails": ["hbambas@mozilla.com"],
+    "bug_numbers": [1294183],
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "HTTP Cache IO queue length"
+  },
+  "HTTP_CACHE_IO_QUEUE_2_MANAGEMENT": {
+    "alert_emails": ["hbambas@mozilla.com"],
+    "bug_numbers": [1294183],
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "HTTP Cache IO queue length"
+  },
+  "HTTP_CACHE_IO_QUEUE_2_OPEN": {
+    "alert_emails": ["hbambas@mozilla.com"],
+    "bug_numbers": [1294183],
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "HTTP Cache IO queue length"
+  },
+  "HTTP_CACHE_IO_QUEUE_2_READ": {
+    "alert_emails": ["hbambas@mozilla.com"],
+    "bug_numbers": [1294183],
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "HTTP Cache IO queue length"
+  },
+  "HTTP_CACHE_IO_QUEUE_2_WRITE": {
+    "alert_emails": ["hbambas@mozilla.com"],
+    "bug_numbers": [1294183],
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "HTTP Cache IO queue length"
+  },
+  "HTTP_CACHE_IO_QUEUE_2_WRITE_PRIORITY": {
+    "alert_emails": ["hbambas@mozilla.com"],
+    "bug_numbers": [1294183],
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "HTTP Cache IO queue length"
+  },
+  "HTTP_CACHE_IO_QUEUE_2_INDEX": {
+    "alert_emails": ["hbambas@mozilla.com"],
+    "bug_numbers": [1294183],
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "HTTP Cache IO queue length"
+  },
+  "HTTP_CACHE_IO_QUEUE_2_EVICT": {
+    "alert_emails": ["hbambas@mozilla.com"],
+    "bug_numbers": [1294183],
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "HTTP Cache IO queue length"
+  },
+  "CACHE_DEVICE_SEARCH_2": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time to search cache (ms)"
+  },
+  "CACHE_MEMORY_SEARCH_2": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time to search memory cache (ms)"
+  },
+  "CACHE_DISK_SEARCH_2": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time to search disk cache (ms)"
+  },
+  "CACHE_OFFLINE_SEARCH_2": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time to search offline cache (ms)"
+  },
+  "TRANSACTION_WAIT_TIME_HTTP": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 5000,
+    "n_buckets": 100,
+    "description": "Time from submission to dispatch of HTTP transaction (ms)"
+  },
+  "TRANSACTION_WAIT_TIME_SPDY": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 5000,
+    "n_buckets": 100,
+    "description": "Time from submission to dispatch of SPDY transaction (ms)"
+  },
+  "HTTP_SAW_QUIC_ALT_PROTOCOL": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Fraction of responses with a quic alt-protocol advertisement."
+  },
+  "HTTP_CONTENT_ENCODING": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 6,
+    "description": "encoding removed: 0=unknown, 1=gzip, 2=deflate, 3=brotli"
+  },
+  "HTTP_DISK_CACHE_OVERHEAD": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 32000000,
+    "n_buckets": 100,
+    "description": "HTTP Disk cache memory overhead (bytes)"
+  },
+  "CACHE_LM_INCONSISTENT": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Cache discovered inconsistent last-modified entry"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_2": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms)"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_2": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock on the main thread (ms)"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSSETDISKSMARTSIZECALLBACK_NOTIFY": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSSETDISKSMARTSIZECALLBACK_NOTIFY"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSPROCESSREQUESTEVENT_RUN": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSPROCESSREQUESTEVENT_RUN"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSOUTPUTSTREAMWRAPPER_LAZYINIT": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSOUTPUTSTREAMWRAPPER_LAZYINIT"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSOUTPUTSTREAMWRAPPER_CLOSEINTERNAL": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSOUTPUTSTREAMWRAPPER_CLOSEINTERNAL"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSOUTPUTSTREAMWRAPPER_RELEASE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSOUTPUTSTREAMWRAPPER_RELEASE"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCOMPRESSOUTPUTSTREAMWRAPPER_RELEASE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCOMPRESSOUTPUTSTREAMWRAPPER_RELEASE"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSINPUTSTREAMWRAPPER_LAZYINIT": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSINPUTSTREAMWRAPPER_LAZYINIT"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSINPUTSTREAMWRAPPER_CLOSEINTERNAL": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSINPUTSTREAMWRAPPER_CLOSEINTERNAL"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSINPUTSTREAMWRAPPER_RELEASE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSINPUTSTREAMWRAPPER_RELEASE"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSDECOMPRESSINPUTSTREAMWRAPPER_RELEASE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSDECOMPRESSINPUTSTREAMWRAPPER_RELEASE"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_SHUTDOWN": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHESERVICE_SHUTDOWN"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_SETOFFLINECACHEENABLED": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHESERVICE_SETOFFLINECACHEENABLED"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_SETOFFLINECACHECAPACITY": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHESERVICE_SETOFFLINECACHECAPACITY"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_SETMEMORYCACHE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHESERVICE_SETMEMORYCACHE"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_SETDISKSMARTSIZE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHESERVICE_SETDISKSMARTSIZE"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_SETDISKCACHEMAXENTRYSIZE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHESERVICE_SETDISKCACHEMAXENTRYSIZE"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_SETMEMORYCACHEMAXENTRYSIZE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHESERVICE_SETMEMORYCACHEMAXENTRYSIZE"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_SETDISKCACHEENABLED": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHESERVICE_SETDISKCACHEENABLED"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_SETDISKCACHECAPACITY": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHESERVICE_SETDISKCACHECAPACITY"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_OPENCACHEENTRY": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHESERVICE_OPENCACHEENTRY"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_ONPROFILESHUTDOWN": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHESERVICE_ONPROFILESHUTDOWN"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_ONPROFILECHANGED": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHESERVICE_ONPROFILECHANGED"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_ISSTORAGEENABLEDFORPOLICY": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHESERVICE_ISSTORAGEENABLEDFORPOLICY"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_GETCACHEIOTARGET": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHESERVICE_GETCACHEIOTARGET"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_EVICTENTRIESFORCLIENT": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHESERVICE_EVICTENTRIESFORCLIENT"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_DISKDEVICEHEAPSIZE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHESERVICE_DISKDEVICEHEAPSIZE"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_CLOSEALLSTREAMS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHESERVICE_CLOSEALLSTREAMS"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_DOOM": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_DOOM"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_SETPREDICTEDDATASIZE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_SETPREDICTEDDATASIZE"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_GETDATASIZE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_GETDATASIZE"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_GETSTORAGEDATASIZE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_GETSTORAGEDATASIZE"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_REQUESTDATASIZECHANGE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_REQUESTDATASIZECHANGE"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_SETDATASIZE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_SETDATASIZE"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_OPENINPUTSTREAM": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_OPENINPUTSTREAM"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_OPENOUTPUTSTREAM": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_OPENOUTPUTSTREAM"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_GETCACHEELEMENT": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_GETCACHEELEMENT"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_SETCACHEELEMENT": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_SETCACHEELEMENT"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_GETSTORAGEPOLICY": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_GETSTORAGEPOLICY"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_SETSTORAGEPOLICY": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_SETSTORAGEPOLICY"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_GETFILE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_GETFILE"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_GETSECURITYINFO": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_GETSECURITYINFO"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_SETSECURITYINFO": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_SETSECURITYINFO"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_DOOMANDFAILPENDINGREQUESTS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_DOOMANDFAILPENDINGREQUESTS"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_MARKVALID": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_MARKVALID"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_CLOSE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_CLOSE"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_GETMETADATAELEMENT": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_GETMETADATAELEMENT"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_SETMETADATAELEMENT": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_SETMETADATAELEMENT"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_VISITMETADATA": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_VISITMETADATA"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_SETEXPIRATIONTIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_SETEXPIRATIONTIME"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_ISSTREAMBASED": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_ISSTREAMBASED"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_GETLASTMODIFIED": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_GETLASTMODIFIED"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_GETEXPIRATIONTIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_GETEXPIRATIONTIME"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_GETKEY": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_GETKEY"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_GETFETCHCOUNT": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_GETFETCHCOUNT"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_GETDEVICEID": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_GETDEVICEID"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_PROCESSREQUEST": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHESERVICE_PROCESSREQUEST"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_VISITENTRIES": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHESERVICE_VISITENTRIES"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_GETPREDICTEDDATASIZE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_GETPREDICTEDDATASIZE"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_GETLASTFETCHED": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_GETLASTFETCHED"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHEENTRYDESCRIPTOR_GETCLIENTID": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSCACHEENTRYDESCRIPTOR_GETCLIENTID"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSBLOCKONCACHETHREADEVENT_RUN": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSBLOCKONCACHETHREADEVENT_RUN"
+  },
+  "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSASYNCDOOMEVENT_RUN": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent waiting on the cache service lock (ms) on the main thread in NSASYNCDOOMEVENT_RUN"
+  },
+  "DNT_USAGE": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 3,
+    "description": "I want to be tracked, I do NOT want to be tracked, DNT unset"
+  },
+  "DNS_LOOKUP_METHOD2": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 16,
+    "description": "DNS Lookup Type (hit, renewal, negative-hit, literal, overflow, network-first, network-shared)"
+  },
+  "DNS_CLEANUP_AGE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1440,
+    "n_buckets": 50,
+    "description": "DNS Cache Entry Age at Removal Time (minutes)"
+  },
+  "DNS_LOOKUP_TIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 50,
+    "description": "Time for a successful DNS OS resolution (msec)"
+  },
+  "DNS_RENEWAL_TIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 50,
+    "description": "Time for a renewed DNS OS resolution (msec)"
+  },
+  "DNS_RENEWAL_TIME_FOR_TTL": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 50,
+    "description": "Time for a DNS OS resolution (msec) used to get TTL"
+  },
+  "DNS_FAILED_LOOKUP_TIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 50,
+    "description": "Time for an unsuccessful DNS OS resolution (msec)"
+  },
+  "DNS_BLACKLIST_COUNT": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 21,
+    "n_buckets": 20,
+    "description": "The number of unusable addresses reported for each record"
+  },
+  "REFRESH_DRIVER_TICK" : {
+    "expires_in_version": "never",
+    "description": "Total time spent ticking the refresh driver in milliseconds",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 50
+  },
+  "PAINT_BUILD_DISPLAYLIST_TIME" : {
+    "expires_in_version": "never",
+    "description": "Time spent in building displaylists in milliseconds",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 50
+  },
+  "PAINT_RASTERIZE_TIME" : {
+    "expires_in_version": "never",
+    "description": "Time spent rasterizing each frame in milliseconds",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 50
+  },
+  "PREDICTOR_PREDICT_ATTEMPTS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000000,
+    "n_buckets": 50,
+    "description": "Number of times nsINetworkPredictor::Predict is called and attempts to predict"
+  },
+  "PREDICTOR_LEARN_ATTEMPTS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000000,
+    "n_buckets": 50,
+    "description": "Number of times nsINetworkPredictor::Learn is called and attempts to learn"
+  },
+  "PREDICTOR_PREDICT_FULL_QUEUE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 50,
+    "description": "Number of times nsINetworkPredictor::Predict doesn't continue because the queue is full"
+  },
+  "PREDICTOR_LEARN_FULL_QUEUE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 50,
+    "description": "Number of times nsINetworkPredictor::Learn doesn't continue because the queue is full"
+  },
+  "PREDICTOR_WAIT_TIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Amount of time a predictor event waits in the queue (ms)"
+  },
+  "PREDICTOR_PREDICT_WORK_TIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Amount of time spent doing the work for predict (ms)",
+    "alert_emails": ["necko@mozilla.com"]
+  },
+  "PREDICTOR_LEARN_WORK_TIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Amount of time spent doing the work for learn (ms)"
+  },
+  "PREDICTOR_TOTAL_PREDICTIONS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000000,
+    "n_buckets": 50,
+    "description": "How many actual predictions (preresolves, preconnects, ...) happen"
+  },
+  "PREDICTOR_TOTAL_PREFETCHES": {
+    "expires_in_version": "never",
+    "alert_emails": [],
+    "bug_numbers": [1016628],
+    "kind": "exponential",
+    "high": 1000000,
+    "n_buckets": 50,
+    "description": "How many actual prefetches happen"
+  },
+  "PREDICTOR_TOTAL_PREFETCHES_USED": {
+    "expires_in_version": "never",
+    "alert_emails": [],
+    "bug_numbers": [1016628],
+    "kind": "exponential",
+    "high": 1000000,
+    "n_buckets": 50,
+    "description": "How many prefetches are actually used by a channel"
+  },
+  "PREDICTOR_PREFETCH_TIME": {
+    "expires_in_version": "never",
+    "alert_emails": [],
+    "bug_numbers": [1016628],
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "How long it takes from OnStartRequest to OnStopRequest for a prefetch"
+  },
+  "PREDICTOR_TOTAL_PRECONNECTS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000000,
+    "n_buckets": 50,
+    "description": "How many actual preconnects happen"
+  },
+  "PREDICTOR_TOTAL_PRECONNECTS_CREATED": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000000,
+    "n_buckets": 50,
+    "description": "How many preconnects actually created a speculative socket"
+  },
+  "PREDICTOR_TOTAL_PRECONNECTS_USED": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000000,
+    "n_buckets": 50,
+    "description": "How many preconnects actually created a used speculative socket"
+  },
+  "PREDICTOR_TOTAL_PRECONNECTS_UNUSED": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000000,
+    "n_buckets": 50,
+    "description": "How many preconnects needlessly created a speculative socket"
+  },
+  "PREDICTOR_TOTAL_PRERESOLVES": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000000,
+    "n_buckets": 50,
+    "description": "How many actual preresolves happen"
+  },
+  "PREDICTOR_PREDICTIONS_CALCULATED": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000000,
+    "n_buckets": 50,
+    "description": "How many prediction calculations are performed"
+  },
+  "PREDICTOR_GLOBAL_DEGRADATION": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 100,
+    "n_buckets": 50,
+    "description": "The global degradation calculated"
+  },
+  "PREDICTOR_SUBRESOURCE_DEGRADATION": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 100,
+    "n_buckets": 50,
+    "description": "The degradation calculated for a subresource"
+  },
+  "PREDICTOR_BASE_CONFIDENCE": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 100,
+    "n_buckets": 50,
+    "description": "The base confidence calculated for a subresource"
+  },
+  "PREDICTOR_CONFIDENCE": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 100,
+    "n_buckets": 50,
+    "description": "The final confidence calculated for a subresource"
+  },
+  "PREDICTOR_PREDICT_TIME_TO_ACTION": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "How long it takes from the time Predict() is called to the time we take action",
+    "alert_emails": ["necko@mozilla.com"]
+  },
+  "PREDICTOR_PREDICT_TIME_TO_INACTION": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "How long it takes from the time Predict() is called to the time we figure out there's nothing to do"
+  },
+  "HTTPCONNMGR_TOTAL_SPECULATIVE_CONN": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000000,
+    "n_buckets": 50,
+    "description": "How many speculative http connections are created"
+  },
+  "HTTPCONNMGR_USED_SPECULATIVE_CONN": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000000,
+    "n_buckets": 50,
+    "description": "How many speculative http connections are actually used"
+  },
+  "HTTPCONNMGR_UNUSED_SPECULATIVE_CONN": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000000,
+    "n_buckets": 50,
+    "description": "How many speculative connections are made needlessly"
+  },
+  "TAP_TO_LOAD_IMAGE_SIZE": {
+    "expires_in_version": "50",
+    "kind": "exponential",
+    "high": 32768,
+    "n_buckets": 50,
+    "description": "The size of the image being shown, when using tap-to-load images. (kilobytes)",
+    "bug_numbers": [1208167]
+  },
+  "STS_POLL_AND_EVENTS_CYCLE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "The duraion of a socketThread cycle, including polls and pending events. (ms)"
+  },
+  "STS_NUMBER_OF_PENDING_EVENTS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 2000,
+    "n_buckets": 100,
+    "description": "Number of pending events per SocketThread cycle."
+  },
+  "STS_POLL_CYCLE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "The duration of poll. (ms)"
+  },
+  "STS_POLL_AND_EVENT_THE_LAST_CYCLE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "The duraion of the socketThread cycle during shutdown, including polls and pending events. (ms)"
+  },
+  "STS_NUMBER_OF_PENDING_EVENTS_IN_THE_LAST_CYCLE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 2000,
+    "n_buckets": 100,
+    "description": "Number of pending events per SocketThread cycle during shutdown."
+  },
+  "STS_NUMBER_OF_ONSOCKETREADY_CALLS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 2000,
+    "n_buckets": 100,
+    "description": "Number of OnSocketReady calls during a single poll."
+  },
+  "STS_POLL_BLOCK_TIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "Time spent blocked on poll (ms)."
+  },
+  "PRCONNECT_BLOCKING_TIME_NORMAL": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "Time spent blocked in PR_Connect when we are not shutting down and there has been niether a network nor an offline state change in the last 60s (ms)."
+  },
+  "PRCONNECT_BLOCKING_TIME_SHUTDOWN": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "Time spent blocked in PR_Connect during a shutdown (ms)."
+  },
+  "PRCONNECT_BLOCKING_TIME_CONNECTIVITY_CHANGE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "Time spent blocked in PR_Connect when there has been the connectiviy change in the last 60s (ms)."
+  },
+  "PRCONNECT_BLOCKING_TIME_LINK_CHANGE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "Time spent blocked in PR_Connect when there has been a link change in the last 60s (ms)."
+  },
+  "PRCONNECT_BLOCKING_TIME_OFFLINE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "Time spent blocked in PR_Connect when the offline state has changed in the last 60s (ms)."
+  },
+  "PRCONNECT_FAIL_BLOCKING_TIME_NORMAL": {
+    "bug_numbers": [1257809],
+    "alert_emails": ["ddamjanovic@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 100,
+    "description": "Time spent blocked in a failed PR_Connect when we are not shutting down and there has been niether a network nor an offline state change in the last 60s (ms)."
+  },
+  "PRCONNECT_FAIL_BLOCKING_TIME_SHUTDOWN": {
+    "bug_numbers": [1257809],
+    "alert_emails": ["ddamjanovic@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 100,
+    "description": "Time spent blocked in a failed PR_Connect during a shutdown (ms)."
+  },
+  "PRCONNECT_FAIL_BLOCKING_TIME_CONNECTIVITY_CHANGE": {
+    "bug_numbers": [1257809],
+    "alert_emails": ["ddamjanovic@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 100,
+    "description": "Time spent blocked in a failed PR_Connect when there has been the connectiviy change in the last 60s (ms)."
+  },
+  "PRCONNECT_FAIL_BLOCKING_TIME_LINK_CHANGE": {
+    "bug_numbers": [1257809],
+    "alert_emails": ["ddamjanovic@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 100,
+    "description": "Time spent blocked in a failed PR_Connect when there has been a link change in the last 60s (ms)."
+  },
+  "PRCONNECT_FAIL_BLOCKING_TIME_OFFLINE": {
+    "bug_numbers": [1257809],
+    "alert_emails": ["ddamjanovic@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 100,
+    "description": "Time spent blocked in a failed PR_Connect when the offline state has changed in the last 60s (ms)."
+  },
+  "PRCONNECTCONTINUE_BLOCKING_TIME_NORMAL": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "Time spent blocked in PR_ConnectContinue when we are not shutting down and there has been niether a network nor an offline state change in the last 60s (ms)."
+  },
+  "PRCONNECTCONTINUE_BLOCKING_TIME_SHUTDOWN": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "Time spent blocked in PR_ConnectContinue during a shutdown (ms)."
+  },
+  "PRCONNECTCONTINUE_BLOCKING_TIME_CONNECTIVITY_CHANGE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "Time spent blocked in PR_ConnectContinue when there has been the connectivity change in the last 60s (ms)."
+  },
+  "PRCONNECTCONTINUE_BLOCKING_TIME_LINK_CHANGE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "Time spent blocked in PR_ConnectContinue when there has been a link change in the last 60s (ms)."
+  },
+  "PRCONNECTCONTINUE_BLOCKING_TIME_OFFLINE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "Time spent blocked in PR_ConnectContinue when the offline state has changed in the last 60s (ms)."
+  },
+  "PRCLOSE_TCP_BLOCKING_TIME_NORMAL": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "Time spent blocked in PR_Close when we are not shutting down and there has been niether a network nor an offline state change in the last 60s (ms)."
+  },
+  "PRCLOSE_TCP_BLOCKING_TIME_SHUTDOWN": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "Time spent blocked in PR_Close during a shutdown (ms)."
+  },
+  "PRCLOSE_TCP_BLOCKING_TIME_CONNECTIVITY_CHANGE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "Time spent blocked in PR_Close when there has been the connectivity change in the last 60s (ms)."
+  },
+  "PRCLOSE_TCP_BLOCKING_TIME_LINK_CHANGE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "Time spent blocked in PR_Close when there has been a link change in the last 60s (ms)."
+  },
+  "PRCLOSE_TCP_BLOCKING_TIME_OFFLINE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "Time spent blocked in PR_Close when the offline state has changed in the last 60s (ms)."
+  },
+  "PRCLOSE_UDP_BLOCKING_TIME_NORMAL": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "Time spent blocked in PR_Close when we are not shutting down and there has been niether a network nor an offline state change in the last 60s (ms)."
+  },
+  "PRCLOSE_UDP_BLOCKING_TIME_SHUTDOWN": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "Time spent blocked in PR_Close during a shutdown (ms)."
+  },
+  "PRCLOSE_UDP_BLOCKING_TIME_CONNECTIVITY_CHANGE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "Time spent blocked in PR_Close when there has been the connectivity change in the last 60s (ms)."
+  },
+  "PRCLOSE_UDP_BLOCKING_TIME_LINK_CHANGE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "Time spent blocked in PR_Close when there has been a link change in the last 60s (ms)."
+  },
+  "PRCLOSE_UDP_BLOCKING_TIME_OFFLINE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "Time spent blocked in PR_Close when the offline state has changed in the last 60s (ms)."
+  },
+  "IPV4_AND_IPV6_ADDRESS_CONNECTIVITY": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 4,
+    "description": "Count the number of 0) successful connections to an ipv4 address, 1) failed connection an ipv4 address, 2) successful connection to an ipv6 address and 3) failed connections to an ipv6 address."
+  },
+  "NETWORK_CONNECTION_COUNT": {
+    "alert_emails": ["amarchesini@mozilla.com"],
+    "expires_in_version": "58",
+    "kind": "count",
+    "bug_numbers": [1330255],
+    "description": "Number of the use of navigator.connection."
+  },
+  "NETWORK_SESSION_AT_900FD": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "session reached 900 fd limit sockets",
+    "bug_numbers": [1260218],
+    "alert_emails": ["necko@mozilla.com"]
+  },
+  "NETWORK_PROBE_MAXCOUNT": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "low": 50,
+    "high": 1000,
+    "n_buckets": 10,
+    "description": "Result of nsSocketTransportService::ProbeMaxCount()",
+    "bug_numbers": [1260218],
+    "alert_emails": ["necko@mozilla.com"]
+  },
+  "FIND_PLUGINS": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent scanning filesystem for plugins (ms)"
+  },
+  "CHECK_JAVA_ENABLED": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent checking if Java is enabled (ms)"
+  },
+  "PLUGIN_HANG_UI_USER_RESPONSE": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 3,
+    "description": "User response to Plugin Hang UI"
+  },
+  "PLUGIN_HANG_UI_DONT_ASK": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Whether the user has requested not to see the Plugin Hang UI again"
+  },
+  "PLUGIN_HANG_UI_RESPONSE_TIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 20,
+    "description": "Time spent in Plugin Hang UI (ms)"
+  },
+  "PLUGIN_HANG_TIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 20,
+    "description": "Value of dom.ipc.plugins.hangUITimeoutSecs plus time spent in Plugin Hang UI (ms)"
+  },
+  "PLUGIN_LOAD_METADATA": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 5000,
+    "n_buckets": 20,
+    "description": "Time spent loading plugin DLL and obtaining metadata (ms)"
+  },
+  "PLUGIN_SHUTDOWN_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 5000,
+    "n_buckets": 20,
+    "description": "Time spent shutting down plugins (ms)"
+  },
+  "FLASH_PLUGIN_STATES": {
+    "expires_in_version": "50",
+    "kind": "enumerated",
+    "n_values": 20,
+    "description": "A flash object's initialization state"
+  },
+  "FLASH_PLUGIN_AREA": {
+    "expires_in_version": "50",
+    "kind": "exponential",
+    "low": 256,
+    "high": 16777216,
+    "n_buckets": 50,
+    "description": "Flash object area (width * height)"
+  },
+  "FLASH_PLUGIN_WIDTH": {
+    "expires_in_version": "50",
+    "kind": "linear",
+    "low": 1,
+    "high": 2000,
+    "n_buckets": 50,
+    "description": "Flash object width"
+  },
+  "FLASH_PLUGIN_HEIGHT": {
+    "expires_in_version": "50",
+    "kind": "linear",
+    "low": 1,
+    "high": 2000,
+    "n_buckets": 50,
+    "description": "Flash object height"
+  },
+  "FLASH_PLUGIN_INSTANCES_ON_PAGE": {
+    "expires_in_version": "50",
+    "kind": "enumerated",
+    "n_values": 30,
+    "description": "Flash object instances count on page"
+  },
+  "MOZ_SQLITE_OPEN_MS": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite open() (ms)"
+  },
+  "MOZ_SQLITE_OPEN_MAIN_THREAD_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite open() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_TRUNCATE_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite truncate() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_TRUNCATE_MAIN_THREAD_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite truncate() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_OTHER_READ_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite read() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_OTHER_READ_MAIN_THREAD_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite read() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_PLACES_READ_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite read() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_PLACES_READ_MAIN_THREAD_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite read() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_COOKIES_OPEN_READAHEAD_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on cookie DB open with readahead (ms)"
+  },
+  "MOZ_SQLITE_COOKIES_READ_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite read() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_COOKIES_READ_MAIN_THREAD_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite read() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_WEBAPPS_READ_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite read() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_WEBAPPS_READ_MAIN_THREAD_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite read() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_OTHER_WRITE_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite write() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_OTHER_WRITE_MAIN_THREAD_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite write() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_PLACES_WRITE_MS": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite write() (ms)"
+  },
+  "MOZ_SQLITE_PLACES_WRITE_MAIN_THREAD_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite write() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_COOKIES_WRITE_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite write() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_COOKIES_WRITE_MAIN_THREAD_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite write() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_WEBAPPS_WRITE_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite write() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_WEBAPPS_WRITE_MAIN_THREAD_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite write() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_OTHER_SYNC_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite fsync() (ms)"
+  },
+  "MOZ_SQLITE_OTHER_SYNC_MAIN_THREAD_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite fsync() (ms)"
+  },
+  "MOZ_SQLITE_PLACES_SYNC_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite fsync() (ms)"
+  },
+  "MOZ_SQLITE_PLACES_SYNC_MAIN_THREAD_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite fsync() (ms)"
+  },
+  "MOZ_SQLITE_COOKIES_SYNC_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite fsync() (ms)"
+  },
+  "MOZ_SQLITE_COOKIES_SYNC_MAIN_THREAD_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite fsync() (ms)"
+  },
+  "MOZ_SQLITE_WEBAPPS_SYNC_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite fsync() (ms)"
+  },
+  "MOZ_SQLITE_WEBAPPS_SYNC_MAIN_THREAD_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time spent on SQLite fsync() (ms)"
+  },
+  "MOZ_SQLITE_OTHER_READ_B": {
+    "expires_in_version": "default",
+    "kind": "linear",
+    "high": 32768,
+    "n_buckets": 3,
+    "description": "SQLite read() (bytes)"
+  },
+  "MOZ_SQLITE_PLACES_READ_B": {
+    "expires_in_version": "40",
+    "kind": "linear",
+    "high": 32768,
+    "n_buckets": 3,
+    "description": "SQLite read() (bytes) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_COOKIES_READ_B": {
+    "expires_in_version": "40",
+    "kind": "linear",
+    "high": 32768,
+    "n_buckets": 3,
+    "description": "SQLite read() (bytes) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_WEBAPPS_READ_B": {
+    "expires_in_version": "40",
+    "kind": "linear",
+    "high": 32768,
+    "n_buckets": 3,
+    "description": "SQLite read() (bytes) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_PLACES_WRITE_B": {
+    "expires_in_version": "40",
+    "kind": "linear",
+    "high": 32768,
+    "n_buckets": 3,
+    "description": "SQLite write (bytes) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_COOKIES_WRITE_B": {
+    "expires_in_version": "40",
+    "kind": "linear",
+    "high": 32768,
+    "n_buckets": 3,
+    "description": "SQLite write (bytes) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_WEBAPPS_WRITE_B": {
+    "expires_in_version": "40",
+    "kind": "linear",
+    "high": 32768,
+    "n_buckets": 3,
+    "description": "SQLite write (bytes) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_SQLITE_OTHER_WRITE_B": {
+    "expires_in_version": "default",
+    "kind": "linear",
+    "high": 32768,
+    "n_buckets": 3,
+    "description": "SQLite write (bytes)"
+  },
+  "MOZ_STORAGE_ASYNC_REQUESTS_MS": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 32768,
+    "n_buckets": 20,
+    "description": "mozStorage async requests completion (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "MOZ_STORAGE_ASYNC_REQUESTS_SUCCESS": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "40",
+    "kind": "boolean",
+    "description": "mozStorage async requests success *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "STARTUP_MEASUREMENT_ERRORS": {
+    "expires_in_version": "default",
+    "kind": "enumerated",
+    "n_values": 16,
+    "description": "Flags errors in startup calculation()"
+  },
+  "NETWORK_DISK_CACHE_OPEN": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 10,
+    "description": "Time spent opening disk cache (ms)"
+  },
+  "NETWORK_DISK_CACHE_TRASHRENAME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 10,
+    "description": "Time spent renaming bad Cache to Cache.Trash (ms)"
+  },
+  "NETWORK_DISK_CACHE_DELETEDIR": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 10,
+    "description": "Time spent deleting disk cache (ms)"
+  },
+  "NETWORK_DISK_CACHE_DELETEDIR_SHUTDOWN": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 10,
+    "description": "Time spent during showdown stopping thread deleting old disk cache (ms)"
+  },
+  "NETWORK_DISK_CACHE_SHUTDOWN": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 10,
+    "description": "Total Time spent (ms) during disk cache showdown"
+  },
+  "NETWORK_DISK_CACHE_SHUTDOWN_V2": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 10,
+    "description": "Total Time spent (ms) during disk cache showdown [cache2]"
+  },
+  "NETWORK_DISK_CACHE_SHUTDOWN_CLEAR_PRIVATE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 10,
+    "description": "Time spent (ms) during showdown deleting disk cache for 'clear private data' option"
+  },
+  "NETWORK_DISK_CACHE2_SHUTDOWN_CLEAR_PRIVATE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 10,
+    "description": "Time spent (ms) during showdown deleting disk cache v2 for 'clear private data' option"
+  },
+  "NETWORK_ID": {
+    "alert_emails": ["necko@mozilla.com"],
+    "bug_numbers": [1240932],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 6,
+    "description": "Network identification (0=None, 1=New, 2=Same)"
+  },
+  "IDLE_NOTIFY_IDLE_MS": {
+    "alert_emails": ["froydnj@mozilla.com"],
+    "bug_numbers": [731004],
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 5000,
+    "n_buckets": 10,
+    "description": "Time spent checking for and notifying listeners that the user is idle (ms)"
+  },
+  "URLCLASSIFIER_LOOKUP_TIME_2": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "bug_numbers": [1336376],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 5000,
+    "n_buckets": 30,
+    "description": "Time spent per dbservice lookup (ms)"
+  },
+  "URLCLASSIFIER_SHUTDOWN_TIME": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 50,
+    "bug_numbers": [1315140],
+    "description": "Time spent per dbservice shutdown (ms)"
+  },
+  "URLCLASSIFIER_CL_CHECK_TIME": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 500,
+    "n_buckets": 10,
+    "description": "Time spent per classifier lookup (ms)"
+  },
+  "URLCLASSIFIER_CL_KEYED_UPDATE_TIME": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "never",
+    "keyed": true,
+    "kind": "exponential",
+    "low": 20,
+    "high": 120000,
+    "n_buckets": 30,
+    "bug_numbers": [1315893],
+    "description": "Time spent per classifier update (ms), keyed by the name of the provider."
+  },
+  "URLCLASSIFIER_CLASSIFYLOCAL_TIME": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "bug_numbers": [1334616],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 30,
+    "description": "Time spent inside ClassifyLocalWithTables (ms)"
+  },
+  "URLCLASSIFIER_ASYNC_CLASSIFYLOCAL_TIME": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "bug_numbers": [1341506],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 30,
+    "description": "Time spent per AsyncClassifyLocalWithTables (ms)"
+  },
+  "URLCLASSIFIER_PS_FILELOAD_TIME": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 10,
+    "description": "Time spent loading PrefixSet from file (ms)"
+  },
+  "URLCLASSIFIER_PS_FALLOCATE_TIME": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 10,
+    "description": "Time spent fallocating PrefixSet (ms)"
+  },
+  "URLCLASSIFIER_PS_CONSTRUCT_TIME": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 5000,
+    "n_buckets": 15,
+    "description": "Time spent constructing PrefixSet from DB (ms)"
+  },
+  "URLCLASSIFIER_VLPS_FILELOAD_TIME": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 10,
+    "bug_numbers": [1283007],
+    "description": "Time spent loading Variable-Length PrefixSet from file (ms)"
+  },
+  "URLCLASSIFIER_VLPS_FALLOCATE_TIME": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 10,
+    "bug_numbers": [1283007],
+    "description": "Time spent fallocating Variable-Length PrefixSet (ms)"
+  },
+  "URLCLASSIFIER_VLPS_CONSTRUCT_TIME": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "60",
+    "kind": "exponential",
+    "high": 5000,
+    "n_buckets": 15,
+    "bug_numbers": [1336865],
+    "description": "Time spent constructing Variable-Length PrefixSet from file (ms)"
+  },
+  "URLCLASSIFIER_VLPS_LOAD_CORRUPT": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "58",
+    "kind": "boolean",
+    "bug_numbers": [1305581],
+    "description": "Whether or not a variable-length prefix set loaded from disk is corrupted (true = file corrupted)."
+  },
+  "URLCLASSIFIER_LC_PREFIXES": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 1500000,
+    "n_buckets": 15,
+    "description": "Size of the prefix cache in entries"
+  },
+  "URLCLASSIFIER_LC_COMPLETIONS": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 200,
+    "n_buckets": 10,
+    "description": "Size of the completion cache in entries"
+  },
+  "URLCLASSIFIER_UPDATE_REMOTE_NETWORK_ERROR": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "60",
+    "kind": "enumerated",
+    "keyed": true,
+    "n_values": 30,
+    "bug_numbers": [1332780],
+    "description": "Network error from SafeBrowsing database updates. (0=sucess, 1=unknown error, 2=already connected, 3=not connected, 4=connection refused,5=net timeout, 6=offline, 7=port access not allowed, 8=net reset, 9=net interrupt, 10=proxy connection refused,11=partial transfer,12=inadequate security,13=unknown host,14=dns lookup queue full,15=unknown proxy host"
+  },
+  "URLCLASSIFIER_UPDATE_REMOTE_STATUS2": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "keyed": true,
+    "n_values": 16,
+    "bug_numbers": [1311910],
+    "description": "Server HTTP status code from SafeBrowsing database updates. (0=1xx, 1=200, 2=2xx, 3=204, 4=3xx, 5=400, 6=4xx, 7=403, 8=404, 9=408, 10=413, 11=5xx, 12=502|504|511, 13=503, 14=505, 15=Other). Keyed by provider"
+  },
+  "URLCLASSIFIER_COMPLETE_REMOTE_STATUS2": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "keyed": true,
+    "n_values": 16,
+    "bug_numbers": [1150921, 1311926],
+    "description": "Server HTTP status code from remote SafeBrowsing gethash lookups. (0=1xx, 1=200, 2=2xx, 3=204, 4=3xx, 5=400, 6=4xx, 7=403, 8=404, 9=408, 10=413, 11=5xx, 12=502|504|511, 13=503, 14=505, 15=Other). Keyed by provider"
+  },
+  "URLCLASSIFIER_COMPLETION_ERROR": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "59",
+    "kind": "enumerated",
+    "n_values": 16,
+    "bug_numbers": [1276826],
+    "description": "SafeBrowsing v4 hash completion error (0 = success, 1 = parsing failure, 2 = unknown threat type)"
+  },
+  "URLCLASSIFIER_COMPLETE_TIMEOUT2": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "59",
+    "kind": "boolean",
+    "keyed": true,
+    "bug_numbers": [1172688, 1311926],
+    "description": "This metric is recorded every time a gethash lookup is performed, `true` is recorded if the lookup times out. Keyed by provider"
+  },
+  "URLCLASSIFIER_UPDATE_ERROR": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "59",
+    "kind": "enumerated",
+    "keyed": true,
+    "n_values": 16,
+    "bug_numbers": [1311910],
+    "description": "Whether or not an error was encountered while processing a Safe Browsing update (0 = success, 1 = unspecified error, 2 = addition of an already existing prefix, 3 = parser got into an infinite loop, 4 = removal index out of bounds, 5 = checksum mismatch, 6 = missing checksum, 7 = update while shutdown, 8 = cannot find table, 9 = build prefix failure, 10 = write disk failure, 11 = protocol parser error). Keyed by provider"
+  },
+  "URLCLASSIFIER_PREFIX_MATCH": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "58",
+    "kind": "enumerated",
+    "n_values": 4,
+    "bug_numbers": [1298257],
+    "description": "Classifier prefix matching result (0 = no match, 1 = match only V2, 2 = match only V4, 3 = match both V2 and V4)"
+  },
+  "URLCLASSIFIER_MATCH_RESULT": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "60",
+    "kind": "enumerated",
+    "n_values": 16,
+    "bug_numbers": [1311931],
+    "description": "The result of each URL lookup against both google and google4 lists(0 = no match, 1 = V2 prefix only, 2 = V4 prefix only, 3 = V2 and V4 prefixes, 4 = V2 and V4 completions, 5 = V2 completion only, 6 = V4 completion only, 7 = V2 completion and v4 prefix, 8 = V2 prefix and V4 completion, 9 = unexpected result)"
+  },
+  "URLCLASSIFIER_POSITIVE_CACHE_DURATION": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "60",
+    "kind": "exponential",
+    "high": 86400000,
+    "n_buckets": 50,
+    "bug_numbers": [1338082],
+    "description": "Positive cache duration (ms) received in fullhash response from any v4 provider"
+  },
+  "URLCLASSIFIER_NEGATIVE_CACHE_DURATION": {
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "expires_in_version": "60",
+    "kind": "exponential",
+    "high": 86400000,
+    "n_buckets": 50,
+    "bug_numbers": [1338082],
+    "description": "Negative cache duration (ms) received in fullhash response from any v4 provider"
+  },
+  "CSP_DOCUMENTS_COUNT": {
+    "alert_emails": ["seceng@mozilla.com"],
+    "bug_numbers": [1252829],
+    "expires_in_version": "55",
+    "kind": "count",
+    "description": "Number of unique pages that contain a CSP"
+  },
+  "CSP_UNSAFE_INLINE_DOCUMENTS_COUNT": {
+    "alert_emails": ["seceng@mozilla.com"],
+    "bug_numbers": [1252829],
+    "expires_in_version": "55",
+    "kind": "count",
+    "description": "Number of unique pages that contain an unsafe-inline CSP directive"
+  },
+  "CSP_UNSAFE_EVAL_DOCUMENTS_COUNT": {
+    "alert_emails": ["seceng@mozilla.com"],
+    "bug_numbers": [1252829],
+    "expires_in_version": "55",
+    "kind": "count",
+    "description": "Number of unique pages that contain an unsafe-eval CSP directive"
+  },
+  "CSP_REFERRER_DIRECTIVE": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "bug_numbers": [1303685],
+    "expires_in_version": "56",
+    "kind": "boolean",
+    "description": "Whether a document with a CSP policy (report-only or enforcing) contains a referrer directive ('true') or not ('false')."
+  },
+  "PLACES_PAGES_COUNT": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 1000,
+    "high": 150000,
+    "n_buckets": 20,
+    "releaseChannelCollection": "opt-out",
+    "description": "PLACES: Number of unique pages"
+  },
+  "PLACES_MOST_RECENT_EXPIRED_VISIT_DAYS": {
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "low": 30,
+    "high": 730,
+    "n_buckets": 12,
+    "description": "PLACES: the most recent expired visit in days"
+  },
+  "PLACES_BOOKMARKS_COUNT": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 100,
+    "high": 8000,
+    "n_buckets": 15,
+    "releaseChannelCollection": "opt-out",
+    "description": "PLACES: Number of bookmarks"
+  },
+  "PLACES_TAGS_COUNT": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 200,
+    "n_buckets": 10,
+    "description": "PLACES: Number of tags"
+  },
+  "PLACES_KEYWORDS_COUNT": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 200,
+    "n_buckets": 10,
+    "description": "PLACES: Number of keywords"
+  },
+  "PLACES_BACKUPS_DAYSFROMLAST": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 15,
+    "description": "PLACES: Days from last backup"
+  },
+  "PLACES_BACKUPS_BOOKMARKSTREE_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 50,
+    "high": 2000,
+    "n_buckets": 10,
+    "description": "PLACES: Time to build the bookmarks tree"
+  },
+  "PLACES_BACKUPS_TOJSON_MS": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "low": 50,
+    "high": 2000,
+    "n_buckets": 10,
+    "description": "PLACES: Time to convert and write the backup"
+  },
+  "PLACES_EXPORT_TOHTML_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 50,
+    "high": 2000,
+    "n_buckets": 10,
+    "description": "PLACES: Time to convert and write bookmarks.html"
+  },
+  "PLACES_FAVICON_ICO_SIZES": {
+    "expires_in_version" : "never",
+    "kind": "exponential",
+    "high": 524288,
+    "n_buckets" : 100,
+    "description": "PLACES: Size of the ICO favicon files loaded from the web (Bytes)"
+  },
+  "PLACES_FAVICON_PNG_SIZES": {
+    "expires_in_version" : "never",
+    "kind": "exponential",
+    "high": 524288,
+    "n_buckets" : 100,
+    "description": "PLACES: Size of the PNG favicon files loaded from the web (Bytes)"
+  },
+  "PLACES_FAVICON_GIF_SIZES": {
+    "expires_in_version" : "never",
+    "kind": "exponential",
+    "high": 524288,
+    "n_buckets" : 100,
+    "description": "PLACES: Size of the GIF favicon files loaded from the web (Bytes)"
+  },
+  "PLACES_FAVICON_JPEG_SIZES": {
+    "expires_in_version" : "never",
+    "kind": "exponential",
+    "high": 524288,
+    "n_buckets" : 100,
+    "description": "PLACES: Size of the JPEG favicon files loaded from the web (Bytes)"
+  },
+  "PLACES_FAVICON_BMP_SIZES": {
+    "expires_in_version" : "never",
+    "kind": "exponential",
+    "high": 524288,
+    "n_buckets" : 100,
+    "description": "PLACES: Size of the BMP favicon files loaded from the web (Bytes)"
+  },
+  "PLACES_FAVICON_SVG_SIZES": {
+    "expires_in_version" : "never",
+    "kind": "exponential",
+    "high": 524288,
+    "n_buckets" : 100,
+    "description": "PLACES: Size of the SVG favicon files loaded from the web (Bytes)"
+  },
+  "PLACES_FAVICON_OTHER_SIZES": {
+    "expires_in_version" : "never",
+    "kind": "exponential",
+    "high": 524288,
+    "n_buckets" : 100,
+    "description": "PLACES: Size of favicon files without a specific file type probe, loaded from the web (Bytes)"
+  },
+  "LINK_ICON_SIZES_ATTR_USAGE": {
+    "expires_in_version" : "never",
+    "kind": "enumerated",
+    "n_values": 4,
+    "description": "The possible types of the 'sizes' attribute for <link rel=icon>. 0: Attribute not specified, 1: 'any', 2: Integer dimensions, 3: Invalid value."
+  },
+  "LINK_ICON_SIZES_ATTR_DIMENSION": {
+    "expires_in_version" : "never",
+    "kind": "linear",
+    "high": 513,
+    "n_buckets" : 64,
+    "description": "The width dimension of the 'sizes' attribute for <link rel=icon>."
+  },
+  "FENNEC_DISTRIBUTION_REFERRER_INVALID": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether the referrer intent specified an invalid distribution name",
+    "cpp_guard": "ANDROID"
+  },
+  "FENNEC_DISTRIBUTION_CODE_CATEGORY": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 20,
+    "description": "First digit of HTTP result code, or error category, during distribution download",
+    "cpp_guard": "ANDROID"
+  },
+  "FENNEC_DISTRIBUTION_DOWNLOAD_TIME_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 100,
+    "high": 40000,
+    "n_buckets": 30,
+    "description": "Time taken to download a specified distribution file (msec)",
+    "cpp_guard": "ANDROID"
+  },
+  "FENNEC_BOOKMARKS_COUNT": {
+    "expires_in_version": "60",
+    "kind": "exponential",
+    "high": 8000,
+    "n_buckets": 20,
+    "description": "Number of bookmarks stored in the browser DB",
+    "alert_emails": ["mobile-frontend@mozilla.com"],
+    "bug_numbers": [1244704]
+  },
+  "FENNEC_ORBOT_INSTALLED": {
+    "expires_in_version": "60",
+    "kind": "flag",
+    "cpp_guard": "ANDROID",
+    "description": "Whether or not users have Orbot installed",
+    "alert_emails": ["seceng@mozilla.org"],
+    "bug_numbers": [1314784]
+  },
+  "FENNEC_READING_LIST_COUNT": {
+    "expires_in_version": "50",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 10,
+    "cpp_guard": "ANDROID",
+    "description": "Number of reading list items stored in the browser DB *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "FENNEC_READER_VIEW_CACHE_SIZE": {
+    "expires_in_version": "60",
+    "alert_emails": ["mobile-frontend@mozilla.com"],
+    "kind": "exponential",
+    "low": 32,
+    "high": 51200,
+    "n_buckets": 20,
+    "description": "Total disk space used by items in the reader view cache (KB)",
+    "bug_numbers": [1246159]
+  },
+  "FENNEC_LOOP_UI_LATENCY": {
+    "expires_in_version": "55",
+    "alert_emails": ["mobile-platform@mozilla.org"],
+    "kind": "exponential",
+    "low": 10,
+    "high": 10485760,
+    "n_buckets": 22,
+    "description": "Latency in microseconds of UI events in the Android event loop between posting and processing",
+    "bug_numbers": [1322574],
+    "cpp_guard": "MOZ_WIDGET_ANDROID"
+  },
+  "FENNEC_LOOP_OTHER_LATENCY": {
+    "expires_in_version": "55",
+    "alert_emails": ["mobile-platform@mozilla.org"],
+    "kind": "exponential",
+    "low": 10,
+    "high": 10485760,
+    "n_buckets": 22,
+    "description": "Latency in microseconds of non-UI events in the Android event loop between posting and processing",
+    "bug_numbers": [1322574],
+    "cpp_guard": "MOZ_WIDGET_ANDROID"
+  },
+  "PLACES_SORTED_BOOKMARKS_PERC": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 100,
+    "n_buckets": 10,
+    "description": "PLACES: Percentage of bookmarks organized in folders"
+  },
+  "PLACES_TAGGED_BOOKMARKS_PERC": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 100,
+    "n_buckets": 10,
+    "description": "PLACES: Percentage of tagged bookmarks"
+  },
+  "PLACES_DATABASE_FILESIZE_MB": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 5,
+    "high": 200,
+    "n_buckets": 10,
+    "description": "PLACES: Database filesize (MB)"
+  },
+  "PLACES_DATABASE_PAGESIZE_B": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 1024,
+    "high": 32768,
+    "n_buckets": 10,
+    "description": "PLACES: Database page size (bytes)"
+  },
+  "PLACES_DATABASE_SIZE_PER_PAGE_B": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 500,
+    "high": 10240,
+    "n_buckets": 20,
+    "description": "PLACES: Average size of a place in the database (bytes)"
+  },
+  "PLACES_EXPIRATION_STEPS_TO_CLEAN2": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "PLACES: Expiration steps to cleanup the database"
+  },
+  "PLACES_AUTOCOMPLETE_1ST_RESULT_TIME_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 50,
+    "high": 500,
+    "n_buckets": 10,
+    "description": "PLACES: Time for first autocomplete result if > 50ms (ms)"
+  },
+  "PLACES_AUTOCOMPLETE_6_FIRST_RESULTS_TIME_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 50,
+    "high": 1000,
+    "n_buckets": 30,
+    "description": "PLACES: Time for the 6 first autocomplete results (ms)"
+  },
+  "HISTORY_LASTVISITED_TREE_QUERY_TIME_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 50,
+    "high": 2000,
+    "n_buckets": 30,
+    "description": "PLACES: Time to load the sidebar history tree sorted by last visit (ms)"
+  },
+  "PLACES_HISTORY_LIBRARY_SEARCH_TIME_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 50,
+    "high": 1000,
+    "n_buckets": 30,
+    "description": "PLACES: Time to search the history library (ms)"
+  },
+  "PLACES_AUTOCOMPLETE_URLINLINE_DOMAIN_QUERY_TIME_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 50,
+    "high": 2000,
+    "n_buckets": 10,
+    "description": "PLACES: Duration of the domain query for the url inline autocompletion (ms)"
+  },
+  "PLACES_IDLE_FRECENCY_DECAY_TIME_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 50,
+    "high": 10000,
+    "n_buckets": 10,
+    "description": "PLACES: Time to decay all frecencies values on idle (ms)"
+  },
+  "PLACES_IDLE_MAINTENANCE_TIME_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 1000,
+    "high": 30000,
+    "n_buckets": 10,
+    "description": "PLACES: Time to execute maintenance tasks on idle (ms)"
+  },
+  "PLACES_ANNOS_BOOKMARKS_COUNT": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 50,
+    "high": 5000,
+    "n_buckets": 10,
+    "description": "PLACES: Number of bookmarks annotations"
+  },
+  "PLACES_ANNOS_PAGES_COUNT": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 50,
+    "high": 5000,
+    "n_buckets": 10,
+    "description": "PLACES: Number of pages annotations"
+  },
+  "PLACES_MAINTENANCE_DAYSFROMLAST": {
+    "expires_in_version" : "never",
+    "kind": "exponential",
+    "low": 7,
+    "high": 60,
+    "n_buckets" : 10,
+    "description": "PLACES: Days from last maintenance"
+  },
+  "UPDATE_CHECK_NO_UPDATE_EXTERNAL" : {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: count of no updates were found for a background update check (externally initiated)"
+  },
+  "UPDATE_CHECK_NO_UPDATE_NOTIFY" : {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: count of no updates were found for a background update check (timer initiated)"
+  },
+  "UPDATE_CHECK_CODE_EXTERNAL": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 50,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: background update check result code except for no updates found (externally initiated)"
+  },
+  "UPDATE_CHECK_CODE_NOTIFY": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 50,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: background update check result code except for no updates found (timer initiated)"
+  },
+  "UPDATE_CHECK_EXTENDED_ERROR_EXTERNAL": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "keyed": true,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: keyed count (key names are prefixed with AUS_CHECK_EX_ERR_) of background update check extended error code (externally initiated)"
+  },
+  "UPDATE_CHECK_EXTENDED_ERROR_NOTIFY": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "keyed": true,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: keyed count (key names are prefixed with AUS_CHECK_EX_ERR_) of background update check extended error code (timer initiated)"
+  },
+  "UPDATE_INVALID_LASTUPDATETIME_EXTERNAL": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: count of systems that have a last update time greater than the current time (externally initiated)"
+  },
+  "UPDATE_INVALID_LASTUPDATETIME_NOTIFY": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: count of systems that have a last update time greater than the current time (timer initiated)"
+  },
+  "UPDATE_LAST_NOTIFY_INTERVAL_DAYS_EXTERNAL": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "n_buckets": 60,
+    "high": 365,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: interval in days since the last background update check (externally initiated)"
+  },
+  "UPDATE_LAST_NOTIFY_INTERVAL_DAYS_NOTIFY": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "n_buckets": 30,
+    "high": 180,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: interval in days since the last background update check (timer initiated)"
+  },
+  "UPDATE_PING_COUNT_EXTERNAL": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: count of systems for this ping for comparison with other pings (externally initiated)"
+  },
+  "UPDATE_PING_COUNT_NOTIFY": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: count of systems for this ping for comparison with other pings (timer initiated)"
+  },
+  "UPDATE_SERVICE_INSTALLED_EXTERNAL": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: whether the service is installed (externally initiated)"
+  },
+  "UPDATE_SERVICE_INSTALLED_NOTIFY": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: whether the service is installed (timer initiated)"
+  },
+  "UPDATE_SERVICE_MANUALLY_UNINSTALLED_EXTERNAL": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: count of systems that manually uninstalled the service (externally initiated)"
+  },
+  "UPDATE_SERVICE_MANUALLY_UNINSTALLED_NOTIFY": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: count of systems that manually uninstalled the service (timer initiated)"
+  },
+  "UPDATE_UNABLE_TO_APPLY_EXTERNAL": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: count of systems that cannot apply updates (externally initiated)"
+  },
+  "UPDATE_UNABLE_TO_APPLY_NOTIFY": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: count of systems that cannot apply updates (timer initiated)"
+  },
+  "UPDATE_CANNOT_STAGE_EXTERNAL": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: count of systems that cannot stage updates (externally initiated)"
+  },
+  "UPDATE_CANNOT_STAGE_NOTIFY": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: count of systems that cannot stage updates (timer initiated)"
+  },
+  "UPDATE_PREF_UPDATE_CANCELATIONS_EXTERNAL": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 100,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: number of sequential update elevation request cancelations greater than 0 (externally initiated)"
+  },
+  "UPDATE_PREF_UPDATE_CANCELATIONS_NOTIFY": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 100,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: number of sequential update elevation request cancelations greater than 0 (timer initiated)"
+  },
+  "UPDATE_PREF_SERVICE_ERRORS_EXTERNAL": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 30,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: number of sequential update service errors greater than 0 (externally initiated)"
+  },
+  "UPDATE_PREF_SERVICE_ERRORS_NOTIFY": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 30,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: number of sequential update service errors greater than 0 (timer initiated)"
+  },
+  "UPDATE_NOT_PREF_UPDATE_AUTO_EXTERNAL": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: count of when the app.update.auto boolean preference is not the default value of true (true values are not submitted)"
+  },
+  "UPDATE_NOT_PREF_UPDATE_AUTO_NOTIFY": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: count of when the app.update.auto boolean preference is not the default value of true (true values are not submitted)"
+  },
+  "UPDATE_NOT_PREF_UPDATE_ENABLED_EXTERNAL": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: count of when the app.update.enabled boolean preference is not the default value of true (true values are not submitted)"
+  },
+  "UPDATE_NOT_PREF_UPDATE_ENABLED_NOTIFY": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: count of when the app.update.enabled boolean preference is not the default value of true (true values are not submitted)"
+  },
+  "UPDATE_NOT_PREF_UPDATE_STAGING_ENABLED_EXTERNAL": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: count of when the app.update.staging.enabled boolean preference is not the default value of true (true values are not submitted)"
+  },
+  "UPDATE_NOT_PREF_UPDATE_STAGING_ENABLED_NOTIFY": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: count of when the app.update.staging.enabled boolean preference is not the default value of true (true values are not submitted)"
+  },
+  "UPDATE_NOT_PREF_UPDATE_SERVICE_ENABLED_EXTERNAL": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: count of when the app.update.service.enabled boolean preference is not the default value of true (true values are not submitted)"
+  },
+  "UPDATE_NOT_PREF_UPDATE_SERVICE_ENABLED_NOTIFY": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: count of when the app.update.service.enabled boolean preference is not the default value of true (true values are not submitted)"
+  },
+  "UPDATE_DOWNLOAD_CODE_COMPLETE": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 50,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: complete patch download result code"
+  },
+  "UPDATE_DOWNLOAD_CODE_PARTIAL": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 50,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: complete patch download result code"
+  },
+  "UPDATE_STATE_CODE_COMPLETE_STARTUP": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 20,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: the state of a complete update from update.status on startup"
+  },
+  "UPDATE_STATE_CODE_PARTIAL_STARTUP": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 20,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: the state of a partial patch update from update.status on startup"
+  },
+  "UPDATE_STATE_CODE_UNKNOWN_STARTUP": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 20,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: the state of an unknown patch update from update.status on startup"
+  },
+  "UPDATE_STATE_CODE_COMPLETE_STAGE": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 20,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: the state of a complete patch update from update.status after staging"
+  },
+  "UPDATE_STATE_CODE_PARTIAL_STAGE": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 20,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: the state of a partial patch update from update.status after staging"
+  },
+  "UPDATE_STATE_CODE_UNKNOWN_STAGE": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 20,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: the state of an unknown patch update from update.status after staging"
+  },
+  "UPDATE_STATUS_ERROR_CODE_COMPLETE_STARTUP": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 100,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: the status error code for a failed complete patch update from update.status on startup"
+  },
+  "UPDATE_STATUS_ERROR_CODE_PARTIAL_STARTUP": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 100,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: the status error code for a failed partial patch update from update.status on startup"
+  },
+  "UPDATE_STATUS_ERROR_CODE_UNKNOWN_STARTUP": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 100,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: the status error code for a failed unknown patch update from update.status on startup"
+  },
+  "UPDATE_STATUS_ERROR_CODE_COMPLETE_STAGE": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 100,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: the status error code for a failed complete patch update from update.status after staging"
+  },
+  "UPDATE_STATUS_ERROR_CODE_PARTIAL_STAGE": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 100,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: the status error code for a failed partial patch update from update.status after staging"
+  },
+  "UPDATE_STATUS_ERROR_CODE_UNKNOWN_STAGE": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 100,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: the status error code for a failed unknown patch update from update.status after staging"
+  },
+  "UPDATE_WIZ_LAST_PAGE_CODE": {
+    "alert_emails": ["application-update-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 30,
+    "releaseChannelCollection": "opt-out",
+    "description": "Update: the update wizard page displayed when the UI was closed (mapped in toolkit/mozapps/update/UpdateTelemetry.jsm)"
+  },
+  "THUNDERBIRD_GLODA_SIZE_MB": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 1000,
+    "n_buckets": 40,
+    "description": "Gloda: size of global-messages-db.sqlite (MB)"
+  },
+  "THUNDERBIRD_CONVERSATIONS_TIME_TO_2ND_GLODA_QUERY_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 30,
+    "description": "Conversations: time between the moment we click and the second gloda query returns (ms)"
+  },
+  "THUNDERBIRD_INDEXING_RATE_MSG_PER_S": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 100,
+    "n_buckets": 20,
+    "description": "Gloda: indexing rate (message/s)"
+  },
+  "FX_GESTURE_INSTALL_SNAPSHOT_OF_PAGE": {
+    "expires_in_version": "50",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 30,
+    "description": "Firefox: Time taken to store the image capture of the page to a canvas, for reuse while swiping through history (ms)."
+  },
+  "FX_GESTURE_COMPRESS_SNAPSHOT_OF_PAGE": {
+    "expires_in_version": "50",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 30,
+    "description": "Firefox: Time taken to kick off image compression of the canvas that will be used during swiping through history (ms)."
+  },
+  "FX_TAB_ANIM_OPEN_PREVIEW_FRAME_INTERVAL_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 7,
+    "high": 500,
+    "n_buckets": 50,
+    "description": "Average frame interval during tab open animation of about:newtab (preview=on), when other tabs are unaffected"
+  },
+  "FX_TAB_ANIM_OPEN_FRAME_INTERVAL_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 7,
+    "high": 500,
+    "n_buckets": 50,
+    "description": "Average frame interval during tab open animation of about:newtab (preview=off), when other tabs are unaffected"
+  },
+  "FX_TAB_ANIM_ANY_FRAME_INTERVAL_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 7,
+    "high": 500,
+    "n_buckets": 50,
+    "description": "Average frame interval during any tab open/close animation (excluding tabstrip scroll)"
+  },
+  "FX_REFRESH_DRIVER_CHROME_FRAME_DELAY_MS": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "bug_numbers": [1220699],
+    "description": "Delay in ms between the target and the actual handling time of the frame at refresh driver in the chrome process."
+  },
+  "FX_REFRESH_DRIVER_CONTENT_FRAME_DELAY_MS": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "bug_numbers": [1221674],
+    "description": "Delay in ms between the target and the actual handling time of the frame at refresh driver in the content process."
+  },
+  "FX_REFRESH_DRIVER_SYNC_SCROLL_FRAME_DELAY_MS": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "bug_numbers": [1228147],
+    "description": "Delay in ms between the target and the actual handling time of the frame at refresh driver while scrolling synchronously."
+  },
+  "FX_TAB_SWITCH_UPDATE_MS": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 20,
+    "description": "Firefox: Time in ms spent updating UI in response to a tab switch"
+  },
+  "FX_TAB_SWITCH_TOTAL_MS": {
+    "expires_in_version": "56",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 20,
+    "releaseChannelCollection": "opt-out",
+    "description": "Firefox: Time in ms till a tab switch is complete including the first paint"
+  },
+  "FX_TAB_SWITCH_TOTAL_E10S_MS": {
+    "expires_in_version": "56",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 20,
+    "releaseChannelCollection": "opt-out",
+    "description": "Firefox: Time in ms between tab selection and tab content paint."
+  },
+  "FX_TAB_SWITCH_SPINNER_VISIBLE_MS": {
+    "expires_in_version": "56",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 20,
+    "releaseChannelCollection": "opt-out",
+    "description": "Firefox: If the spinner interstitial displays during tab switching, records the time in ms the graphic is visible"
+  },
+  "FX_TAB_SWITCH_SPINNER_VISIBLE_LONG_MS": {
+    "expires_in_version": "56",
+    "kind": "exponential",
+    "low": 1000,
+    "high": 64000,
+    "n_buckets": 7,
+    "bug_numbers": [1301104],
+    "alert_emails": ["mconley@mozilla.com"],
+    "releaseChannelCollection": "opt-out",
+    "description": "Firefox: If the spinner interstitial displays during tab switching, records the time in ms the graphic is visible. This probe is similar to FX_TAB_SWITCH_SPINNER_VISIBLE_MS, but is for truly degenerate cases."
+  },
+  "FX_TAB_SWITCH_SPINNER_TYPE": {
+    "expires_in_version": "60",
+    "kind": "categorical",
+    "bug_numbers": [1301104],
+    "alert_emails": ["mconley@mozilla.com"],
+    "releaseChannelCollection": "opt-out",
+    "description": "Firefox: If the spinner interstitial displays during tab switching, record if the tab being switched to has been seen (content was visible) before. If not, record if the tab is 'old' (> 1000ms since creation) or 'new'.",
+    "labels": ["seen", "unseenOld", "unseenNew"]
+  },
+  "FX_TAB_CLICK_MS": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 20,
+    "description": "Firefox: Time in ms spent on switching tabs in response to a tab click"
+  },
+  "FX_BOOKMARKS_TOOLBAR_INIT_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 50,
+    "high": 5000,
+    "n_buckets": 10,
+    "description": "Firefox: Time to initialize the bookmarks toolbar view (ms)"
+  },
+  "FX_BROWSER_FULLSCREEN_USED": {
+    "expires_in_version": "46",
+    "kind": "count",
+    "description": "The number of times that a session enters browser fullscreen (f11-fullscreen)"
+  },
+  "FX_NEW_WINDOW_MS": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "description": "Firefox: Time taken to open a new browser window (ms)"
+  },
+  "FX_PAGE_LOAD_MS": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "description": "Firefox: Time taken to load a page (ms). This includes all static contents, no dynamic content. Loading of about: pages is not counted."
+  },
+  "FX_TOTAL_TOP_VISITS": {
+    "expires_in_version": "default",
+    "kind": "boolean",
+    "description": "Count the number of times a new top page was starting to load"
+  },
+  "FX_THUMBNAILS_CAPTURE_TIME_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 500,
+    "n_buckets": 15,
+    "description": "THUMBNAILS: Time (ms) it takes to capture a thumbnail"
+  },
+  "FX_THUMBNAILS_STORE_TIME_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 500,
+    "n_buckets": 15,
+    "description": "THUMBNAILS: Time (ms) it takes to store a thumbnail in the cache"
+  },
+  "FX_THUMBNAILS_HIT_OR_MISS": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "THUMBNAILS: Thumbnail found"
+  },
+  "FX_MIGRATION_ENTRY_POINT": {
+    "bug_numbers": [731025],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "57",
+    "kind": "enumerated",
+    "n_values": 10,
+    "releaseChannelCollection": "opt-out",
+    "description": "Where the migration wizard was entered from. 0=Other/catch-all, 1=first-run, 2=refresh-firefox, 3=Places window, 4=Password manager"
+  },
+  "FX_MIGRATION_SOURCE_BROWSER": {
+    "bug_numbers": [731025],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "57",
+    "kind": "enumerated",
+    "n_values": 15,
+    "releaseChannelCollection": "opt-out",
+    "description": "The browser that data is pulled from. The values correspond to the internal browser ID (see MigrationUtils.jsm)"
+  },
+  "FX_MIGRATION_ERRORS": {
+    "bug_numbers": [731025],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "57",
+    "kind": "enumerated",
+    "keyed": true,
+    "n_values": 12,
+    "releaseChannelCollection": "opt-out",
+    "description": "Errors encountered during migration in buckets defined by the datatype, keyed by the string description of the browser."
+  },
+  "FX_MIGRATION_USAGE": {
+    "bug_numbers": [731025],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "57",
+    "kind": "enumerated",
+    "keyed": true,
+    "n_values": 12,
+    "releaseChannelCollection": "opt-out",
+    "description": "Usage of migration for each datatype when migration is run through the post-firstrun flow which allows individual datatypes, keyed by the string description of the browser."
+  },
+  "FX_MIGRATION_IMPORTED_HOMEPAGE": {
+    "bug_numbers": [731025, 1298208],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "57",
+    "kind": "boolean",
+    "keyed": true,
+    "releaseChannelCollection": "opt-out",
+    "description": "Whether the homepage was imported during browser migration. Only available on release builds during firstrun."
+  },
+  "FX_MIGRATION_BOOKMARKS_IMPORT_MS": {
+    "bug_numbers": [1289436],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "57",
+    "kind": "exponential",
+    "n_buckets": 70,
+    "high": 100000,
+    "releaseChannelCollection": "opt-out",
+    "keyed": true,
+    "description": "How long it took to import bookmarks from another browser, keyed by the name of the browser."
+  },
+  "FX_MIGRATION_HISTORY_IMPORT_MS": {
+    "bug_numbers": [1289436],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "57",
+    "kind": "exponential",
+    "n_buckets": 70,
+    "high": 100000,
+    "releaseChannelCollection": "opt-out",
+    "keyed": true,
+    "description": "How long it took to import history from another browser, keyed by the name of the browser."
+  },
+  "FX_MIGRATION_LOGINS_IMPORT_MS": {
+    "bug_numbers": [1289436],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "57",
+    "kind": "exponential",
+    "n_buckets": 70,
+    "high": 100000,
+    "releaseChannelCollection": "opt-out",
+    "keyed": true,
+    "description": "How long it took to import logins (passwords) from another browser, keyed by the name of the browser."
+  },
+  "FX_MIGRATION_BOOKMARKS_JANK_MS": {
+    "bug_numbers": [1338522],
+    "alert_emails": ["dao@mozilla.com"],
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "n_buckets": 20,
+    "high": 60000,
+    "releaseChannelCollection": "opt-out",
+    "keyed": true,
+    "description": "Accumulated timer delay (variance between when the timer was expected to fire and when it actually fired) in milliseconds as an indicator for decreased main-thread responsiveness while importing bookmarks from another browser, keyed by the name of the browser (see gAvailableMigratorKeys in MigrationUtils.jsm). The import is happening on a background thread and should ideally not affect the UI noticeably."
+  },
+  "FX_MIGRATION_HISTORY_JANK_MS": {
+    "bug_numbers": [1338522],
+    "alert_emails": ["dao@mozilla.com"],
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "n_buckets": 20,
+    "high": 60000,
+    "releaseChannelCollection": "opt-out",
+    "keyed": true,
+    "description": "Accumulated timer delay (variance between when the timer was expected to fire and when it actually fired) in milliseconds as an indicator for decreased main-thread responsiveness while importing history from another browser, keyed by the name of the browser (see gAvailableMigratorKeys in MigrationUtils.jsm). The import is happening on a background thread and should ideally not affect the UI noticeably."
+  },
+  "FX_MIGRATION_LOGINS_JANK_MS": {
+    "bug_numbers": [1338522],
+    "alert_emails": ["dao@mozilla.com"],
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "n_buckets": 20,
+    "high": 60000,
+    "releaseChannelCollection": "opt-out",
+    "keyed": true,
+    "description": "Accumulated timer delay (variance between when the timer was expected to fire and when it actually fired) in milliseconds as an indicator for decreased main-thread responsiveness while importing logins / passwords from another browser, keyed by the name of the browser (see gAvailableMigratorKeys in MigrationUtils.jsm). The import is happening on a background thread and should ideally not affect the UI noticeably."
+  },
+  "FX_MIGRATION_BOOKMARKS_QUANTITY": {
+    "bug_numbers": [1279501],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "57",
+    "kind": "exponential",
+    "n_buckets": 20,
+    "high": 1000,
+    "releaseChannelCollection": "opt-out",
+    "keyed": true,
+    "description": "How many bookmarks we imported from another browser, keyed by the name of the browser."
+  },
+  "FX_MIGRATION_HISTORY_QUANTITY": {
+    "bug_numbers": [1279501],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "57",
+    "kind": "exponential",
+    "n_buckets": 40,
+    "high": 10000,
+    "releaseChannelCollection": "opt-out",
+    "keyed": true,
+    "description": "How many history visits we imported from another browser, keyed by the name of the browser."
+  },
+  "FX_MIGRATION_LOGINS_QUANTITY": {
+    "bug_numbers": [1279501],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "57",
+    "kind": "exponential",
+    "n_buckets": 20,
+    "high": 1000,
+    "releaseChannelCollection": "opt-out",
+    "keyed": true,
+    "description": "How many logins (passwords) we imported from another browser, keyed by the name of the browser."
+  },
+  "FX_STARTUP_MIGRATION_BROWSER_COUNT": {
+    "bug_numbers": [1275114],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "57",
+    "kind": "enumerated",
+    "n_values": 15,
+    "releaseChannelCollection": "opt-out",
+    "description": "Number of browsers from which the user could migrate on initial profile migration. Only available on release builds during firstrun."
+  },
+  "FX_STARTUP_MIGRATION_EXISTING_DEFAULT_BROWSER": {
+    "bug_numbers": [1275114],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "57",
+    "kind": "enumerated",
+    "n_values": 15,
+    "releaseChannelCollection": "opt-out",
+    "description": "The browser that was the default on the initial profile migration. The values correspond to the internal browser ID (see MigrationUtils.jsm)"
+  },
+  "FX_STARTUP_MIGRATION_AUTOMATED_IMPORT_PROCESS_SUCCESS": {
+    "bug_numbers": [1271775],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "57",
+    "kind": "enumerated",
+    "n_values": 27,
+    "releaseChannelCollection": "opt-out",
+    "description": "Where automatic migration was attempted, indicates to what degree we succeeded. Values 0-25 indicate progress through the automatic migration sequence, with 25 indicating the migration finished. 26 is only used when the migration produced errors before it finished."
+  },
+  "FX_STARTUP_MIGRATION_AUTOMATED_IMPORT_UNDO": {
+    "bug_numbers": [1283565],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "57",
+    "kind": "enumerated",
+    "n_values": 31,
+    "releaseChannelCollection": "opt-out",
+    "description": "Where undo of the automatic migration was attempted, indicates to what degree we succeeded to undo. 0 means we started to undo, 5 means we bailed out from the undo because it was not possible to complete it (there was nothing to undo or the user was signed in to sync). All higher values indicate progression through the undo sequence, with 30 indicating we finished the undo without exceptions in the middle."
+  },
+  "FX_STARTUP_MIGRATION_UNDO_REASON": {
+    "bug_numbers": [1289906],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "57",
+    "keyed": true,
+    "kind": "enumerated",
+    "n_values": 10,
+    "releaseChannelCollection": "opt-out",
+    "description": "Why the undo functionality of an automatic migration was disabled: 0 means we used undo, 1 means the user signed in to sync, 2 means the user created/modified a password, 3 means the user created/modified a bookmark (item or folder), 4 means we showed an undo option repeatedly and the user did not use it, 5 means we showed an undo option and the user actively elected to keep the data. The whole thing is keyed to the identifiers of different browsers (so 'chrome', 'ie', 'edge', 'safari', etc.)."
+  },
+  "FX_STARTUP_MIGRATION_UNDO_OFFERED": {
+    "bug_numbers": [1309617],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "57",
+    "kind": "enumerated",
+    "n_values": 5,
+    "releaseChannelCollection": "opt-out",
+    "description": "Indicates we showed a 'would you like to undo this automatic migration?' notification bar. The bucket indicates which nth day we're on (1st/2nd/3rd, by default - 0 would be indicative the pref didn't get set which shouldn't happen). After 3 days on which the notification gets shown, it will get disabled and never shown again."
+  },
+  "FX_STARTUP_MIGRATION_UNDO_BOOKMARKS_ERRORCOUNT": {
+    "bug_numbers": [1333233],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "58",
+    "keyed": true,
+    "kind": "exponential",
+    "n_buckets": 20,
+    "high": 100,
+    "releaseChannelCollection": "opt-out",
+    "description": "Indicates how many errors we find when trying to 'undo' bookmarks import. Keys are internal ids of browsers we import from, e.g. 'chrome' or 'ie', etc."
+  },
+  "FX_STARTUP_MIGRATION_UNDO_LOGINS_ERRORCOUNT": {
+    "bug_numbers": [1333233],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "58",
+    "keyed": true,
+    "kind": "exponential",
+    "n_buckets": 20,
+    "high": 100,
+    "releaseChannelCollection": "opt-out",
+    "description": "Indicates how many errors we find when trying to 'undo' login (password) import. Keys are internal ids of browsers we import from, e.g. 'chrome' or 'ie', etc."
+  },
+  "FX_STARTUP_MIGRATION_UNDO_VISITS_ERRORCOUNT": {
+    "bug_numbers": [1333233],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "58",
+    "keyed": true,
+    "kind": "exponential",
+    "n_buckets": 20,
+    "high": 100,
+    "releaseChannelCollection": "opt-out",
+    "description": "Indicates how many errors we find when trying to 'undo' history import. Keys are internal ids of browsers we import from, e.g. 'chrome' or 'ie', etc."
+  },
+  "FX_STARTUP_MIGRATION_UNDO_BOOKMARKS_MS": {
+    "bug_numbers": [1333233],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "58",
+    "keyed": true,
+    "kind": "exponential",
+    "n_buckets": 20,
+    "high": 60000,
+    "releaseChannelCollection": "opt-out",
+    "description": "Indicates how long it took to undo the startup import of bookmarks, in ms. Keys are internal ids of browsers we import from, e.g. 'chrome' or 'ie', etc."
+  },
+  "FX_STARTUP_MIGRATION_UNDO_LOGINS_MS": {
+    "bug_numbers": [1333233],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "58",
+    "keyed": true,
+    "kind": "exponential",
+    "n_buckets": 20,
+    "high": 60000,
+    "releaseChannelCollection": "opt-out",
+    "description": "Indicates how long it took to undo the startup import of logins, in ms. Keys are internal ids of browsers we import from, e.g. 'chrome' or 'ie', etc."
+  },
+  "FX_STARTUP_MIGRATION_UNDO_VISITS_MS": {
+    "bug_numbers": [1333233],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "58",
+    "keyed": true,
+    "kind": "exponential",
+    "n_buckets": 20,
+    "high": 60000,
+    "releaseChannelCollection": "opt-out",
+    "description": "Indicates how long it took to undo the startup import of visits (history), in ms. Keys are internal ids of browsers we import from, e.g. 'chrome' or 'ie', etc."
+  },
+  "FX_STARTUP_MIGRATION_UNDO_TOTAL_MS": {
+    "bug_numbers": [1333233],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "58",
+    "keyed": true,
+    "kind": "exponential",
+    "n_buckets": 20,
+    "high": 60000,
+    "releaseChannelCollection": "opt-out",
+    "description": "Indicates how long it took to undo the entirety of the startup undo, in ms. Keys are internal ids of browsers we import from, e.g. 'chrome' or 'ie', etc."
+  },
+  "FX_STARTUP_MIGRATION_DATA_RECENCY": {
+    "bug_numbers": [1276694],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "57",
+    "keyed": true,
+    "kind": "exponential",
+    "n_buckets": 50,
+    "high": 8760,
+    "releaseChannelCollection": "opt-out",
+    "description": "The 'last modified' time of the data we imported on the initial profile migration (time delta with 'now' at the time of migration, in hours). Collected for all browsers for which migration data is available, and stored keyed by browser identifier (e.g. 'ie', 'edge', 'safari', etc.)."
+  },
+  "FX_STARTUP_MIGRATION_USED_RECENT_BROWSER": {
+    "bug_numbers": [1276694],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "57",
+    "keyed": true,
+    "kind": "boolean",
+    "releaseChannelCollection": "opt-out",
+    "description": "Whether the browser we migrated from was the browser with the most recent data. Keyed by that browser's identifier (e.g. 'ie', 'edge', 'safari', etc.)."
+  },
+  "FX_PREFERENCES_CATEGORY_OPENED": {
+    "bug_numbers": [1324167],
+    "alert_emails": ["jaws@mozilla.com"],
+    "expires_in_version": "56",
+    "kind": "categorical",
+    "labels": ["unknown", "general", "search", "content", "applications", "privacy", "security", "sync", "advancedGeneral", "advancedDataChoices", "advancedNetwork", "advancedUpdates", "advancedCerts"],
+    "releaseChannelCollection": "opt-out",
+    "description": "Count how often each preference category is opened."
+  },
+  "INPUT_EVENT_RESPONSE_MS": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1235908],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time (ms) from the Input event being created to the end of it being handled"
+  },
+  "LOAD_INPUT_EVENT_RESPONSE_MS": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1298101],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time (ms) from the Input event being created to the end of it being handled for events handling during page load only"
+  },
+  "EVENTLOOP_UI_ACTIVITY_EXP_MS": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1198196],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 50,
+    "description": "Widget: Time it takes for the message before a UI message (ms)"
+  },
+  "FX_SESSION_RESTORE_STARTUP_INIT_SESSION_MS": {
+    "alert_emails": ["session-restore-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 20,
+    "description": "Session restore: Time it takes to prepare the data structures for restoring a session (ms)"
+  },
+  "FX_SESSION_RESTORE_STARTUP_ONLOAD_INITIAL_WINDOW_MS": {
+    "alert_emails": ["session-restore-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 20,
+    "description": "Session restore: Time it takes to finish restoration once we have first opened a window (ms)"
+  },
+  "FX_SESSION_RESTORE_COLLECT_ALL_WINDOWS_DATA_MS": {
+    "alert_emails": ["session-restore-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 10,
+    "description": "Session restore: Time to collect all window data (ms)"
+  },
+  "FX_SESSION_RESTORE_COLLECT_COOKIES_MS": {
+    "alert_emails": ["session-restore-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 10,
+    "description": "Session restore: Time to collect cookies (ms)"
+  },
+  "FX_SESSION_RESTORE_COLLECT_DATA_MS": {
+    "alert_emails": ["session-restore-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 10,
+    "description": "Session restore: Time to collect all window and tab data (ms)"
+  },
+  "FX_SESSION_RESTORE_COLLECT_DATA_LONGEST_OP_MS": {
+    "alert_emails": ["session-restore-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 10,
+    "description": "Session restore: Duration of the longest uninterruptible operation while collecting all window and tab data (ms)"
+  },
+  "FX_SESSION_RESTORE_CONTENT_COLLECT_DATA_LONGEST_OP_MS": {
+    "alert_emails": ["session-restore-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 10,
+    "description": "Session restore: Duration of the longest uninterruptible operation while collecting data in the content process (ms)"
+  },
+  "FX_SESSION_RESTORE_SERIALIZE_DATA_MS": {
+    "alert_emails": ["session-restore-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 10,
+    "description": "Session restore: Time to JSON serialize session data (ms)"
+  },
+  "FX_SESSION_RESTORE_READ_FILE_MS": {
+    "alert_emails": ["session-restore-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Session restore: Time to read the session data from the file on disk (ms)"
+  },
+  "FX_SESSION_RESTORE_WRITE_FILE_MS": {
+    "alert_emails": ["session-restore-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Session restore: Time to write the session data to the file on disk (ms)"
+  },
+  "FX_SESSION_RESTORE_FILE_SIZE_BYTES": {
+    "alert_emails": ["session-restore-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 50000000,
+    "n_buckets": 30,
+    "description": "Session restore: The size of file sessionstore.js (bytes)"
+  },
+  "FX_SESSION_RESTORE_CORRUPT_FILE": {
+    "alert_emails": ["session-restore-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "default",
+    "kind": "boolean",
+    "description": "Session restore: Whether the file read on startup contained parse-able JSON"
+  },
+  "FX_SESSION_RESTORE_ALL_FILES_CORRUPT": {
+    "alert_emails": ["session-restore-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "default",
+    "kind": "boolean",
+    "description": "Session restore: Whether none of the backup files contained parse-able JSON"
+  },
+  "FX_SESSION_RESTORE_RESTORE_WINDOW_MS": {
+    "alert_emails": ["session-restore-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Session restore: Time spent blocking the main thread while restoring a window state (ms)"
+  },
+  "FX_SESSION_RESTORE_SEND_UPDATE_CAUSED_OOM": {
+    "alert_emails": ["session-restore-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "default",
+    "kind": "count",
+    "description": "Count of messages sent by SessionRestore from child frames to the parent and that cannot be transmitted as they eat up too much memory."
+  },
+  "FX_SESSION_RESTORE_DOM_STORAGE_SIZE_ESTIMATE_CHARS": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 30000000,
+    "n_buckets": 20,
+    "description": "Session restore: Number of characters in DOM Storage for a tab. Pages without DOM Storage or with an empty DOM Storage are ignored."
+  },
+  "FX_SESSION_RESTORE_AUTO_RESTORE_DURATION_UNTIL_EAGER_TABS_RESTORED_MS": {
+    "alert_emails": ["session-restore-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "low": 100,
+    "high": 100000,
+    "n_buckets": 20,
+    "description": "Session restore: If the browser is setup to auto-restore tabs, this probe measures the time elapsed between the instant we start Session Restore and the instant we have finished restoring tabs eagerly. At this stage, the tabs that are restored on demand are not restored yet."
+  },
+  "FX_SESSION_RESTORE_MANUAL_RESTORE_DURATION_UNTIL_EAGER_TABS_RESTORED_MS": {
+    "alert_emails": ["session-restore-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "low": 100,
+    "high": 100000,
+    "n_buckets": 20,
+    "description": "Session restore: If a session is restored by the user clicking on 'Restore Session', this probe measures the time elapsed between the instant the user has clicked and the instant we have finished restoring tabs eagerly. At this stage, the tabs that are restored on demand are not restored yet."
+  },
+  "FX_SESSION_RESTORE_NUMBER_OF_TABS_RESTORED": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 500,
+    "n_buckets": 20,
+    "description": "Session restore: Number of tabs in the session that has just been restored."
+  },
+  "FX_SESSION_RESTORE_NUMBER_OF_WINDOWS_RESTORED": {
+    "expires_in_version": "default",
+    "kind": "enumerated",
+    "n_values": 50,
+    "description": "Session restore: Number of windows in the session that has just been restored."
+  },
+  "FX_SESSION_RESTORE_NUMBER_OF_EAGER_TABS_RESTORED": {
+    "expires_in_version": "default",
+    "kind": "enumerated",
+    "n_values": 50,
+    "description": "Session restore: Number of tabs restored eagerly in the session that has just been restored."
+  },
+  "FX_TABLETMODE_PAGE_LOAD": {
+    "expires_in_version": "47",
+    "kind": "exponential",
+    "high": 100000,
+    "n_buckets": 30,
+    "keyed": true,
+    "description": "Number of toplevel location changes in tablet and desktop mode (only used on win10 where tablet mode is available)"
+  },
+  "FX_TOUCH_USED": {
+    "expires_in_version": "46",
+    "kind": "count",
+    "description": "Windows only. Counts occurrences of touch events"
+  },
+  "FX_URLBAR_SELECTED_RESULT_INDEX": {
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 17,
+    "releaseChannelCollection": "opt-out",
+    "bug_numbers": [775825],
+    "description": "Firefox: The index of the selected result in the URL bar popup"
+  },
+  "FX_URLBAR_SELECTED_RESULT_TYPE": {
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 14,
+    "releaseChannelCollection": "opt-out",
+    "bug_numbers": [775825],
+    "description": "Firefox: The type of the selected result in the URL bar popup. See BrowserUsageTelemetry.jsm:URLBAR_SELECTED_RESULT_TYPES for the result types."
+  },
+  "INNERWINDOWS_WITH_MUTATION_LISTENERS": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Deleted or to-be-reused innerwindow which has had mutation event listeners."
+  },
+  "CHARSET_OVERRIDE_SITUATION": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 8,
+    "description": "Labeling status of top-level page when overriding charset (0: unlabeled file URL without detection, 1: unlabeled non-TLD-guessed non-file URL without detection, 2: unlabeled file URL with detection, 3: unlabeled non-file URL with detection, 4: labeled, 5: already overridden, 6: bug, 7: unlabeled with TLD guessing)"
+  },
+  "CHARSET_OVERRIDE_USED": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether the character encoding menu was used to override an encoding in this session."
+  },
+  "DECODER_INSTANTIATED_ISO2022JP": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether the decoder for ISO-2022-JP has been instantiated in this session."
+  },
+  "DECODER_INSTANTIATED_IBM866": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether the decoder for IBM866 has been instantiated in this session."
+  },
+  "DECODER_INSTANTIATED_MACGREEK": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether the decoder for MACGREEK has been instantiated in this session."
+  },
+  "DECODER_INSTANTIATED_MACICELANDIC": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether the decoder for MACICELANDIC has been instantiated in this session."
+  },
+  "DECODER_INSTANTIATED_MACCE": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether the decoder for MACCE has been instantiated in this session."
+  },
+  "DECODER_INSTANTIATED_MACHEBREW": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether the decoder for MACHEBREW has been instantiated in this session."
+  },
+  "DECODER_INSTANTIATED_MACARABIC": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether the decoder for MACARABIC has been instantiated in this session."
+  },
+  "DECODER_INSTANTIATED_MACFARSI": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether the decoder for MACFARSI has been instantiated in this session."
+  },
+  "DECODER_INSTANTIATED_MACCROATIAN": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether the decoder for MACCROATIAN has been instantiated in this session."
+  },
+  "DECODER_INSTANTIATED_MACCYRILLIC": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether the decoder for MACCYRILLIC has been instantiated in this session."
+  },
+  "DECODER_INSTANTIATED_MACROMANIAN": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether the decoder for MACROMANIAN has been instantiated in this session."
+  },
+  "DECODER_INSTANTIATED_MACTURKISH": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether the decoder for MACTURKISH has been instantiated in this session."
+  },
+  "DECODER_INSTANTIATED_MACDEVANAGARI": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether the decoder for MACDEVANAGARI has been instantiated in this session."
+  },
+  "DECODER_INSTANTIATED_MACGUJARATI": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether the decoder for MACGUJARATI has been instantiated in this session."
+  },
+  "DECODER_INSTANTIATED_MACGURMUKHI": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether the decoder for MACGURMUKHI has been instantiated in this session."
+  },
+  "DECODER_INSTANTIATED_KOI8R": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether the decoder for KOI8R has been instantiated in this session."
+  },
+  "DECODER_INSTANTIATED_KOI8U": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether the decoder for KOI8U has been instantiated in this session."
+  },
+  "DECODER_INSTANTIATED_ISO_8859_5": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether the decoder for ISO-8859-5 has been instantiated in this session."
+  },
+  "LONG_REFLOW_INTERRUPTIBLE": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Long running reflow, interruptible or not"
+  },
+  "XMLHTTPREQUEST_ASYNC_OR_SYNC": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Type of XMLHttpRequest, async or sync"
+  },
+  "LOCALDOMSTORAGE_SHUTDOWN_DATABASE_MS": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time to flush and close the localStorage database (ms)"
+  },
+  "LOCALDOMSTORAGE_PRELOAD_PENDING_ON_FIRST_ACCESS": {
+    "expires_in_version": "default",
+    "kind": "boolean",
+    "description": "True when we had to wait for a pending preload on first access to localStorage data, false otherwise"
+  },
+  "LOCALDOMSTORAGE_GETALLKEYS_BLOCKING_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time to block before we return a list of all keys in domain's LocalStorage (ms)"
+  },
+  "LOCALDOMSTORAGE_GETKEY_BLOCKING_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time to block before we return a key name in domain's LocalStorage (ms)"
+  },
+  "LOCALDOMSTORAGE_GETLENGTH_BLOCKING_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time to block before we return number of keys in domain's LocalStorage (ms)"
+  },
+  "LOCALDOMSTORAGE_GETVALUE_BLOCKING_MS": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time to block before we return a value for a key in LocalStorage (ms)"
+  },
+  "LOCALDOMSTORAGE_SETVALUE_BLOCKING_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time to block before we set a single key's value in LocalStorage (ms)"
+  },
+  "LOCALDOMSTORAGE_REMOVEKEY_BLOCKING_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time to block before we remove a single key from LocalStorage (ms)"
+  },
+  "LOCALDOMSTORAGE_CLEAR_BLOCKING_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time to block before we clear LocalStorage for all domains (ms)"
+  },
+  "LOCALDOMSTORAGE_UNLOAD_BLOCKING_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time to fetch LocalStorage data before we can clean the cache (ms)"
+  },
+  "LOCALDOMSTORAGE_SESSIONONLY_PRELOAD_BLOCKING_MS": {
+    "expires_in_version": "40",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time to fetch LocalStorage data before we can expose them as session only data (ms)"
+  },
+  "RANGE_CHECKSUM_ERRORS": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Number of histograms with range checksum errors"
+  },
+  "BUCKET_ORDER_ERRORS": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Number of histograms with bucket order errors"
+  },
+  "TOTAL_COUNT_HIGH_ERRORS": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Number of histograms with total count high errors"
+  },
+  "TOTAL_COUNT_LOW_ERRORS": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Number of histograms with total count low errors"
+  },
+  "TELEMETRY_ARCHIVE_DIRECTORIES_COUNT": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 13,
+    "n_buckets": 12,
+    "bug_numbers": [1162538],
+    "description": "Number of directories in the archive at scan"
+  },
+  "TELEMETRY_ARCHIVE_OLDEST_DIRECTORY_AGE": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 13,
+    "n_buckets": 12,
+    "bug_numbers": [1162538],
+    "description": "The age of the oldest Telemetry archive directory in months"
+  },
+  "TELEMETRY_ARCHIVE_SCAN_PING_COUNT": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 100000,
+    "n_buckets": 100,
+    "bug_numbers": [1162538],
+    "description": "Number of Telemetry pings in the archive at scan"
+  },
+  "TELEMETRY_ARCHIVE_SESSION_PING_COUNT": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1162538],
+    "description": "Number of Telemetry pings added to the archive during the session"
+  },
+  "TELEMETRY_ARCHIVE_SIZE_MB": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 300,
+    "n_buckets": 60,
+    "bug_numbers": [1162538],
+    "description": "The size of the Telemetry archive (MB)"
+  },
+  "TELEMETRY_ARCHIVE_EVICTED_OVER_QUOTA": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 100000,
+    "n_buckets": 100,
+    "bug_numbers": [1162538],
+    "description": "Number of Telemetry pings evicted from the archive during cleanup, because they were over the quota"
+  },
+  "TELEMETRY_ARCHIVE_EVICTED_OLD_DIRS": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 13,
+    "n_buckets": 12,
+    "bug_numbers": [1162538],
+    "description": "Number of Telemetry directories evicted from the archive during cleanup, because they were too old"
+  },
+  "TELEMETRY_ARCHIVE_EVICTING_DIRS_MS": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 300000,
+    "n_buckets": 20,
+    "bug_numbers": [1162538],
+    "description": "Time (ms) it takes for evicting old directories"
+  },
+  "TELEMETRY_ARCHIVE_CHECKING_OVER_QUOTA_MS": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 300000,
+    "n_buckets": 20,
+    "bug_numbers": [1162538],
+    "description": "Time (ms) it takes for checking if the archive is over-quota"
+  },
+  "TELEMETRY_ARCHIVE_EVICTING_OVER_QUOTA_MS": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 300000,
+    "n_buckets": 20,
+    "bug_numbers": [1162538],
+    "description": "Time (ms) it takes for evicting over-quota pings"
+  },
+  "TELEMETRY_PENDING_LOAD_FAILURE_READ": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Number of pending Telemetry pings that failed to load from the disk"
+  },
+  "TELEMETRY_PENDING_LOAD_FAILURE_PARSE": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Number of pending Telemetry pings that failed to parse once loaded from the disk"
+  },
+  "TELEMETRY_PENDING_PINGS_SIZE_MB": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 17,
+    "n_buckets": 16,
+    "description": "The size of the Telemetry pending pings directory (MB). The special value 17 is used to indicate over quota pings."
+  },
+  "TELEMETRY_PENDING_PINGS_AGE": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 365,
+    "n_buckets": 30,
+    "description": "The age, in days, of the pending pings."
+  },
+  "TELEMETRY_PENDING_PINGS_EVICTED_OVER_QUOTA": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 100000,
+    "n_buckets": 100,
+    "description": "Number of Telemetry pings evicted from the pending pings directory during cleanup, because they were over the quota"
+  },
+  "TELEMETRY_PENDING_EVICTING_OVER_QUOTA_MS": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 300000,
+    "n_buckets": 20,
+    "description": "Time (ms) it takes for evicting over-quota pending pings"
+  },
+  "TELEMETRY_PENDING_CHECKING_OVER_QUOTA_MS": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 300000,
+    "n_buckets": 20,
+    "description": "Time (ms) it takes for checking if the pending pings are over-quota"
+  },
+  "TELEMETRY_PING_SIZE_EXCEEDED_SEND": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Number of Telemetry pings discarded before sending because they exceeded the maximum size"
+  },
+  "TELEMETRY_PING_SIZE_EXCEEDED_PENDING": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Number of Telemetry pending pings discarded because they exceeded the maximum size"
+  },
+  "TELEMETRY_PING_SIZE_EXCEEDED_ARCHIVED": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Number of archived Telemetry pings discarded because they exceeded the maximum size"
+  },
+  "TELEMETRY_PING_SUBMISSION_WAITING_CLIENTID": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "bug_numbers": [1233986],
+    "description": "The number of pings that were submitted and had to wait for a client id (i.e. before it was cached or loaded from disk)"
+  },
+  "TELEMETRY_DISCARDED_PENDING_PINGS_SIZE_MB": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 30,
+    "n_buckets": 29,
+    "description": "The size (MB) of the Telemetry pending pings exceeding the maximum file size"
+  },
+  "TELEMETRY_DISCARDED_ARCHIVED_PINGS_SIZE_MB": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 30,
+    "n_buckets": 29,
+    "description": "The size (MB) of the Telemetry archived, compressed, pings exceeding the maximum file size"
+  },
+  "TELEMETRY_DISCARDED_SEND_PINGS_SIZE_MB": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 30,
+    "n_buckets": 29,
+    "description": "The size (MB) of the ping data submitted to Telemetry exceeding the maximum size"
+  },
+  "TELEMETRY_DISCARDED_CONTENT_PINGS_COUNT": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Count of discarded content payloads."
+  },
+  "TELEMETRY_COMPRESS": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time taken to compress telemetry object (ms)"
+  },
+  "TELEMETRY_SEND_SUCCESS" : {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "bug_numbers": [1318284],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 120000,
+    "n_buckets": 20,
+    "description": "Time needed (in ms) for a successful send of a Telemetry ping to the servers and getting a reply back."
+  },
+  "TELEMETRY_SEND_FAILURE" : {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "bug_numbers": [1318284],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 120000,
+    "n_buckets": 20,
+    "description": "Time needed (in ms) for a failed send of a Telemetry ping to the servers and getting a reply back."
+  },
+  "TELEMETRY_STRINGIFY" : {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 3000,
+    "n_buckets": 10,
+    "description": "Time to stringify telemetry object (ms)"
+  },
+  "TELEMETRY_SUCCESS": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Successful telemetry submission"
+  },
+  "TELEMETRY_INVALID_PING_TYPE_SUBMITTED": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "keyed": true,
+    "description": "Count of individual invalid ping types that were submitted to Telemetry."
+  },
+  "TELEMETRY_INVALID_PAYLOAD_SUBMITTED": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "bug_numbers": [1292226],
+    "kind": "count",
+    "description": "Count of individual invalid payloads that were submitted to Telemetry."
+  },
+  "TELEMETRY_PING_EVICTED_FOR_SERVER_ERRORS": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Number of Telemetry ping files evicted due to server errors (4XX HTTP code received)"
+  },
+  "TELEMETRY_SESSIONDATA_FAILED_LOAD": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Set if Telemetry failed to load the session data from disk."
+  },
+  "TELEMETRY_SESSIONDATA_FAILED_PARSE": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Set if Telemetry failed to parse the session data loaded from disk."
+  },
+  "TELEMETRY_SESSIONDATA_FAILED_VALIDATION": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Set if Telemetry failed to validate the session data loaded from disk."
+  },
+  "TELEMETRY_SESSIONDATA_FAILED_SAVE": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Set if Telemetry failed to save the session data to disk."
+  },
+  "TELEMETRY_ASSEMBLE_PAYLOAD_EXCEPTION": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "bug_numbers": [1250640],
+    "expires_in_version": "53",
+    "kind": "count",
+    "description": "Count of exceptions in TelemetrySession.getSessionPayload()."
+  },
+  "TELEMETRY_SCHEDULER_TICK_EXCEPTION": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "bug_numbers": [1250640],
+    "expires_in_version": "53",
+    "kind": "count",
+    "description": "Count of exceptions during executing the TelemetrySession scheduler tick logic."
+  },
+  "TELEMETRY_SCHEDULER_WAKEUP": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "bug_numbers": [1250640],
+    "expires_in_version": "53",
+    "kind": "count",
+    "description": "Count of TelemetrySession scheduler ticks that were delayed long enough to suspect sleep."
+  },
+  "TELEMETRY_TEST_FLAG": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "a testing histogram; not meant to be touched"
+  },
+  "TELEMETRY_TEST_COUNT": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "a testing histogram; not meant to be touched"
+  },
+  "TELEMETRY_TEST_COUNT2": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1288745],
+    "description": "a testing histogram; not meant to be touched"
+  },
+  "TELEMETRY_TEST_COUNT_INIT_NO_RECORD": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "a testing histogram; not meant to be touched - initially not recording"
+  },
+  "TELEMETRY_TEST_CATEGORICAL": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "bug_numbers": [1188888],
+    "expires_in_version": "never",
+    "kind": "categorical",
+    "labels": [
+      "CommonLabel",
+      "Label2",
+      "Label3"
+    ],
+    "description": "a testing histogram; not meant to be touched"
+  },
+  "TELEMETRY_TEST_CATEGORICAL_OPTOUT": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "bug_numbers": [1188888],
+    "expires_in_version": "never",
+    "releaseChannelCollection": "opt-out",
+    "kind": "categorical",
+    "labels": [
+      "CommonLabel",
+      "Label4",
+      "Label5",
+      "Label6"
+    ],
+    "description": "a testing histogram; not meant to be touched"
+  },
+  "TELEMETRY_TEST_CATEGORICAL_NVALUES": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "bug_numbers": [1188888],
+    "expires_in_version": "never",
+    "kind": "categorical",
+    "n_values": 70,
+    "labels": [
+      "CommonLabel",
+      "Label7",
+      "Label8"
+    ],
+    "description": "a testing histogram; not meant to be touched"
+  },
+  "TELEMETRY_TEST_KEYED_COUNT_INIT_NO_RECORD": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "keyed": true,
+    "description": "a testing histogram; not meant to be touched - initially not recording"
+  },
+  "TELEMETRY_TEST_KEYED_FLAG": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "flag",
+    "keyed": true,
+    "description": "a testing histogram; not meant to be touched"
+  },
+  "TELEMETRY_TEST_KEYED_COUNT": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "keyed": true,
+    "description": "a testing histogram; not meant to be touched"
+  },
+    "TELEMETRY_TEST_KEYED_BOOLEAN": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "keyed": true,
+    "bug_numbers": [1299144],
+    "description": "a testing histogram; not meant to be touched"
+  },
+  "TELEMETRY_TEST_RELEASE_OPTOUT": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "flag",
+    "releaseChannelCollection": "opt-out",
+    "description": "a testing histogram; not meant to be touched"
+  },
+  "TELEMETRY_TEST_RELEASE_OPTIN": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "flag",
+    "releaseChannelCollection": "opt-in",
+    "description": "a testing histogram; not meant to be touched"
+  },
+  "TELEMETRY_TEST_KEYED_RELEASE_OPTIN": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "flag",
+    "keyed": true,
+    "releaseChannelCollection": "opt-in",
+    "description": "a testing histogram; not meant to be touched"
+  },
+  "TELEMETRY_TEST_KEYED_RELEASE_OPTOUT": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "flag",
+    "keyed": true,
+    "releaseChannelCollection": "opt-out",
+    "description": "a testing histogram; not meant to be touched"
+  },
+  "TELEMETRY_TEST_EXPONENTIAL": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 1,
+    "high": 2147483646,
+    "n_buckets": 10,
+    "bug_numbers": [1288745],
+    "description": "a testing histogram; not meant to be touched"
+  },
+  "TELEMETRY_TEST_LINEAR": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "low": 1,
+    "high": 2147483646,
+    "n_buckets": 10,
+    "bug_numbers": [1288745],
+    "description": "a testing histogram; not meant to be touched"
+  },
+  "TELEMETRY_TEST_BOOLEAN": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version" : "never",
+    "kind": "boolean",
+    "bug_numbers": [1288745],
+    "description": "a testing histogram; not meant to be touched"
+  },
+  "TELEMETRY_TEST_EXPIRED": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "4.0a1",
+    "kind": "flag",
+    "description": "a testing histogram; not meant to be touched"
+  },
+  "STARTUP_CRASH_DETECTED": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether there was a crash during the last startup"
+  },
+  "SAFE_MODE_USAGE": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 3,
+    "description": "Whether the user is in safe mode (No, Yes, Forced)"
+  },
+  "SCRIPT_BLOCK_INCORRECT_MIME": {
+    "alert_emails": ["ckerschbaumer@mozilla.com"],
+    "bug_numbers": [1288361, 1299267],
+    "expires_in_version": "56",
+    "kind": "enumerated",
+    "n_values": 15,
+    "description": "Whether the script load has a MIME type of ...?  (0=unknown, 1=js, 2=image, 3=audio, 4=video, 5=text/plain, 6=text/csv, 7=text/xml, 8=application/octet-stream, 9=application/xml, 10=text/html, 11=empty)"
+  },
+  "XCTO_NOSNIFF_BLOCK_IMAGE": {
+    "alert_emails": ["ckerschbaumer@mozilla.com"],
+    "bug_numbers": [1302539],
+    "expires_in_version": "56",
+    "kind": "enumerated",
+    "n_values": 3,
+    "description": "Whether XCTO: nosniff would allow/block an image load? (0=allow, 1=block)"
+  },
+  "NEWTAB_PAGE_ENABLED": {
+    "expires_in_version": "default",
+    "kind": "boolean",
+    "description": "New tab page is enabled."
+  },
+  "NEWTAB_PAGE_ENHANCED": {
+    "expires_in_version": "default",
+    "kind": "boolean",
+    "description": "New tab page is enhanced (showing suggestions)."
+  },
+  "NEWTAB_PAGE_LIFE_SPAN": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 1200,
+    "n_buckets": 100,
+    "description": "Life-span of a new tab without suggested tile: time delta between first-visible and unload events (half-seconds)."
+  },
+  "NEWTAB_PAGE_LIFE_SPAN_SUGGESTED": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 1200,
+    "n_buckets": 100,
+    "description": "Life-span of a new tab with suggested tile: time delta between first-visible and unload events (half-seconds)."
+  },
+  "NEWTAB_PAGE_PINNED_SITES_COUNT": {
+    "expires_in_version": "default",
+    "kind": "enumerated",
+    "n_values": 9,
+    "description": "Number of pinned sites on the new tab page."
+  },
+  "NEWTAB_PAGE_BLOCKED_SITES_COUNT": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 100,
+    "n_buckets": 10,
+    "description": "Number of sites blocked from the new tab page."
+  },
+  "NEWTAB_PAGE_SHOWN": {
+    "expires_in_version": "35",
+    "kind": "boolean",
+    "description": "Number of times about:newtab was shown from opening a new tab or window. *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "NEWTAB_PAGE_SITE_CLICKED": {
+    "expires_in_version": "35",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "Track click count on about:newtab tiles per index (0-8). For non-default row or column configurations all clicks into the '9' bucket. *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***"
+  },
+  "BROWSERPROVIDER_XUL_IMPORT_BOOKMARKS": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 50000,
+    "n_buckets": 20,
+    "description": "Number of bookmarks in the original XUL places database",
+    "cpp_guard": "ANDROID"
+  },
+  "FENNEC_GLOBALHISTORY_ADD_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 10,
+    "high": 20000,
+    "n_buckets": 20,
+    "description": "Time for a record to be added to history (ms)",
+    "cpp_guard": "ANDROID"
+  },
+  "FENNEC_GLOBALHISTORY_UPDATE_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 10,
+    "high": 20000,
+    "n_buckets": 20,
+    "description": "Time for a record to be updated in history (ms)",
+    "cpp_guard": "ANDROID"
+  },
+  "FENNEC_GLOBALHISTORY_VISITED_BUILD_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 10,
+    "high": 20000,
+    "n_buckets": 20,
+    "description": "Time to update the visited link set (ms)",
+    "cpp_guard": "ANDROID"
+  },
+  "FENNEC_RESTORING_ACTIVITY": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Fennec is starting up but the Gecko thread was still running",
+    "cpp_guard": "ANDROID"
+  },
+  "FENNEC_SEARCH_LOADER_TIME_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 10,
+    "high": 20000,
+    "n_buckets": 20,
+    "description": "Time for a URL bar DB search to return (ms)",
+    "cpp_guard": "ANDROID"
+  },
+  "FENNEC_STARTUP_TIME_GECKOREADY": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 500,
+    "high": 20000,
+    "n_buckets": 20,
+    "description": "Time for the Gecko:Ready message to arrive (ms)",
+    "cpp_guard": "ANDROID"
+  },
+  "FENNEC_STARTUP_TIME_JAVAUI": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 100,
+    "high": 5000,
+    "n_buckets": 20,
+    "description": "Time for the Java UI to load (ms)",
+    "cpp_guard": "ANDROID"
+  },
+  "FENNEC_TOPSITES_LOADER_TIME_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 10,
+    "high": 20000,
+    "n_buckets": 20,
+    "description": "Time for the home screen Top Sites query to return with no filter set (ms)",
+    "cpp_guard": "ANDROID"
+  },
+  "FENNEC_ACTIVITY_STREAM_TOPSITES_LOADER_TIME_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 10,
+    "high": 20000,
+    "n_buckets": 20,
+    "description": "Time for the Activity Stream home screen Top Sites query to return (ms)",
+    "alert_emails": ["mobile-frontend@mozilla.com"],
+    "bug_numbers": [1293790],
+    "cpp_guard": "ANDROID"
+  },
+  "FENNEC_ACTIVITY_STREAM_HIGHLIGHTS_LOADER_TIME_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 10,
+    "high": 20000,
+    "n_buckets": 20,
+    "description": "Time for the Activity Stream highlights query to return (ms)",
+    "alert_emails": ["mobile-frontend@mozilla.com"],
+    "bug_numbers": [1298786],
+    "cpp_guard": "ANDROID"
+  },
+  "FENNEC_HOMEPANELS_CUSTOM": {
+    "expires_in_version": "54",
+    "kind": "boolean",
+    "bug_numbers": [1245368],
+    "description": "Whether the user has customized their homepanels",
+    "cpp_guard": "ANDROID"
+  },
+  "FENNEC_WAS_KILLED": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Killed, likely due to an OOM condition",
+    "cpp_guard": "ANDROID"
+  },
+  "FIPS_ENABLED": {
+    "alert_emails": ["seceng@mozilla.org"],
+    "expires_in_version": "54",
+    "kind": "flag",
+    "bug_numbers": [1241317],
+    "releaseChannelCollection": "opt-out",
+    "description": "Has FIPS mode been enabled?"
+  },
+  "SECURITY_UI": {
+    "alert_emails": ["seceng-telemetry@mozilla.com", "fxprivacyandsecurity@mozilla.com"],
+    "bug_numbers": [767676],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 100,
+    "description": "Security-related UI events (addons, form submission, TLS certs, Safe Browsing, updates and geolocation). See /security/manager/ssl/nsISecurityUITelemetry.idl for the specific values."
+  },
+  "JS_TELEMETRY_ADDON_EXCEPTIONS" : {
+    "expires_in_version" : "never",
+    "kind": "count",
+    "keyed" : true,
+    "description" : "Exceptions thrown by add-ons"
+  },
+  "IPC_TRANSACTION_CANCEL": {
+    "alert_emails": ["billm@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "True when an IPC transaction is canceled"
+  },
+  "IPC_SAME_PROCESS_MESSAGE_COPY_OOM_KB": {
+     "expires_in_version": "50",
+     "kind": "exponential",
+     "low": 100,
+     "high": 10000000,
+     "n_buckets": 10,
+     "description": "Whenever the same-process MessageManager cannot be sent through sendAsyncMessage as it would cause an OOM, the size of the message content, in kb."
+  },
+  "SLOW_ADDON_WARNING_STATES": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 20,
+    "description": "The states the Slow Add-on Warning goes through. 0: Displayed the warning. 1: User clicked on 'Disable add-on'. 2: User clicked 'Ignore add-on for now'. 3: User clicked 'Ignore add-on permanently'. 4: User closed notification. Other values are reserved for future uses."
+  },
+  "SLOW_ADDON_WARNING_RESPONSE_TIME": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 86400000,
+    "n_buckets": 30,
+    "description": "Time elapsed between before responding to Slow Add-on Warning UI (ms). Not updated if the user doesn't respond at all."
+  },
+  "SEARCH_COUNTS": {
+    "expires_in_version": "never",
+    "kind": "count",
+    "keyed": true,
+    "releaseChannelCollection": "opt-out",
+    "description": "Record the search counts for search engines"
+  },
+  "SEARCH_RESET_RESULT": {
+    "alert_emails": ["fqueze@mozilla.com"],
+    "bug_numbers": [1203168],
+    "expires_in_version": "57",
+    "kind": "enumerated",
+    "n_values": 5,
+    "releaseChannelCollection": "opt-out",
+    "description": "Result of showing the search reset prompt to the user. 0=restored original default, 1=kept current engine, 2=changed engine, 3=closed the page, 4=opened search settings"
+  },
+  "SEARCH_SERVICE_INIT_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 15,
+    "description": "Time (ms) it takes to initialize the search service"
+  },
+  "SEARCH_SERVICE_INIT_SYNC": {
+    "alert_emails": ["rvitillo@mozilla.com", "gavin@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "search service has been initialized synchronously"
+  },
+  "SEARCH_SERVICE_ENGINE_COUNT": {
+    "releaseChannelCollection": "opt-out",
+    "alert_emails": ["florian@mozilla.com"],
+    "expires_in_version": "55",
+    "bug_numbers": [1268424],
+    "kind": "linear",
+    "high": 200,
+    "n_buckets": 50,
+    "description": "Recorded once per session near startup: records the search plugin count, including both built-in plugins (including the ones the user has hidden) and user-installed plugins."
+  },
+  "SEARCH_SERVICE_COUNTRY_FETCH_TIME_MS": {
+    "alert_emails": ["mhammond@mozilla.com", "gavin@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "n_buckets": 30,
+    "high": 100000,
+    "description": "Time (ms) it takes to fetch the country code"
+  },
+  "SEARCH_SERVICE_COUNTRY_FETCH_RESULT": {
+    "alert_emails": ["mhammond@mozilla.com", "gavin@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 8,
+    "description": "Result of XHR request fetching the country-code. 0=SUCCESS, 1=SUCCESS_WITHOUT_DATA, 2=XHRTIMEOUT, 3=ERROR (rest reserved for finer-grained error codes later)"
+  },
+  "SEARCH_SERVICE_COUNTRY_TIMEOUT": {
+    "alert_emails": ["mhammond@mozilla.com", "gavin@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "True if we stopped waiting for the XHR response before it completed"
+  },
+  "SEARCH_SERVICE_COUNTRY_FETCH_CAUSED_SYNC_INIT": {
+    "alert_emails": ["mhammond@mozilla.com", "gavin@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "True if the search service was synchronously initialized while we were waiting for the XHR response"
+  },
+  "SEARCH_SERVICE_US_COUNTRY_MISMATCHED_TIMEZONE": {
+    "alert_emails": ["mhammond@mozilla.com", "gavin@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Set if the fetched country-code indicates US but the time-zone heuristic doesn't"
+  },
+  "SEARCH_SERVICE_US_TIMEZONE_MISMATCHED_COUNTRY": {
+    "alert_emails": ["mhammond@mozilla.com", "gavin@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Set if the time-zone heuristic indicates US but the fetched country code doesn't"
+  },
+  "SEARCH_SERVICE_US_COUNTRY_MISMATCHED_PLATFORM_OSX": {
+    "alert_emails": ["mhammond@mozilla.com", "gavin@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "If we are on OSX and either the OSX countryCode or the geoip countryCode indicates we are in the US, set to false if they both do or true otherwise"
+  },
+  "SEARCH_SERVICE_NONUS_COUNTRY_MISMATCHED_PLATFORM_OSX": {
+    "alert_emails": ["mhammond@mozilla.com", "gavin@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "If we are on OSX and neither the OSX countryCode nor the geoip countryCode indicates we are in the US, set to false if they both agree on the value or true otherwise"
+  },
+  "SEARCH_SERVICE_US_COUNTRY_MISMATCHED_PLATFORM_WIN": {
+    "alert_emails": ["mhammond@mozilla.com", "gavin@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "If we are on Windows and either the Windows countryCode or the geoip countryCode indicates we are in the US, set to false if they both do or true otherwise"
+  },
+  "SEARCH_SERVICE_NONUS_COUNTRY_MISMATCHED_PLATFORM_WIN": {
+    "alert_emails": ["mhammond@mozilla.com", "gavin@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "If we are on Windows and neither the Windows countryCode nor the geoip countryCode indicates we are in the US, set to false if they both agree on the value or true otherwise"
+  },
+  "SOCIAL_ENABLED_ON_SESSION": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Social has been enabled at least once on the current session"
+  },
+  "ENABLE_PRIVILEGE_EVER_CALLED": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether enablePrivilege has ever been called during the current session"
+  },
+  "SUBJECT_PRINCIPAL_ACCESSED_WITHOUT_SCRIPT_ON_STACK": {
+    "expires_in_version": "46",
+    "alert_emails": ["bholley@mozilla.com"],
+    "kind": "flag",
+    "description": "Whether the subject principal was accessed without script on the stack during the current session"
+  },
+  "TOUCH_ENABLED_DEVICE": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "The device supports touch input",
+    "cpp_guard": "XP_WIN"
+  },
+  "COMPONENTS_SHIM_ACCESSED_BY_CONTENT": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "Whether content ever accesed the Components shim in this session"
+  },
+  "CHECK_ADDONS_MODIFIED_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 5000,
+    "n_buckets": 15,
+    "description": "Time (ms) it takes to figure out extension last modified time"
+  },
+  "TELEMETRY_MEMORY_REPORTER_MS": {
+    "alert_emails": ["memshrink-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 5000,
+    "n_buckets": 10,
+    "description": "Time (ms) it takes to run memory reporters when sending a telemetry ping"
+  },
+  "SSL_SUCCESFUL_CERT_VALIDATION_TIME_MOZILLAPKIX" : {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 50,
+    "description": "Time spent on a successful cert verification in mozilla::pkix mode (ms)"
+  },
+  "SSL_INITIAL_FAILED_CERT_VALIDATION_TIME_MOZILLAPKIX" : {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 50,
+    "description": "Time spent on an initially failed cert verification in mozilla::pkix mode (ms)"
+  },
+  "CRASH_STORE_COMPRESSED_BYTES": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000000,
+    "n_buckets": 202,
+    "description": "Size (in bytes) of the compressed crash store JSON file."
+  },
+  "PDF_VIEWER_USED": {
+    "expires_in_version": "default",
+    "kind": "boolean",
+    "description": "How many times PDF Viewer was used"
+  },
+  "PDF_VIEWER_FALLBACK_SHOWN": {
+    "expires_in_version": "default",
+    "kind": "boolean",
+    "description": "How many times PDF Viewer fallback bar was shown"
+  },
+  "PDF_VIEWER_PRINT": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "How many times PDF Viewer print functionality was used"
+  },
+  "PDF_VIEWER_DOCUMENT_VERSION": {
+    "expires_in_version": "default",
+    "kind": "enumerated",
+    "n_values": 20,
+    "description": "The PDF document version (1.1, 1.2, etc.)"
+  },
+  "PDF_VIEWER_DOCUMENT_GENERATOR": {
+    "expires_in_version": "default",
+    "kind": "enumerated",
+    "n_values": 30,
+    "description": "The PDF document generator"
+  },
+  "PDF_VIEWER_DOCUMENT_SIZE_KB": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "low": 2,
+    "high": 65536,
+    "n_buckets": 20,
+    "description": "The PDF document size (KB)"
+  },
+  "PDF_VIEWER_FONT_TYPES": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 19,
+    "description": "The PDF document font types used"
+  },
+  "PDF_VIEWER_EMBED": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "A PDF document was embedded: true using OBJECT/EMBED and false using IFRAME"
+  },
+  "PDF_VIEWER_FORM": {
+    "expires_in_version": "default",
+    "kind": "boolean",
+    "description": "A PDF form expected: true for AcroForm and false for XFA"
+  },
+  "PDF_VIEWER_STREAM_TYPES": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 19,
+    "description": "The PDF document compression stream types used"
+  },
+  "PDF_VIEWER_TIME_TO_VIEW_MS": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent to display first page in PDF Viewer (ms)"
+  },
+  "PLUGINS_NOTIFICATION_SHOWN": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "The number of times the click-to-activate notification was shown: false: shown by in-content activation true: shown by location bar activation"
+  },
+  "PLUGINS_NOTIFICATION_PLUGIN_COUNT": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 5,
+    "description": "The number of plugins present in the click-to-activate notification, minus one (1, 2, 3, 4, more than 4)"
+  },
+  "PLUGINS_NOTIFICATION_USER_ACTION": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 3,
+    "description": "User actions taken in the plugin notification: 0: allownow 1: allowalways 2: block"
+  },
+  "PLUGINS_INFOBAR_SHOWN": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Count of when the hidden-plugin infobar was displayed."
+  },
+  "PLUGINS_INFOBAR_BLOCK": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Count the number of times the user clicked 'block' on the hidden-plugin infobar."
+  },
+  "PLUGINS_INFOBAR_ALLOW": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Count the number of times the user clicked 'allow' on the hidden-plugin infobar."
+  },
+  "POPUP_NOTIFICATION_STATS": {
+    "releaseChannelCollection": "opt-out",
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "bug_numbers": [1207089],
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "keyed": true,
+    "n_values": 40,
+    "description": "(Bug 1207089) Usage of popup notifications, keyed by ID (0 = Offered, 1..4 = Action, 5 = Click outside, 6 = Leave page, 7 = Use 'X', 8 = Not now, 10 = Open submenu, 11 = Learn more. Add 20 if happened after reopen.)"
+  },
+  "POPUP_NOTIFICATION_MAIN_ACTION_MS": {
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "bug_numbers": [1207089],
+    "expires_in_version": "55",
+    "kind": "exponential",
+    "keyed": true,
+    "low": 100,
+    "high": 600000,
+    "n_buckets": 40,
+    "description": "(Bug 1207089) Time in ms between initially requesting a popup notification and triggering the main action, keyed by ID"
+  },
+  "POPUP_NOTIFICATION_DISMISSAL_MS": {
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "bug_numbers": [1207089],
+    "expires_in_version": "55",
+    "kind": "exponential",
+    "keyed": true,
+    "low": 200,
+    "high": 20000,
+    "n_buckets": 50,
+    "description": "(Bug 1207089) Time in ms between displaying a popup notification and dismissing it without an action the first time, keyed by ID"
+  },
+  "PRINT_PREVIEW_OPENED_COUNT": {
+    "alert_emails": ["carnold@mozilla.org"],
+    "bug_numbers": [1275570],
+    "expires_in_version": "56",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "A counter incremented every time the browser enters print preview."
+  },
+  "PRINT_PREVIEW_SIMPLIFY_PAGE_OPENED_COUNT": {
+    "alert_emails": ["carnold@mozilla.org"],
+    "bug_numbers": [1275570],
+    "expires_in_version": "56",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "A counter incremented every time the browser enters simplified mode on print preview."
+  },
+  "PRINT_PREVIEW_SIMPLIFY_PAGE_UNAVAILABLE_COUNT": {
+     "alert_emails": ["carnold@mozilla.org"],
+     "bug_numbers": [1287587],
+     "expires_in_version": "56",
+     "kind": "count",
+     "releaseChannelCollection": "opt-out",
+     "description": "A counter incremented every time the simplified mode is unavailable on print preview."
+   },
+  "PRINT_DIALOG_OPENED_COUNT": {
+    "alert_emails": ["carnold@mozilla.org"],
+    "bug_numbers": [1306624],
+    "expires_in_version": "56",
+    "kind": "count",
+    "keyed": true,
+    "releaseChannelCollection": "opt-out",
+    "description": "A counter incremented every time the user opens print dialog."
+  },
+  "PRINT_COUNT": {
+     "alert_emails": ["carnold@mozilla.org"],
+     "bug_numbers": [1287587],
+     "expires_in_version": "56",
+     "kind": "count",
+     "keyed": true,
+     "releaseChannelCollection": "opt-out",
+     "description": "A counter incremented every time the user prints a document."
+   },
+  "DEVTOOLS_DEBUGGER_DISPLAY_SOURCE_LOCAL_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 1000,
+    "description": "The time (in milliseconds) that it took to display a selected source to the user."
+  },
+  "DEVTOOLS_DEBUGGER_DISPLAY_SOURCE_REMOTE_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 1000,
+    "description": "The time (in milliseconds) that it took to display a selected source to the user."
+  },
+  "MEDIA_RUST_MP4PARSE_SUCCESS": {
+    "alert_emails": ["giles@mozilla.com", "kinetik@flim.org"],
+    "expires_in_version": "55",
+    "kind": "boolean",
+    "bug_numbers": [1220885],
+    "description": "(Bug 1220885) Whether the rust mp4 demuxer successfully parsed a stream segment."
+  },
+  "MEDIA_RUST_MP4PARSE_ERROR_CODE": {
+    "alert_emails": ["giles@mozilla.com", "kinetik@flim.org"],
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 32,
+    "bug_numbers": [1238420],
+    "description": "The error code reported when an MP4 parse attempt has failed.0 = OK, 1 = bad argument, 2 = invalid data, 3 = unsupported, 4 = unexpected end of file, 5 = read error."
+  },
+  "MEDIA_RUST_MP4PARSE_TRACK_MATCH_AUDIO": {
+    "alert_emails": ["giles@mozilla.com", "kinetik@flim.org"],
+    "expires_in_version": "55",
+    "kind": "boolean",
+    "bug_numbers": [1231169],
+    "description": "Whether rust and stagefight mp4 parser audio track results match."
+  },
+  "MEDIA_RUST_MP4PARSE_TRACK_MATCH_VIDEO": {
+    "alert_emails": ["giles@mozilla.com", "kinetik@flim.org"],
+    "expires_in_version": "55",
+    "kind": "boolean",
+    "bug_numbers": [1231169],
+    "description": "Whether rust and stagefight mp4 parser video track results match."
+  },
+  "MEDIA_WMF_DECODE_ERROR": {
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 256,
+    "description": "WMF media decoder error or success (0) codes."
+  },
+  "MEDIA_OGG_LOADED_IS_CHAINED": {
+    "alert_emails": ["cpearce@mozilla.com"],
+    "expires_in_version": "53",
+    "kind": "boolean",
+    "description": "Whether Ogg audio/video encountered are chained or not.",
+    "bug_numbers": [1230295]
+  },
+  "MEDIA_HLS_CANPLAY_REQUESTED": {
+    "alert_emails": ["ajones@mozilla.com", "giles@mozilla.com"],
+    "expires_in_version": "55",
+    "kind": "boolean",
+    "description": "Reports a true value when a page requests canPlayType for an HTTP Live Streaming media type (or generic m3u playlist).",
+    "bug_numbers": [1262659]
+  },
+  "MEDIA_HLS_DECODER_SUCCESS": {
+    "alert_emails": ["ajones@mozilla.com", "giles@mozilla.com"],
+    "expires_in_version": "55",
+    "kind": "boolean",
+    "description": "Reports whether a decoder for an HTTP Live Streaming media type was created when requested.",
+    "bug_numbers": [1262659]
+  },
+  "MEDIA_DECODING_PROCESS_CRASH": {
+    "alert_emails": ["bwu@mozilla.com", "jolin@mozilla.com", "jacheng@mozilla.com"],
+    "expires_in_version": "57",
+    "kind": "count",
+    "bug_numbers": [1297556, 1257777],
+    "description": "Records a value each time Fennec remote decoding process crashes unexpected while decoding media content.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "VIDEO_MFT_OUTPUT_NULL_SAMPLES": {
+    "alert_emails": ["cpearce@mozilla.com"],
+    "expires_in_version": "53",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "Does the WMF video decoder return success but null output? 0 = playback successful, 1 = excessive null output but able to decode some frames, 2 = excessive null output and gave up, 3 = null output but recovered, 4 = non-excessive null output without being able to decode frames.",
+    "bug_numbers": [1176071]
+  },
+  "AUDIO_MFT_OUTPUT_NULL_SAMPLES": {
+    "alert_emails": ["cpearce@mozilla.com"],
+    "expires_in_version": "53",
+    "kind": "count",
+    "description": "How many times the audio MFT decoder returns success but output nothing.",
+    "bug_numbers": [1176071]
+  },
+  "VIDEO_CAN_CREATE_AAC_DECODER": {
+    "alert_emails": ["cpearce@mozilla.com"],
+    "expires_in_version": "58",
+    "kind": "boolean",
+    "description": "Whether at startup we report we can playback MP4 (AAC) audio. This is single value is recorded at every startup.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "VIDEO_CAN_CREATE_H264_DECODER": {
+    "alert_emails": ["cpearce@mozilla.com"],
+    "expires_in_version": "58",
+    "kind": "boolean",
+    "description": "Whether at startup we report we can playback MP4 (H.264) video. This is single value is recorded at every startup.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "VIDEO_CANPLAYTYPE_H264_CONSTRAINT_SET_FLAG": {
+    "expires_in_version": "50",
+    "kind": "enumerated",
+    "n_values": 128,
+    "description": "The H.264 constraint set flag as extracted from the codecs parameter passed to HTMLMediaElement.canPlayType, with the addition of 0 for unknown values."
+  },
+  "VIDEO_CANPLAYTYPE_H264_LEVEL": {
+    "expires_in_version": "50",
+    "kind": "enumerated",
+    "n_values": 51,
+    "description": "The H.264 level (level_idc) as extracted from the codecs parameter passed to HTMLMediaElement.canPlayType, from levels 1 (10) to 5.2 (51), with the addition of 0 for unknown values."
+  },
+  "VIDEO_CANPLAYTYPE_H264_PROFILE": {
+    "expires_in_version": "50",
+    "kind": "enumerated",
+    "n_values": 244,
+    "description": "The H.264 profile number (profile_idc) as extracted from the codecs parameter passed to HTMLMediaElement.canPlayType."
+  },
+  "DECODER_DOCTOR_INFOBAR_STATS": {
+    "alert_emails": ["gsquelart@mozilla.com"],
+    "bug_numbers": [1271483, 1337566],
+    "expires_in_version": "59",
+    "kind": "enumerated",
+    "keyed": true,
+    "n_values": 8,
+    "description": "Counts of various Decoder Doctor notification events. Used to track efficacy of Decoder Doctor at helping users fix problems with their audio/video codecs. Keys are localized string names that identify problem with audio/video codecs that Decoder Doctor attempts to solve; see string values in dom.properties for verbose description of problems being solved. 0=recorded every time the Decoder Doctor notification is shown, 1=recorded the first time in a profile when notification is shown, 2=recorded when 'Learn how' button clicked, 3=recorded when 'Learn how' button first clicked in a profile, 4=recorded when issue solved after infobar has been shown at least once in a profile."
+  },
+  "VIDEO_DECODED_H264_SPS_CONSTRAINT_SET_FLAG": {
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 128,
+    "description": "A bit pattern to collect H.264 constraint set flag from the decoded SPS. Bits 0 through 5 represent constraint_set0_flag through constraint_set5_flag, respectively."
+  },
+  "VIDEO_DECODED_H264_SPS_LEVEL": {
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 51,
+    "description": "The H.264 level (level_idc) as extracted from the decoded SPS, from levels 1 (10) to 5.2 (51), with the addition of 0 for unknown values."
+  },
+  "VIDEO_DECODED_H264_SPS_PROFILE": {
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 244,
+    "description": "The H.264 profile number (profile_idc) as extracted from the decoded SPS."
+  },
+  "VIDEO_H264_SPS_MAX_NUM_REF_FRAMES": {
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 17,
+    "description": "SPS.max_num_ref_frames indicates how deep the H.264 queue is going to be, and as such the minimum memory usage by the decoder, from 0 to 16. 17 indicates an invalid value."
+  },
+  "WEBRTC_DTLS_CLIENT_SUCCESS_TIME": {
+    "alert_emails": ["webrtc-dtls-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1336182],
+    "expires_in_version": "60",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "description": "The length of time (in milliseconds) it took for a client DTLS handshake to complete, given that DTLS succeeded."
+  },
+  "WEBRTC_DTLS_CLIENT_ABORT_TIME": {
+    "alert_emails": ["webrtc-dtls-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1336182],
+    "expires_in_version": "60",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "description": "The length of time (in milliseconds) it took for a client DTLS handshake to be aborted due to some external factor (eg; PeerConnection torn down)."
+  },
+  "WEBRTC_DTLS_CLIENT_FAILURE_TIME": {
+    "alert_emails": ["webrtc-dtls-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1336182],
+    "expires_in_version": "60",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "description": "The length of time (in milliseconds) it took for a client DTLS handshake to complete, given that it failed."
+  },
+  "WEBRTC_DTLS_SERVER_SUCCESS_TIME": {
+    "alert_emails": ["webrtc-dtls-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1336182],
+    "expires_in_version": "60",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "description": "The length of time (in milliseconds) it took for a server DTLS handshake to complete, given that DTLS succeeded."
+  },
+  "WEBRTC_DTLS_SERVER_ABORT_TIME": {
+    "alert_emails": ["webrtc-dtls-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1336182],
+    "expires_in_version": "60",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "description": "The length of time (in milliseconds) it took for a server DTLS handshake to be aborted due to some external factor (eg; PeerConnection torn down)."
+  },
+  "WEBRTC_DTLS_SERVER_FAILURE_TIME": {
+    "alert_emails": ["webrtc-dtls-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1336182],
+    "expires_in_version": "60",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "description": "The length of time (in milliseconds) it took for a server DTLS handshake to complete, given that it failed."
+  },
+  "WEBRTC_ICE_FINAL_CONNECTION_STATE": {
+    "alert_emails": ["webrtc-ice-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1319268],
+    "expires_in_version": "58",
+    "kind": "enumerated",
+    "n_values": 7,
+    "description": "The ICE connection state when the PC was closed"
+  },
+  "WEBRTC_ICE_ON_TIME_TRICKLE_ARRIVAL_TIME": {
+    "alert_emails": ["webrtc-ice-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1319268],
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "description": "The length of time (in milliseconds) that a trickle candidate took to arrive after the start of ICE, given that it arrived when ICE was not in a failure state (ie; a candidate that we could do something with, hence 'on time')"
+  },
+  "WEBRTC_ICE_LATE_TRICKLE_ARRIVAL_TIME": {
+    "alert_emails": ["webrtc-ice-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1319268],
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "description": "The length of time (in milliseconds) that a trickle candidate took to arrive after the start of ICE, given that it arrived after ICE failed."
+  },
+  "WEBRTC_ICE_OFFERER_SUCCESS_TIME": {
+    "alert_emails": ["webrtc-ice-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1342523],
+    "expires_in_version": "60",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "description": "The length of time (in milliseconds) it took for the offerer to complete ICE, given that ICE succeeded."
+  },
+  "WEBRTC_ICE_OFFERER_ABORT_TIME": {
+    "alert_emails": ["webrtc-ice-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1342523],
+    "expires_in_version": "60",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "description": "The length of time (in milliseconds) it took for the offerer to abort ICE due to some external factor (eg; PeerConnection torn down). Does not count cases where StartChecks() was never called."
+  },
+  "WEBRTC_ICE_OFFERER_FAILURE_TIME": {
+    "alert_emails": ["webrtc-ice-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1342523],
+    "expires_in_version": "60",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "description": "The length of time (in milliseconds) it took for the offerer to complete ICE, given that it failed. Does not count cases where StartChecks() was never called."
+  },
+  "WEBRTC_ICE_ANSWERER_SUCCESS_TIME": {
+    "alert_emails": ["webrtc-ice-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1342523],
+    "expires_in_version": "60",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "description": "The length of time (in milliseconds) it took for the answerer to complete ICE, given that ICE succeeded."
+  },
+  "WEBRTC_ICE_ANSWERER_ABORT_TIME": {
+    "alert_emails": ["webrtc-ice-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1342523],
+    "expires_in_version": "60",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "description": "The length of time (in milliseconds) it took for the answerer to abort ICE due to some external factor (eg; PeerConnection torn down). Does not count cases where StartChecks() was never called."
+  },
+  "WEBRTC_ICE_ANSWERER_FAILURE_TIME": {
+    "alert_emails": ["webrtc-ice-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1342523],
+    "expires_in_version": "60",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "description": "The length of time (in milliseconds) it took for the answerer to complete ICE, given that it failed. Does not count cases where StartChecks() was never called."
+  },
+  "WEBRTC_ICE_SUCCESS_TIME": {
+    "alert_emails": ["webrtc-ice-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1319268],
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "description": "The length of time (in milliseconds) it took for ICE to complete, given that ICE succeeded."
+  },
+  "WEBRTC_ICE_FAILURE_TIME": {
+    "alert_emails": ["webrtc-ice-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1319268],
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "description": "The length of time (in milliseconds) it took for ICE to complete, given that it failed."
+  },
+  "WEBRTC_ICE_SUCCESS_RATE": {
+    "alert_emails": ["webrtc-ice-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1319268],
+    "expires_in_version": "58",
+    "kind": "boolean",
+    "description": "The number of failed ICE Connections (0) vs. number of successful ICE connections (1)."
+  },
+  "WEBRTC_STUN_RATE_LIMIT_EXCEEDED_BY_TYPE_GIVEN_SUCCESS": {
+    "alert_emails": ["webrtc-ice-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1319268],
+    "expires_in_version": "58",
+    "kind": "enumerated",
+    "n_values": 4,
+    "description": "For each successful PeerConnection, bit 0 indicates the short-duration rate limit was reached, bit 1 indicates the long-duration rate limit was reached"
+  },
+  "WEBRTC_STUN_RATE_LIMIT_EXCEEDED_BY_TYPE_GIVEN_FAILURE": {
+    "alert_emails": ["webrtc-ice-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1319268],
+    "expires_in_version": "58",
+    "kind": "enumerated",
+    "n_values": 4,
+    "description": "For each failed PeerConnection, bit 0 indicates the short-duration rate limit was reached, bit 1 indicates the long-duration rate limit was reached"
+  },
+  "WEBRTC_AVSYNC_WHEN_AUDIO_LAGS_VIDEO_MS": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "The delay (in milliseconds) when audio is behind video. Zero delay is counted. Measured every second of a call."
+  },
+  "WEBRTC_AVSYNC_WHEN_VIDEO_LAGS_AUDIO_MS": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 1000,
+    "description": "The delay (in milliseconds) when video is behind audio. Zero delay is not counted. Measured every second of a call."
+  },
+  "WEBRTC_VIDEO_QUALITY_INBOUND_BANDWIDTH_KBITS": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000000,
+    "n_buckets": 1000,
+    "description": "Locally measured data rate of inbound video (kbit/s). Computed every second of a call."
+  },
+  "WEBRTC_AUDIO_QUALITY_INBOUND_BANDWIDTH_KBITS": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000000,
+    "n_buckets": 1000,
+    "description": "Locally measured data rate on inbound audio (kbit/s). Computed every second of a call."
+  },
+  "WEBRTC_VIDEO_QUALITY_OUTBOUND_BANDWIDTH_KBITS": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000000,
+    "n_buckets": 1000,
+    "description": "Data rate deduced from RTCP from remote recipient of outbound video (kbit/s). Computed every second of a call (for easy comparison)."
+  },
+  "WEBRTC_AUDIO_QUALITY_OUTBOUND_BANDWIDTH_KBITS": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000000,
+    "n_buckets": 1000,
+    "description": "Data rate deduced from RTCP from remote recipient of outbound audio (kbit/s). Computed every second of a call (for easy comparison)."
+  },
+  "WEBRTC_VIDEO_QUALITY_INBOUND_PACKETLOSS_RATE": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 100,
+    "description": "Locally measured packet loss on inbound video (permille). Sampled every second of a call."
+  },
+  "WEBRTC_AUDIO_QUALITY_INBOUND_PACKETLOSS_RATE": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 100,
+    "description": "Locally measured packet loss on inbound audio (permille). Sampled every second of a call."
+  },
+  "WEBRTC_VIDEO_QUALITY_OUTBOUND_PACKETLOSS_RATE": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 100,
+    "description": "RTCP-reported packet loss by remote recipient of outbound video (permille). Sampled every second of a call (for easy comparison)."
+  },
+  "WEBRTC_AUDIO_QUALITY_OUTBOUND_PACKETLOSS_RATE": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 100,
+    "description": "RTCP-reported packet loss by remote recipient of outbound audio (permille). Sampled every second of a call (for easy comparison)."
+  },
+  "WEBRTC_VIDEO_QUALITY_INBOUND_JITTER": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 100,
+    "description": "Locally measured jitter on inbound video (ms). Sampled every second of a call."
+  },
+  "WEBRTC_AUDIO_QUALITY_INBOUND_JITTER": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 1000,
+    "description": "Locally measured jitter on inbound audio (ms). Sampled every second of a call."
+  },
+  "WEBRTC_VIDEO_QUALITY_OUTBOUND_JITTER": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 1000,
+    "description": "RTCP-reported jitter by remote recipient of outbound video (ms). Sampled every second of a call (for easy comparison)."
+  },
+  "WEBRTC_AUDIO_QUALITY_OUTBOUND_JITTER": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 1000,
+    "description": "RTCP-reported jitter by remote recipient of outbound audio (ms). Sampled every second of a call (for easy comparison)."
+  },
+  "WEBRTC_VIDEO_ERROR_RECOVERY_MS": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 500,
+    "description": "Time to recover from a video error in ms"
+  },
+  "WEBRTC_VIDEO_RECOVERY_BEFORE_ERROR_PER_MIN": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 200,
+    "description": "Number of losses recovered before error per min"
+  },
+  "WEBRTC_VIDEO_RECOVERY_AFTER_ERROR_PER_MIN": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 200,
+    "description": "Number of losses recovered after error per min"
+  },
+  "WEBRTC_VIDEO_DECODE_ERROR_TIME_PERMILLE": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 100,
+    "description": "Percentage*10 (permille) of call decoding with errors or frozen due to errors"
+  },
+  "WEBRTC_VIDEO_QUALITY_OUTBOUND_RTT": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 1000,
+    "description": "Roundtrip time of outbound video (ms). Sampled every second of a call."
+  },
+  "WEBRTC_AUDIO_QUALITY_OUTBOUND_RTT": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 1000,
+    "description": "Roundtrip time of outbound audio (ms). Sampled every second of a call."
+  },
+  "WEBRTC_VIDEO_ENCODER_BITRATE_AVG_PER_CALL_KBPS": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 100,
+    "description": "Video encoder's average bitrate (in kbits/s) over an entire call"
+  },
+  "WEBRTC_VIDEO_ENCODER_BITRATE_STD_DEV_PER_CALL_KBPS": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 5000,
+    "n_buckets": 100,
+    "description": "Standard deviation from video encoder's average bitrate (in kbits/s) over an entire call"
+  },
+  "WEBRTC_VIDEO_ENCODER_FRAMERATE_AVG_PER_CALL": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 200,
+    "n_buckets": 50,
+    "description": "Video encoder's average framerate (in fps) over an entire call"
+  },
+  "WEBRTC_VIDEO_ENCODER_FRAMERATE_10X_STD_DEV_PER_CALL": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 200,
+    "n_buckets": 50,
+    "description": "Standard deviation from video encoder's average framerate (in 1/10 fps) over an entire call"
+  },
+  "WEBRTC_VIDEO_ENCODER_DROPPED_FRAMES_PER_CALL_FPM": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 50000,
+    "n_buckets": 100,
+    "description": "Video encoder's number of frames dropped (in frames/min) over an entire call"
+  },
+  "WEBRTC_VIDEO_DECODER_BITRATE_AVG_PER_CALL_KBPS": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 100,
+    "description": "Video decoder's average bitrate (in kbits/s) over an entire call"
+  },
+  "WEBRTC_VIDEO_DECODER_BITRATE_STD_DEV_PER_CALL_KBPS": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 5000,
+    "n_buckets": 100,
+    "description": "Standard deviation from video decoder's average bitrate (in kbits/s) over an entire call"
+  },
+  "WEBRTC_VIDEO_DECODER_FRAMERATE_AVG_PER_CALL": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 200,
+    "n_buckets": 50,
+    "description": "Video decoder's average framerate (in fps) over an entire call"
+  },
+  "WEBRTC_VIDEO_DECODER_FRAMERATE_10X_STD_DEV_PER_CALL": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 200,
+    "n_buckets": 50,
+    "description": "Standard deviation from video decoder's average framerate (in 1/10 fps) over an entire call"
+  },
+  "WEBRTC_VIDEO_DECODER_DISCARDED_PACKETS_PER_CALL_PPM": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 50000,
+    "n_buckets": 100,
+    "description": "Video decoder's number of discarded packets (in packets/min) over an entire call"
+  },
+  "WEBRTC_CALL_DURATION": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 1000,
+    "description": "The length of time (in seconds) that a call lasted."
+  },
+  "WEBRTC_CALL_COUNT_2": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1261063],
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "The number of calls made during a session."
+  },
+  "WEBRTC_ICE_ADD_CANDIDATE_ERRORS_GIVEN_SUCCESS": {
+    "alert_emails": ["webrtc-ice-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1319268],
+    "expires_in_version": "58",
+    "kind": "linear",
+    "high": 30,
+    "n_buckets": 29,
+    "description": "The number of times AddIceCandidate failed on a given PeerConnection, given that ICE succeeded."
+  },
+  "WEBRTC_ICE_ADD_CANDIDATE_ERRORS_GIVEN_FAILURE": {
+    "alert_emails": ["webrtc-ice-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1319268],
+    "expires_in_version": "58",
+    "kind": "linear",
+    "high": 30,
+    "n_buckets": 29,
+    "description": "The number of times AddIceCandidate failed on a given PeerConnection, given that ICE failed."
+  },
+  "WEBRTC_GET_USER_MEDIA_SECURE_ORIGIN": {
+    "alert_emails": ["seceng@mozilla.org"],
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 15,
+    "description": "Origins for getUserMedia calls (0=other, 1=HTTPS, 2=file, 3=app, 4=localhost, 5=loop, 6=privileged)",
+    "releaseChannelCollection": "opt-out"
+  },
+  "WEBRTC_GET_USER_MEDIA_TYPE": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 8,
+    "description": "Type for media in getUserMedia calls (0=Camera, 1=Screen, 2=Application, 3=Window, 4=Browser, 5=Microphone, 6=AudioCapture, 7=Other)"
+  },
+  "WEBRTC_LOAD_STATE_RELAXED": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 100,
+    "n_buckets": 25,
+    "description": "Percentage of time spent in the Relaxed load state in calls over 30 seconds."
+  },
+  "WEBRTC_LOAD_STATE_RELAXED_SHORT": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 100,
+    "n_buckets": 25,
+    "description": "Percentage of time spent in the Relaxed load state in calls 5-30 seconds."
+  },
+  "WEBRTC_LOAD_STATE_NORMAL": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 100,
+    "n_buckets": 25,
+    "description": "Percentage of time spent in the Normal load state in calls over 30 seconds."
+  },
+  "WEBRTC_LOAD_STATE_NORMAL_SHORT": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 100,
+    "n_buckets": 25,
+    "description": "Percentage of time spent in the Normal load state in calls over 5-30 seconds."
+  },
+  "WEBRTC_LOAD_STATE_STRESSED": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 100,
+    "n_buckets": 25,
+    "description": "Percentage of time spent in the Stressed load state in calls over 30 seconds."
+  },
+  "WEBRTC_LOAD_STATE_STRESSED_SHORT": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 100,
+    "n_buckets": 25,
+    "description": "Percentage of time spent in the Stressed load state in calls 5-30 seconds."
+  },
+  "WEBRTC_RENEGOTIATIONS": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 21,
+    "n_buckets": 20,
+    "description": "Number of Renegotiations during each call"
+  },
+  "WEBRTC_MAX_VIDEO_SEND_TRACK": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 10,
+    "n_buckets": 9,
+    "description": "Number of Video tracks sent simultaneously"
+  },
+  "WEBRTC_MAX_VIDEO_RECEIVE_TRACK": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 20,
+    "n_buckets": 19,
+    "description": "Number of Video tracks received simultaneously"
+  },
+  "WEBRTC_MAX_AUDIO_SEND_TRACK": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 20,
+    "n_buckets": 19,
+    "description": "Number of Audio tracks sent simultaneously"
+  },
+  "WEBRTC_MAX_AUDIO_RECEIVE_TRACK": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 30,
+    "n_buckets": 29,
+    "description": "Number of Audio tracks received simultaneously"
+  },
+  "WEBRTC_DATACHANNEL_NEGOTIATED": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Was DataChannels negotiated"
+  },
+  "WEBRTC_CALL_TYPE": {
+    "alert_emails": ["webrtc-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 8,
+    "description": "Type of call: (Bitmask) Audio = 1, Video = 2, DataChannels = 4"
+  },
+  "DEVTOOLS_TOOLBOX_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools toolbox has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_OPTIONS_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools options panel has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_WEBCONSOLE_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Web Console has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_BROWSERCONSOLE_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Browser Console has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_INSPECTOR_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Inspector has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_RULEVIEW_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Rule View has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_COMPUTEDVIEW_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Computed View has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_FONTINSPECTOR_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Font Inspector has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_ANIMATIONINSPECTOR_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Animation Inspector has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_JSDEBUGGER_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Debugger has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_JSBROWSERDEBUGGER_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Browser Debugger has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_STYLEEDITOR_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Style Editor has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_SHADEREDITOR_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Shader Editor has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_WEBAUDIOEDITOR_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Web Audio Editor has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_CANVASDEBUGGER_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Canvas Debugger has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_JSPROFILER_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools JS Profiler has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_MEMORY_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Memory Tool has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_NETMONITOR_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Network Monitor has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_STORAGE_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Storage Inspector has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_DOM_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1343501],
+    "description": "Number of times the DevTools DOM Inspector has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_PAINTFLASHING_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Paint Flashing has been opened via the toolbox button.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_TILT_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Tilt has been opened via the toolbox button.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_SCRATCHPAD_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Scratchpad toolbox panel has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_SCRATCHPAD_WINDOW_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1214352, 1247985],
+    "description": "Number of times the DevTools Scratchpad standalone window has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_RESPONSIVE_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Responsive Design Mode tool has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_EYEDROPPER_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Eyedropper tool has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_MENU_EYEDROPPER_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Eyedropper has been opened via the DevTools menu.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_PICKER_EYEDROPPER_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Eyedropper has been opened via the color picker.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_DEVELOPERTOOLBAR_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools Developer Toolbar / GCLI has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_ABOUTDEBUGGING_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org", "jan@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985, 1204601],
+    "description": "Number of times about:debugging has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_WEBIDE_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools WebIDE has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_WEBIDE_PROJECT_EDITOR_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times the DevTools WebIDE project editor has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_WEBIDE_PROJECT_EDITOR_SAVE_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times a file has been saved in the DevTools WebIDE project editor.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_WEBIDE_NEW_PROJECT_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times a new project has been created in the DevTools WebIDE.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_WEBIDE_IMPORT_PROJECT_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times a project has been imported into the DevTools WebIDE.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_CUSTOM_OPENED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1247985],
+    "description": "Number of times a custom developer tool has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_RELOAD_ADDON_INSTALLED_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "55",
+    "kind": "count",
+    "description": "Number of times the reload addon has been installed.",
+    "bug_numbers": [1248435]
+  },
+  "DEVTOOLS_RELOAD_ADDON_RELOAD_COUNT": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "55",
+    "kind": "count",
+    "description": "Number of times the tools have been reloaded by the reload addon.",
+    "bug_numbers": [1248435]
+  },
+  "DEVTOOLS_TOOLBOX_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has the toolbox been active (seconds)"
+  },
+  "DEVTOOLS_OPTIONS_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has the options panel been active (seconds)"
+  },
+  "DEVTOOLS_WEBCONSOLE_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has the web console been active (seconds)"
+  },
+  "DEVTOOLS_BROWSERCONSOLE_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has the browser console been active (seconds)"
+  },
+  "DEVTOOLS_INSPECTOR_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has the inspector been active (seconds)"
+  },
+  "DEVTOOLS_RULEVIEW_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has the rule view been active (seconds)"
+  },
+  "DEVTOOLS_COMPUTEDVIEW_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has the computed view been active (seconds)"
+  },
+  "DEVTOOLS_FONTINSPECTOR_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has the font inspector been active (seconds)"
+  },
+  "DEVTOOLS_ANIMATIONINSPECTOR_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has the animation inspector been active (seconds)"
+  },
+  "DEVTOOLS_JSDEBUGGER_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has the JS debugger been active (seconds)"
+  },
+  "DEVTOOLS_JSBROWSERDEBUGGER_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has the JS browser debugger been active (seconds)"
+  },
+  "DEVTOOLS_STYLEEDITOR_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has the style editor been active (seconds)"
+  },
+  "DEVTOOLS_SHADEREDITOR_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has the Shader Editor been active (seconds)"
+  },
+  "DEVTOOLS_WEBAUDIOEDITOR_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has the Web Audio Editor been active (seconds)"
+  },
+  "DEVTOOLS_CANVASDEBUGGER_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has the Canvas Debugger been active (seconds)"
+  },
+  "DEVTOOLS_JSPROFILER_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has the JS profiler been active (seconds)"
+  },
+  "DEVTOOLS_MEMORY_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has the Memory Tool been active (seconds)"
+  },
+  "DEVTOOLS_NETMONITOR_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has the network monitor been active (seconds)"
+  },
+  "DEVTOOLS_STORAGE_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has the storage inspector been active (seconds)"
+  },
+  "DEVTOOLS_DOM_TIME_ACTIVE_SECONDS": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "bug_numbers": [1343501],
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has the DOM inspector been active (seconds)"
+  },
+  "DEVTOOLS_PAINTFLASHING_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has paint flashing been active (seconds)"
+  },
+  "DEVTOOLS_TILT_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has Tilt been active (seconds)"
+  },
+  "DEVTOOLS_SCRATCHPAD_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has Scratchpad been active (seconds)"
+  },
+  "DEVTOOLS_RESPONSIVE_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "55",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "bug_numbers": [1242057],
+    "description": "How long has the responsive view been active (seconds)",
+    "releaseChannelCollection": "opt-out"
+  },
+  "DEVTOOLS_DEVELOPERTOOLBAR_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has the developer toolbar been active (seconds)"
+  },
+  "DEVTOOLS_ABOUTDEBUGGING_TIME_ACTIVE_SECONDS": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org", "jan@mozilla.com"],
+    "expires_in_version": "55",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has about:debugging been active? (seconds) (bug 1204601)"
+  },
+  "DEVTOOLS_WEBIDE_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has WebIDE been active (seconds)"
+  },
+  "DEVTOOLS_WEBIDE_PROJECT_EDITOR_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has WebIDE's project editor been active (seconds)"
+  },
+  "DEVTOOLS_CUSTOM_TIME_ACTIVE_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long has a custom developer tool been active (seconds)"
+  },
+  "DEVTOOLS_WEBIDE_CONNECTION_RESULT": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Did WebIDE runtime connection succeed?"
+  },
+  "DEVTOOLS_WEBIDE_USB_CONNECTION_RESULT": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Did WebIDE USB runtime connection succeed?"
+  },
+  "DEVTOOLS_WEBIDE_WIFI_CONNECTION_RESULT": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Did WebIDE WiFi runtime connection succeed?"
+  },
+  "DEVTOOLS_WEBIDE_SIMULATOR_CONNECTION_RESULT": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Did WebIDE simulator runtime connection succeed?"
+  },
+  "DEVTOOLS_WEBIDE_REMOTE_CONNECTION_RESULT": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Did WebIDE remote runtime connection succeed?"
+  },
+  "DEVTOOLS_WEBIDE_LOCAL_CONNECTION_RESULT": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Did WebIDE local runtime connection succeed?"
+  },
+  "DEVTOOLS_WEBIDE_OTHER_CONNECTION_RESULT": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Did WebIDE other runtime connection succeed?"
+  },
+  "DEVTOOLS_WEBIDE_CONNECTION_TIME_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 100,
+    "description": "How long was WebIDE connected to a runtime (seconds)?"
+  },
+  "DEVTOOLS_WEBIDE_CONNECTION_PLAY_USED": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Was WebIDE's play button used during this runtime connection?"
+  },
+  "DEVTOOLS_WEBIDE_CONNECTION_DEBUG_USED": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Was WebIDE's debug button used during this runtime connection?"
+  },
+  "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_TYPE": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "keyed": true,
+    "description": "What runtime type did WebIDE connect to?"
+  },
+  "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_ID": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "keyed": true,
+    "description": "What runtime ID did WebIDE connect to?"
+  },
+  "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_PROCESSOR": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "keyed": true,
+    "description": "What runtime processor did WebIDE connect to?"
+  },
+  "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_OS": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "keyed": true,
+    "description": "What runtime OS did WebIDE connect to?"
+  },
+  "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_PLATFORM_VERSION": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "keyed": true,
+    "description": "What runtime platform version did WebIDE connect to?"
+  },
+  "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_APP_TYPE": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "keyed": true,
+    "description": "What runtime app type did WebIDE connect to?"
+  },
+  "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_VERSION": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "keyed": true,
+    "description": "What runtime version did WebIDE connect to?"
+  },
+  "DEVTOOLS_OS_ENUMERATED_PER_USER": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 13,
+    "description": "OS of DevTools user (0:Windows XP, 1:Windows Vista, 2:Windows 7, 3:Windows 8, 4:Windows 8.1, 5:OSX, 6:Linux 7:Windows 10, 8:reserved, 9:reserved, 10:reserved, 11:reserved, 12:other)"
+  },
+  "DEVTOOLS_OS_IS_64_BITS_PER_USER": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 3,
+    "description": "OS bit size of DevTools user (0:32bit, 1:64bit, 2:128bit)"
+    },
+  "DEVTOOLS_SCREEN_RESOLUTION_ENUMERATED_PER_USER": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 13,
+    "description": "Screen resolution of DevTools user (0:lower, 1:800x600, 2:1024x768, 3:1280x800, 4:1280x1024, 5:1366x768, 6:1440x900, 7:1920x1080, 8:2560×1440, 9:2560×1600, 10:2880x1800, 11:other, 12:higher)"
+  },
+  "DEVTOOLS_TABS_OPEN_PEAK_LINEAR": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 101,
+    "n_buckets": 100,
+    "description": "The peak number of open tabs in all windows for a session for devtools users."
+  },
+  "DEVTOOLS_TABS_OPEN_AVERAGE_LINEAR": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 101,
+    "n_buckets": 100,
+    "description": "The mean number of open tabs in all windows for a session for devtools users."
+  },
+  "DEVTOOLS_TABS_PINNED_PEAK_LINEAR": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 101,
+    "n_buckets": 100,
+    "description": "The peak number of pinned tabs (app tabs) in all windows for a session for devtools users."
+  },
+  "DEVTOOLS_TABS_PINNED_AVERAGE_LINEAR": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 101,
+    "n_buckets": 100,
+    "description": "The mean number of pinned tabs (app tabs) in all windows for a session for devtools users."
+  },
+  "DEVTOOLS_SAVE_HEAP_SNAPSHOT_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 100000,
+    "n_buckets": 1000,
+    "description": "The time (in milliseconds) that it took to save a heap snapshot in mozilla::devtools::ChromeUtils::SaveHeapSnapshot."
+  },
+  "DEVTOOLS_READ_HEAP_SNAPSHOT_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 100000,
+    "n_buckets": 1000,
+    "description": "The time (in milliseconds) that it took to read a heap snapshot in mozilla::devtools::ChromeUtils::ReadHeapSnapshot."
+  },
+  "DEVTOOLS_HEAP_SNAPSHOT_NODE_COUNT": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 10000000,
+    "n_buckets": 10000,
+    "description": "The number of nodes serialized into a heap snapshot."
+  },
+  "DEVTOOLS_HEAP_SNAPSHOT_EDGE_COUNT": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 10000000,
+    "n_buckets": 10000,
+    "description": "The number of edges serialized into a heap snapshot."
+  },
+  "DEVTOOLS_PERFTOOLS_RECORDING_COUNT": {
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Incremented whenever a performance tool recording is completed."
+  },
+  "DEVTOOLS_PERFTOOLS_CONSOLE_RECORDING_COUNT": {
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Incremented whenever a performance tool recording is completed that was initiated via console.profile."
+  },
+  "DEVTOOLS_PERFTOOLS_RECORDING_IMPORT_FLAG": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "When a user imports a recording in the performance tool."
+  },
+  "DEVTOOLS_PERFTOOLS_RECORDING_EXPORT_FLAG": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "When a user imports a recording in the performance tool."
+  },
+  "DEVTOOLS_PERFTOOLS_RECORDING_FEATURES_USED": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "keyed": true,
+    "description": "When a user starts a recording with specific recording options, keyed by feature name (withMarkers, withAllocations, etc.)."
+  },
+  "DEVTOOLS_PERFTOOLS_RECORDING_DURATION_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 600000,
+    "n_buckets": 20,
+    "description": "The length of a duration in MS of a performance tool recording."
+  },
+  "DEVTOOLS_PERFTOOLS_SELECTED_VIEW_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "keyed": true,
+    "high": 600000,
+    "n_buckets": 20,
+    "description": "The amount of time spent in a specific performance tool view, keyed by view name (waterfall, js-calltree, js-flamegraph, etc)."
+  },
+  "DEVTOOLS_JAVASCRIPT_ERROR_DISPLAYED": {
+    "alert_emails": ["mphillips@mozilla.com"],
+    "bug_numbers": [1255133],
+    "expires_in_version": "55",
+    "kind": "boolean",
+    "keyed": true,
+    "description": "Measures whether a particular JavaScript error has been displayed in the webconsole."
+  },
+  "DEVTOOLS_TOOLBOX_HOST": {
+    "alert_emails": ["dev-developer-tools@lists.mozilla.org"],
+    "expires_in_version": "58",
+    "kind": "enumerated",
+    "bug_numbers": [1205845],
+    "n_values": 9,
+    "releaseChannelCollection": "opt-out",
+    "description": "Records DevTools toolbox host each time the toolbox is opened and when the host is changed (0:Bottom, 1:Side, 2:Window, 3:Custom, 9:Unknown)."
+  },
+  "VIEW_SOURCE_IN_BROWSER_OPENED_BOOLEAN": {
+    "alert_emails": ["mozilla-dev-developer-tools@lists.mozilla.org", "jryans@mozilla.com"],
+    "expires_in_version": "53",
+    "kind": "boolean",
+    "description": "How many times has view source in browser / tab been opened?"
+  },
+  "VIEW_SOURCE_IN_WINDOW_OPENED_BOOLEAN": {
+    "alert_emails": ["mozilla-dev-developer-tools@lists.mozilla.org", "jryans@mozilla.com"],
+    "expires_in_version": "53",
+    "kind": "boolean",
+    "description": "How many times has view source in a new window been opened?"
+  },
+  "VIEW_SOURCE_EXTERNAL_RESULT_BOOLEAN": {
+    "alert_emails": ["mozilla-dev-developer-tools@lists.mozilla.org", "jryans@mozilla.com"],
+    "expires_in_version": "53",
+    "kind": "boolean",
+    "description": "How many times has view source in an external editor been opened, and did it succeed?"
+  },
+  "BROWSER_IS_USER_DEFAULT": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "releaseChannelCollection": "opt-out",
+    "description": "The result of the startup default desktop browser check."
+  },
+  "BROWSER_IS_USER_DEFAULT_ERROR": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "releaseChannelCollection": "opt-out",
+    "description": "True if the browser was unable to determine if the browser was set as default."
+  },
+  "BROWSER_SET_DEFAULT_DIALOG_PROMPT_RAWCOUNT": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 250,
+    "n_buckets": 15,
+    "releaseChannelCollection": "opt-out",
+    "description": "The number of times that a profile has seen the 'Set Default Browser' dialog."
+  },
+  "BROWSER_SET_DEFAULT_ALWAYS_CHECK": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "releaseChannelCollection": "opt-out",
+    "description": "True if the profile has `browser.shell.checkDefaultBrowser` set to true."
+  },
+  "BROWSER_SET_DEFAULT_RESULT": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 4,
+    "releaseChannelCollection": "opt-out",
+    "description": "Result of the Set Default Browser dialog (0=Use Firefox + 'Always perform check' unchecked, 1=Use Firefox + 'Always perform check' checked, 2=Not Now + 'Always perform check' unchecked, 3=Not Now + 'Always perform check' checked)"
+  },
+  "BROWSER_SET_DEFAULT_ERROR": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "releaseChannelCollection": "opt-out",
+    "description": "True if the browser was unable to set Firefox as the default browser"
+  },
+  "BROWSER_SET_DEFAULT_TIME_TO_COMPLETION_SECONDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 500,
+    "n_buckets": 15,
+    "releaseChannelCollection": "opt-out",
+    "description": "Time to successfully set Firefox as the default browser after clicking 'Set Firefox as Default'. Should be near-instant in some environments, others require user interaction. Measured in seconds."
+  },
+  "BROWSER_IS_ASSIST_DEFAULT": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "The result of the default browser check for assist intent."
+  },
+  "MIXED_CONTENT_PAGE_LOAD": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 4,
+    "description": "Accumulates type of content per page load (0=no mixed or non-secure page, 1=mixed passive, 2=mixed active, 3=mixed passive and mixed active)"
+  },
+  "MIXED_CONTENT_UNBLOCK_COUNTER": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 3,
+    "description": "A simple counter of daily mixed-content unblock operations and top documents loaded"
+  },
+  "MIXED_CONTENT_HSTS": {
+    "alert_emails": ["seceng@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "How often would blocked mixed content be allowed if HSTS upgrades were allowed? 0=display/no-HSTS, 1=display/HSTS, 2=active/no-HSTS, 3=active/HSTS"
+  },
+  "MIXED_CONTENT_HSTS_PRIMING": {
+    "alert_emails": ["seceng@mozilla.org"],
+    "bug_numbers": [1246540],
+    "expires_in_version": "60",
+    "kind": "enumerated",
+    "n_values": 16,
+    "description": "How often would blocked mixed content be allowed if HSTS upgrades were allowed, including how often would we send an HSTS priming request? 0=display/no-HSTS, 1=display/HSTS, 2=active/no-HSTS, 3=active/HSTS, 4=display/no-HSTS-priming, 5=display/do-HSTS-priming, 6=active/no-HSTS-priming, 7=active/do-HSTS-priming"
+  },
+  "MIXED_CONTENT_HSTS_PRIMING_RESULT": {
+    "alert_emails": ["seceng@mozilla.org"],
+    "bug_numbers": [1246540],
+    "expires_in_version": "60",
+    "kind": "enumerated",
+    "n_values": 16,
+    "description": "How often do we get back an HSTS priming result which upgrades the connection to HTTPS? 0=cached (no upgrade), 1=cached (do upgrade), 2=cached (blocked), 3=already upgraded, 4=priming succeeded, 5=priming succeeded (block due to pref), 6=priming succeeded (no upgrade due to pref), 7=priming failed (block), 8=priming failed (accept), 9=timeout (block), 10=timeout (accept)"
+  },
+  "HSTS_PRIMING_REQUEST_DURATION": {
+    "alert_emails": ["seceng-telemetry@mozilla.org"],
+    "bug_numbers": [1311893],
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "low": 100,
+    "high": 30000,
+    "n_buckets": 100,
+    "keyed": true,
+    "description": "The amount of time required for HSTS priming requests (ms), keyed by success or failure of the priming request. (success, failure)"
+  },
+  "MIXED_CONTENT_OBJECT_SUBREQUEST": {
+    "alert_emails": ["seceng@mozilla.org"],
+    "bug_numbers": [1244116],
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "How often objects load insecure content on secure pages (counting pages, not objects). 0=pages with no mixed object subrequests, 1=pages with mixed object subrequests"
+  },
+  "COOKIE_SCHEME_SECURITY": {
+    "alert_emails": ["seceng@mozilla.org"],
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 10,
+    "releaseChannelCollection": "opt-out",
+    "description": "How often are secure cookies set from non-secure origins, and vice-versa? 0=nonsecure/http, 1=nonsecure/https, 2=secure/http, 3=secure/https"
+  },
+  "COOKIE_LEAVE_SECURE_ALONE": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "bug_numbers": [976073, 1325909],
+    "expires_in_version": "57",
+    "kind": "enumerated",
+    "n_values": 10,
+    "releaseChannelCollection": "opt-out",
+    "description": "Strict Secure Cookies: 0=blocked secure cookie from http; 1=blocked shadowing secure cookie from http; 2=shadowing secure cookie from https; 3=evicted newer insecure cookie; 4=evicted oldest insecure cookie; 5=evicted secure cookie; 6=evicting secure cookie blocked; 7=blocked downgrading secure cookie from http; 8=downgraded secure cookie from https"
+  },
+  "NTLM_MODULE_USED_2": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 8,
+    "description": "The module used for the NTLM protocol (Windows_API, Kerberos, Samba_auth or Generic) and whether or not the authentication was used to connect to a proxy server. This data is collected only once per session (at first NTLM authentification) ; fixed version."
+  },
+  "FX_THUMBNAILS_BG_QUEUE_SIZE_ON_CAPTURE": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 100,
+    "n_buckets": 15,
+    "description": "BACKGROUND THUMBNAILS: Size of capture queue when a capture request is received"
+  },
+  "FX_THUMBNAILS_BG_CAPTURE_QUEUE_TIME_MS": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 300000,
+    "n_buckets": 20,
+    "description": "BACKGROUND THUMBNAILS: Time the capture request spent in the queue before being serviced (ms)"
+  },
+  "FX_THUMBNAILS_BG_CAPTURE_SERVICE_TIME_MS": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 20,
+    "description": "BACKGROUND THUMBNAILS: Time the capture took once it started and successfully completed (ms)"
+  },
+  "FX_THUMBNAILS_BG_CAPTURE_DONE_REASON_2": {
+    "expires_in_version": "default",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "BACKGROUND THUMBNAILS: Reason the capture completed (see TEL_CAPTURE_DONE_* constants in BackgroundPageThumbs.jsm)"
+  },
+  "FX_THUMBNAILS_BG_CAPTURE_PAGE_LOAD_TIME_MS": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 20,
+    "description": "BACKGROUND THUMBNAILS: Time the capture's page load took (ms)"
+  },
+  "FX_THUMBNAILS_BG_CAPTURE_CANVAS_DRAW_TIME_MS": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 500,
+    "n_buckets": 15,
+    "description": "BACKGROUND THUMBNAILS: Time it took to draw the capture's window to canvas (ms)"
+  },
+  "NETWORK_CACHE_V2_MISS_TIME_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent to find out a cache entry file is missing"
+  },
+  "NETWORK_CACHE_V2_HIT_TIME_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent to open an existing file"
+  },
+  "NETWORK_CACHE_V1_TRUNCATE_TIME_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent to reopen an entry with OPEN_TRUNCATE"
+  },
+  "NETWORK_CACHE_V1_MISS_TIME_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent to find out a cache entry is missing"
+  },
+  "NETWORK_CACHE_V1_HIT_TIME_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent to open an existing cache entry"
+  },
+  "NETWORK_CACHE_V2_OUTPUT_STREAM_STATUS": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 7,
+    "description": "Final status of the CacheFileOutputStream (0=ok, 1=other error, 2=out of memory, 3=disk full, 4=file corrupted, 5=file not found, 6=binding aborted)"
+  },
+  "NETWORK_CACHE_V2_INPUT_STREAM_STATUS": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 7,
+    "description": "Final status of the CacheFileInputStream (0=ok, 1=other error, 2=out of memory, 3=disk full, 4=file corrupted, 5=file not found, 6=binding aborted)"
+  },
+  "NETWORK_CACHE_FS_TYPE": {
+    "expires_in_version": "42",
+    "kind": "enumerated",
+    "n_values": 5,
+    "description": "Type of FS that the cache is stored on (0=NTFS (Win), 1=FAT32 (Win), 2=FAT (Win), 3=other FS (Win), 4=other OS)"
+  },
+  "NETWORK_CACHE_SIZE_FULL_FAT": {
+    "expires_in_version": "42",
+    "kind": "linear",
+    "high": 500,
+    "n_buckets": 50,
+    "description": "Size (in MB) of a cache that reached a file count limit"
+  },
+  "NETWORK_CACHE_HIT_MISS_STAT_PER_CACHE_SIZE": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 40,
+    "description": "Hit/Miss count split by cache size in file count (0=Hit 0-5000, 1=Miss 0-5000, 2=Hit 5001-10000, ...)"
+  },
+  "NETWORK_CACHE_HIT_RATE_PER_CACHE_SIZE": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 400,
+    "description": "Hit rate for a specific cache size in file count. The hit rate is split into 20 buckets, the lower limit of the range in percents is 5*n/20. The cache size is divided into 20 ranges of length 5000, the lower limit of the range is 5000*(n%20)"
+  },
+  "NETWORK_CACHE_METADATA_FIRST_READ_TIME_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent to read the first part of the metadata from the cache entry file."
+  },
+  "NETWORK_CACHE_METADATA_SECOND_READ_TIME_MS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 50,
+    "description": "Time spent to read the missing part of the metadata from the cache entry file."
+  },
+  "NETWORK_CACHE_METADATA_FIRST_READ_SIZE": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 5119,
+    "n_buckets": 256,
+    "description": "Guessed size of the metadata that we read from the cache file as the first part."
+  },
+  "NETWORK_CACHE_METADATA_SIZE": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 5119,
+    "n_buckets": 256,
+    "description": "Actual size of the metadata parsed from the disk."
+  },
+  "NETWORK_CACHE_HASH_STATS": {
+    "expires_in_version": "46",
+    "kind": "enumerated",
+    "n_values": 160,
+    "description": "The longest hash match between a newly added entry and all the existing entries."
+  },
+  "DATABASE_LOCKED_EXCEPTION": {
+    "expires_in_version": "42",
+    "kind": "enumerated",
+    "description": "Record database locks when opening one of Fennec's databases. The index corresponds to how many attempts, beginning with 0.",
+    "n_values": 5
+  },
+  "DATABASE_SUCCESSFUL_UNLOCK": {
+    "expires_in_version": "42",
+    "kind": "enumerated",
+    "description": "Record on which attempt we successfully unlocked a database. See DATABASE_LOCKED_EXCEPTION.",
+    "n_values": 5
+  },
+  "SSL_TLS13_INTOLERANCE_REASON_PRE": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "bug_numbers": [1250568],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 64,
+    "description": "Potential TLS 1.3 intolerance, before considering historical info (see tlsIntoleranceTelemetryBucket() in nsNSSIOLayer.cpp)."
+  },
+  "SSL_TLS13_INTOLERANCE_REASON_POST": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "bug_numbers": [1250568],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 64,
+    "description": "Potential TLS 1.3 intolerance, after considering historical info (see tlsIntoleranceTelemetryBucket() in nsNSSIOLayer.cpp)."
+  },
+  "SSL_TLS12_INTOLERANCE_REASON_PRE": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 64,
+    "description": "Potential TLS 1.2 intolerance, before considering historical info (see tlsIntoleranceTelemetryBucket() in nsNSSIOLayer.cpp)."
+  },
+  "SSL_TLS12_INTOLERANCE_REASON_POST": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 64,
+    "description": "Potential TLS 1.2 intolerance, after considering historical info (see tlsIntoleranceTelemetryBucket() in nsNSSIOLayer.cpp)."
+  },
+  "SSL_TLS11_INTOLERANCE_REASON_PRE": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 64,
+    "description": "Potential TLS 1.1 intolerance, before considering historical info (see tlsIntoleranceTelemetryBucket() in nsNSSIOLayer.cpp)."
+  },
+  "SSL_TLS11_INTOLERANCE_REASON_POST": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 64,
+    "description": "Potential TLS 1.1 intolerance, after considering historical info (see tlsIntoleranceTelemetryBucket() in nsNSSIOLayer.cpp)."
+  },
+  "SSL_TLS10_INTOLERANCE_REASON_PRE": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 64,
+    "description": "Potential TLS 1.0 intolerance, before considering historical info (see tlsIntoleranceTelemetryBucket() in nsNSSIOLayer.cpp)."
+  },
+  "SSL_TLS10_INTOLERANCE_REASON_POST": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 64,
+    "description": "Potential TLS 1.0 intolerance, after considering historical info (see tlsIntoleranceTelemetryBucket() in nsNSSIOLayer.cpp)."
+  },
+  "SSL_VERSION_FALLBACK_INAPPROPRIATE": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 64,
+    "description": "TLS/SSL version intolerance was falsely detected, server rejected handshake (see tlsIntoleranceTelemetryBucket() in nsNSSIOLayer.cpp)."
+  },
+  "SSL_CIPHER_SUITE_FULL": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 128,
+    "description": "Negotiated cipher suite in full handshake (see key in HandshakeCallback in nsNSSCallbacks.cpp)"
+  },
+  "SSL_CIPHER_SUITE_RESUMED": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 128,
+    "description": "Negotiated cipher suite in resumed handshake (see key in HandshakeCallback in nsNSSCallbacks.cpp)"
+  },
+  "SSL_KEA_RSA_KEY_SIZE_FULL": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 24,
+    "description": "RSA KEA (TLS_RSA_*) key size in full handshake"
+  },
+  "SSL_KEA_DHE_KEY_SIZE_FULL": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 24,
+    "description": "DHE KEA (TLS_DHE_*) key size in full handshake"
+  },
+  "SSL_KEA_ECDHE_CURVE_FULL": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 36,
+    "description": "ECDHE KEA (TLS_ECDHE_*) curve (23=P-256, 24=P-384, 25=P-521) in full handshake"
+  },
+  "SSL_AUTH_ALGORITHM_FULL": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 16,
+    "description": "SSL Authentication Algorithm (null=0, rsa=1, dsa=2, ecdsa=4) in full handshake"
+  },
+  "SSL_AUTH_RSA_KEY_SIZE_FULL": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 24,
+    "description": "RSA signature key size for TLS_*_RSA_* in full handshake"
+  },
+  "SSL_AUTH_ECDSA_CURVE_FULL": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 36,
+    "description": "ECDSA signature curve for TLS_*_ECDSA_* in full handshake (23=P-256, 24=P-384, 25=P-521)"
+  },
+  "SSL_SYMMETRIC_CIPHER_FULL": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 32,
+    "description": "Symmetric cipher used in full handshake (null=0, 3des=4, aes-cbc=7, aes-gcm=10, chacha20=11)"
+  },
+  "SSL_SYMMETRIC_CIPHER_RESUMED": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 32,
+    "description": "Symmetric cipher used in resumed handshake (null=0, 3des=4, aes-cbc=7, aes-gcm=10, chacha20=11)"
+  },
+  "SSL_REASONS_FOR_NOT_FALSE_STARTING": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 512,
+    "description": "Bitmask of reasons we did not false start when libssl would have let us (see key in nsNSSCallbacks.cpp)"
+  },
+  "SSL_HANDSHAKE_TYPE": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 8,
+    "description": "Type of handshake (1=resumption, 2=false started, 3=chose not to false start, 4=not allowed to false start)"
+  },
+  "SSL_OCSP_STAPLING": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 8,
+    "description": "Status of OCSP stapling on this handshake (1=present, good; 2=none; 3=present, expired; 4=present, other error)"
+  },
+  "SSL_OCSP_MAY_FETCH": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "default",
+    "kind": "enumerated",
+    "n_values": 8,
+    "description": "For non-stapling cases, is OCSP fetching a possibility? (0=yes, 1=no because missing/invalid OCSP URI, 2=no because fetching disabled, 3=no because both)"
+  },
+  "SSL_CERT_ERROR_OVERRIDES": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 24,
+    "description": "Was a certificate error overridden on this handshake? What was it? (0=unknown error (indicating bug), 1=no, >1=a specific error)"
+  },
+  "SSL_CERT_VERIFICATION_ERRORS": {
+    "alert_emails": ["seceng@mozilla.org"],
+    "expires_in_version": "default",
+    "kind": "enumerated",
+    "n_values": 100,
+    "description": "If certificate verification failed in a TLS handshake, what was the error? (see MapCertErrorToProbeValue in security/manager/ssl/SSLServerCertVerification.cpp and the values in security/pkix/include/pkix/Result.h)"
+  },
+  "SSL_CT_POLICY_COMPLIANCE_OF_EV_CERTS": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "62",
+    "kind": "enumerated",
+    "n_values": 10,
+    "bug_numbers": [1320567],
+    "releaseChannelCollection": "opt-out",
+    "description": "Certificate Transparency Policy compliance of successfully established SSL connections with EV certificate (1=Compliant, 2=Insufficient number of SCTs, 3=Insufficient diversity of CT Log operators)"
+  },
+  "SSL_CT_POLICY_COMPLIANT_CONNECTIONS_BY_CA": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 256,
+    "bug_numbers": [1320567],
+    "releaseChannelCollection": "opt-out",
+    "description": "Number of successfully established TLS connections compliant with the Certificate Transparency Policy, by CA. See https://dxr.mozilla.org/mozilla-central/source/security/manager/ssl/RootHashes.inc for names of CAs. Bucket zero holds CAs not present in the list."
+  },
+  "SSL_CT_POLICY_NON_COMPLIANT_CONNECTIONS_BY_CA": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 256,
+    "bug_numbers": [1320567],
+    "releaseChannelCollection": "opt-out",
+    "description": "Number of successfully established TLS connections NOT compliant with the Certificate Transparency Policy, by CA. See https://dxr.mozilla.org/mozilla-central/source/security/manager/ssl/RootHashes.inc for names of CAs. Bucket zero holds CAs not present in the list."
+  },
+  "SSL_PERMANENT_CERT_ERROR_OVERRIDES": {
+    "alert_emails": ["seceng@mozilla.org"],
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 1024,
+    "n_buckets": 10,
+    "description": "How many permanent certificate overrides a user has stored."
+  },
+  "SSL_SCTS_ORIGIN": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 10,
+    "bug_numbers": [1293231],
+    "releaseChannelCollection": "opt-out",
+    "description": "Origin of Signed Certificate Timestamps received (1=Embedded, 2=TLS handshake extension, 3=Stapled OCSP response)"
+  },
+  "SSL_SCTS_PER_CONNECTION": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 10,
+    "bug_numbers": [1293231],
+    "releaseChannelCollection": "opt-out",
+    "description": "Histogram of Signed Certificate Timestamps per SSL connection, from all sources (embedded / OCSP Stapling / TLS handshake). Bucket 0 counts the cases when no SCTs were received, or none were extracted due to parsing errors."
+  },
+  "SSL_SCTS_VERIFICATION_STATUS": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 10,
+    "bug_numbers": [1293231],
+    "releaseChannelCollection": "opt-out",
+    "description": "Verification status of Signed Certificate Timestamps received (0=Decoding error, 1=Valid SCT, 2=SCT from unknown log, 3=Invalid SCT signature, 4=SCT timestamp is in the future, 5=Valid SCT from a disqualified log)"
+  },
+  "SSL_SERVER_AUTH_EKU": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "Presence of of the Server Authenticaton EKU in accepted SSL server certificates (0=No EKU, 1=EKU present and has id_kp_serverAuth, 2=EKU present and has id_kp_serverAuth as well as some other EKU, 3=EKU present but does not contain id_kp_serverAuth)"
+  },
+  "TLS_ERROR_REPORT_UI": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 15,
+    "description": "User interaction with the TLS Error Reporter in about:neterror (0=Error seen, 1='auto' checked, 2='auto' unchecked, 3=Sent manually, 4=Sent automatically, 5=Send success, 6=Send failure, 7=Report section expanded)"
+  },
+  "CERT_OCSP_ENABLED": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Is OCSP fetching enabled? (pref security.OCSP.enabled)"
+  },
+  "CERT_OCSP_REQUIRED": {
+    "alert_emails": ["seceng-telemetry@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Is OCSP required when the cert has an OCSP URI? (pref security.OCSP.require)"
+  },
+  "OSFILE_WORKER_LAUNCH_MS": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "description": "The duration between the instant the first message is sent to OS.File and the moment the OS.File worker starts executing JavaScript, in milliseconds",
+    "high": 5000,
+    "n_buckets": 10
+  },
+  "OSFILE_WORKER_READY_MS": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "description": "The duration between the instant the first message is sent to OS.File and the moment the OS.File worker has finished executing its startup JavaScript and is ready to receive requests, in milliseconds",
+    "high": 5000,
+    "n_buckets": 10
+  },
+  "OSFILE_WRITEATOMIC_JANK_MS": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "description": "The duration during which the main thread is blocked during a call to OS.File.writeAtomic, in milliseconds",
+    "high": 5000,
+    "n_buckets": 10
+  },
+  "CERT_EV_STATUS": {
+    "expires_in_version": "never",
+    "alert_emails": ["seceng@mozilla.org"],
+    "bug_numbers": [1254653],
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "EV status of a certificate, recorded on each TLS connection. 0=invalid, 1=DV, 2=EV"
+  },
+  "CERT_VALIDATION_SUCCESS_BY_CA": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 256,
+    "description": "Successful SSL server cert validations by CA (see RootHashes.inc for names of CAs)"
+  },
+  "CERT_PINNING_FAILURES_BY_CA": {
+    "alert_emails": ["pinning@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 256,
+    "description": "Pinning failures by CA (see RootHashes.inc for names of CAs)"
+  },
+  "CERT_PINNING_RESULTS": {
+    "alert_emails": ["pinning@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Certificate pinning results (0 = failure, 1 = success)"
+  },
+  "CERT_PINNING_TEST_RESULTS": {
+    "alert_emails": ["pinning@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Certificate pinning test results (0 = failure, 1 = success)"
+  },
+  "CERT_PINNING_MOZ_RESULTS": {
+    "alert_emails": ["pinning@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Certificate pinning results for Mozilla sites (0 = failure, 1 = success)"
+  },
+  "CERT_PINNING_MOZ_TEST_RESULTS": {
+    "alert_emails": ["pinning@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Certificate pinning test results for Mozilla sites (0 = failure, 1 = success)"
+  },
+  "CERT_PINNING_MOZ_RESULTS_BY_HOST": {
+    "alert_emails": ["pinning@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 512,
+    "description": "Certificate pinning results by host for Mozilla operational sites"
+  },
+  "CERT_PINNING_MOZ_TEST_RESULTS_BY_HOST": {
+    "alert_emails": ["pinning@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 512,
+    "description": "Certificate pinning test results by host for Mozilla operational sites"
+  },
+  "CERT_CHAIN_KEY_SIZE_STATUS": {
+    "expires_in_version": "default",
+    "kind": "enumerated",
+    "n_values": 4,
+    "description": "Does enforcing a larger minimum RSA key size cause verification failures? 1 = no, 2 = yes, 3 = another error prevented finding a verified chain"
+  },
+  "CERT_CHAIN_SHA1_POLICY_STATUS": {
+    "expires_in_version": "default",
+    "kind": "enumerated",
+    "n_values": 6,
+    "description": "1 = No SHA1 signatures, 2 = SHA1 certificates issued by an imported root, 3 = SHA1 certificates issued before 2016, 4 = SHA1 certificates issued after 2015, 5 = another error prevented successful verification"
+  },
+  "WEAVE_CONFIGURED": {
+    "expires_in_version": "default",
+    "kind": "boolean",
+    "description": "If any version of Firefox Sync is configured for this device",
+    "releaseChannelCollection": "opt-out"
+  },
+  "WEAVE_CONFIGURED_MASTER_PASSWORD": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "If both Firefox Sync and Master Password are configured for this device"
+  },
+  "WEAVE_START_COUNT": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 10,
+    "description": "The number of times a sync started in this session"
+  },
+  "WEAVE_COMPLETE_SUCCESS_COUNT": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 10,
+    "description": "The number of times a sync successfully completed in this session"
+  },
+  "WEAVE_WIPE_SERVER_SUCCEEDED": {
+    "expires_in_version": "55",
+    "alert_emails": ["sync-dev@mozilla.org"],
+    "kind": "boolean",
+    "bug_numbers": [1241699],
+    "description": "Stores 1 if a wipeServer call succeeded, and 0 if it failed."
+  },
+  "WEBCRYPTO_EXTRACTABLE_IMPORT": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Whether an imported key was marked as extractable"
+  },
+  "WEBCRYPTO_EXTRACTABLE_GENERATE": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Whether a generated key was marked as extractable"
+  },
+  "WEBCRYPTO_EXTRACTABLE_ENC": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Whether a key used in an encrypt/decrypt operation was marked as extractable"
+  },
+  "WEBCRYPTO_EXTRACTABLE_SIG": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Whether a key used in a sign/verify operation was marked as extractable"
+  },
+  "WEBCRYPTO_RESOLVED": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Whether a promise created by WebCrypto was resolved (vs rejected)"
+  },
+  "WEBCRYPTO_METHOD": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 20,
+    "description": "Methods invoked under window.crypto.subtle (0=encrypt, 1=decrypt, 2=sign, 3=verify, 4=digest, 5=generateKey, 6=deriveKey, 7=deriveBits, 8=importKey, 9=exportKey, 10=wrapKey, 11=unwrapKey)"
+  },
+  "WEBCRYPTO_ALG": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 30,
+    "description": "Algorithms used with WebCrypto (see table in WebCryptoTask.cpp)"
+  },
+  "MASTER_PASSWORD_ENABLED": {
+    "expires_in_version": "never",
+    "kind": "flag",
+    "description": "If a master-password is enabled for this profile"
+  },
+  "DISPLAY_SCALING_OSX" : {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 500,
+    "n_buckets": 100,
+    "description": "Scaling percentage for the display where the first window is opened (OS X only)",
+    "cpp_guard": "XP_MACOSX"
+  },
+  "DISPLAY_SCALING_MSWIN" : {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 500,
+    "n_buckets": 100,
+    "description": "Scaling percentage for the display where the first window is opened (MS Windows only)",
+    "cpp_guard": "XP_WIN"
+  },
+  "DISPLAY_SCALING_LINUX" : {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 500,
+    "n_buckets": 100,
+    "description": "Scaling percentage for the display where the first window is opened (Linux only)",
+    "cpp_guard": "XP_LINUX"
+  },
+  "SOCIAL_SIDEBAR_STATE": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Social Sidebar state 0: closed, 1: opened.  Toggling between providers will result in a higher opened rate."
+  },
+  "SOCIAL_TOOLBAR_BUTTONS": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 3,
+    "description": "Social toolbar button has been used (0:share, 1:status, 2:bookmark)"
+  },
+  "SOCIAL_PANEL_CLICKS": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 4,
+    "description": "Social content has been interacted with (0:share, 1:status, 2:bookmark, 3: sidebar)"
+  },
+  "SOCIAL_SIDEBAR_OPEN_DURATION": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000000,
+    "n_buckets": 10,
+    "description": "Sidebar showing: seconds that the sidebar has been opened"
+  },
+  "SHUTDOWN_PHASE_DURATION_TICKS_QUIT_APPLICATION": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 65,
+    "n_buckets": 10,
+    "description": "Duration of shutdown phase quit-application, as measured by the shutdown terminator, in seconds of activity"
+  },
+  "SHUTDOWN_PHASE_DURATION_TICKS_PROFILE_CHANGE_TEARDOWN": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 65,
+    "n_buckets": 10,
+    "description": "Duration of shutdown phase profile-change-teardown, as measured by the shutdown terminator, in seconds of activity"
+  },
+  "SHUTDOWN_PHASE_DURATION_TICKS_XPCOM_WILL_SHUTDOWN": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 65,
+    "n_buckets": 10,
+    "description": "Duration of shutdown phase xpcom-will-shutdown, as measured by the shutdown terminator, in seconds of activity"
+  },
+  "SHUTDOWN_PHASE_DURATION_TICKS_PROFILE_BEFORE_CHANGE": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 65,
+    "n_buckets": 10,
+    "description": "Duration of shutdown phase profile-before-change, as measured by the shutdown terminator, in seconds of activity"
+  },
+  "BR_9_2_1_SUBJECT_ALT_NAMES": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 8,
+    "description": "Baseline Requirements section 9.2.1: subject alternative names extension (0: ok, 1 or more: error)"
+  },
+  "BR_9_2_2_SUBJECT_COMMON_NAME": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 8,
+    "description": "Baseline Requirements section 9.2.2: subject common name field (0: present, in subject alt. names; 1: not present; 2: not present in subject alt. names)"
+  },
+  "TAP_TO_LOAD_ENABLED": {
+    "expires_in_version": "50",
+    "kind": "enumerated",
+    "n_values": 3,
+    "description": "Whether or not a user has tap-to-load enabled.",
+    "bug_numbers": [1208167]
+  },
+  "ZOOMED_VIEW_ENABLED": {
+    "expires_in_version": "60",
+    "kind": "boolean",
+    "description": "Whether or not a user has the zoomed view (a.k.a. \"Magnify small areas\") enabled.",
+    "alert_emails": ["mobile-frontend@mozilla.com"],
+    "bug_numbers": [1235061]
+  },
+  "TRACKING_PROTECTION_ENABLED": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "True if tracking protection is enabled globally at the time that a non-Private-Browsing session is initialized.",
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "bug_numbers": [1058133]
+  },
+  "TRACKING_PROTECTION_PBM_DISABLED": {
+    "expires_in_version": "60",
+    "kind": "boolean",
+    "description": "True if tracking protection in Private Browsing mode is disabled at the time that a non-Private-Browsing session is initialized.",
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "bug_numbers": [1200944]
+  },
+  "FENNEC_TRACKING_PROTECTION_STATE": {
+    "expires_in_version": "60",
+    "kind": "enumerated",
+    "n_values": 5,
+    "description": "The state of the user-visible tracking protection setting (0 = Disabled, 1 = Enabled in PB, 2 = Enabled)",
+    "alert_emails": ["mleibovic@mozilla.com"],
+    "bug_numbers": [1228090]
+  },
+  "TRACKING_PROTECTION_SHIELD": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 4,
+    "description": "Status of the shield icon for each top-level pageload (outside of Private Browsing mode) when tracking protection is enabled (0 = shield not shown because no trackers were detected, 1 = shield crossed out because TP was disabled on this page by the user, 2 = shield shown because a tracker was blocked)",
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "bug_numbers": [1058133]
+  },
+  "TRACKING_PROTECTION_EVENTS": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 3,
+    "description": "A value of 0 is sent when the security UI changes on pages loaded outside of Private Browsing mode, a value of 1 is sent when users manually disable TP on that page, and 2 is sent when users manually re-enable TP on that page.",
+    "alert_emails": ["safebrowsing-telemetry@mozilla.org"],
+    "bug_numbers": [1058133]
+  },
+  "SERVICE_WORKER_REGISTRATION_LOADING": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 5000,
+    "n_buckets": 20,
+    "description": "Tracking how ServiceWorkerRegistrar loads data before the first content is shown. File bugs in Core::DOM in case of a Telemetry regression."
+  },
+  "SERVICE_WORKER_REQUEST_PASSTHROUGH": {
+    "expires_in_version": "50",
+    "kind": "boolean",
+    "description": "Intercepted fetch sending back same Request object. File bugs in Core::DOM in case of a Telemetry regression."
+  },
+  "E10S_STATUS": {
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 12,
+    "releaseChannelCollection": "opt-out",
+    "bug_numbers": [1241294],
+    "description": "Why e10s is enabled or disabled (0=ENABLED_BY_USER, 1=ENABLED_BY_DEFAULT, 2=DISABLED_BY_USER, 3=DISABLED_IN_SAFE_MODE, 4=DISABLED_FOR_ACCESSIBILITY, 5=DISABLED_FOR_MAC_GFX, 6=DISABLED_FOR_BIDI, 7=DISABLED_FOR_ADDONS, 8=FORCE_DISABLED, 9=DISABLED_FOR_XPLAYERS, 10=DISABLED_FOR_OS_VERSION)"
+  },
+  "E10S_BLOCKED_FROM_RUNNING": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Whether the e10s pref was set but it was blocked from running due to blacklisted conditions"
+  },
+  "BLOCKED_ON_PLUGIN_MODULE_INIT_MS": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "keyed": true,
+    "description": "Time (ms) that the main thread has been blocked on LoadModule and NP_Initialize in PluginModuleParent"
+  },
+  "BLOCKED_ON_PLUGIN_INSTANCE_INIT_MS": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "keyed": true,
+    "description": "Time (ms) that the main thread has been blocked on NPP_New in an IPC plugin"
+  },
+  "BLOCKED_ON_PLUGIN_STREAM_INIT_MS": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "keyed": true,
+    "description": "Time (ms) that the main thread has been blocked on NPP_NewStream in an IPC plugin"
+  },
+  "BLOCKED_ON_PLUGINASYNCSURROGATE_WAITFORINIT_MS": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "50",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "keyed": true,
+    "description": "Time (ms) that the main thread has been blocked on PluginAsyncSurrogate::WaitForInit in an IPC plugin"
+  },
+  "BLOCKED_ON_PLUGIN_INSTANCE_DESTROY_MS": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 20,
+    "keyed": true,
+    "description": "Time (ms) that the main thread has been blocked on NPP_Destroy in an IPC plugin"
+  },
+  "ONBEFOREUNLOAD_PROMPT_ACTION" : {
+    "expires_in_version": "45",
+    "kind": "enumerated",
+    "n_values": 3,
+    "description": "What button a user clicked in an onbeforeunload prompt.  (Stay on Page = 0, Leave Page = 1, prompt aborted = 2)"
+  },
+  "ONBEFOREUNLOAD_PROMPT_COUNT" : {
+    "expires_in_version": "45",
+    "kind": "count",
+    "description": "How many onbeforeunload prompts has the user encountered in their session?"
+  },
+  "SUBPROCESS_ABNORMAL_ABORT": {
+    "expires_in_version": "never",
+    "kind": "count",
+    "keyed": true,
+    "releaseChannelCollection": "opt-out",
+    "description": "Counts of plugin/content process abnormal shutdown, whether or not a crash report was available."
+  },
+  "SUBPROCESS_CRASHES_WITH_DUMP": {
+    "expires_in_version": "never",
+    "kind": "count",
+    "keyed": true,
+    "releaseChannelCollection": "opt-out",
+    "description": "Counts of plugin and content process crashes which are reported with a crash dump."
+  },
+  "SUBPROCESS_LAUNCH_FAILURE": {
+    "alert_emails": ["haftandilian@mozilla.com"],
+    "expires_in_version": "never",
+    "bug_numbers": [1275430],
+    "kind": "count",
+    "keyed": true,
+    "releaseChannelCollection": "opt-out",
+    "description": "Counts the number of times launching a subprocess fails. Counts are by subprocess-type using the GeckoProcessType enum."
+  },
+  "PROCESS_CRASH_SUBMIT_ATTEMPT": {
+    "expires_in_version": "never",
+    "kind": "count",
+    "keyed": true,
+    "releaseChannelCollection": "opt-out",
+    "description": "An attempt to submit a crash. Keyed on the CrashManager Crash.type."
+  },
+  "PROCESS_CRASH_SUBMIT_SUCCESS": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "keyed": true,
+    "releaseChannelCollection": "opt-out",
+    "description": "The submission status when main/plugin/content crashes are submitted. 1 is success, 0 is failure. Keyed on the CrashManager Crash.type."
+  },
+  "STUMBLER_TIME_BETWEEN_UPLOADS_SEC": {
+    "expires_in_version": "45",
+    "kind": "exponential",
+    "n_buckets": 50,
+    "high": 259200,
+    "description": "Stumbler: The time in seconds between uploads."
+  },
+  "STUMBLER_VOLUME_BYTES_UPLOADED_PER_SEC": {
+    "expires_in_version": "45",
+    "kind": "exponential",
+    "n_buckets": 50,
+    "high": 1000000,
+    "description": "Stumbler: Volume measurement of bytes uploaded, normalized to per-second."
+  },
+  "STUMBLER_TIME_BETWEEN_START_SEC": {
+    "expires_in_version": "45",
+    "kind": "exponential",
+    "n_buckets": 50,
+    "high": 259200,
+    "description": "Stumbler: The time between the service starts."
+  },
+  "STUMBLER_UPLOAD_BYTES": {
+    "expires_in_version": "45",
+    "kind": "exponential",
+    "n_buckets": 50,
+    "high": 1000000,
+    "description": "Stumbler: The bytes per upload."
+  },
+  "STUMBLER_UPLOAD_OBSERVATION_COUNT": {
+    "expires_in_version": "45",
+    "kind": "exponential",
+    "n_buckets": 50,
+    "high": 10000,
+    "description": "Stumbler: The observations per upload."
+  },
+  "STUMBLER_UPLOAD_CELL_COUNT": {
+    "expires_in_version": "45",
+    "kind": "exponential",
+    "n_buckets": 50,
+    "high": 10000,
+    "description": "Stumbler: The cells per upload."
+  },
+  "STUMBLER_UPLOAD_WIFI_AP_COUNT": {
+    "expires_in_version": "45",
+    "kind": "exponential",
+    "n_buckets": 50,
+    "high": 10000,
+    "description": "Stumbler: The Wi-Fi APs per upload."
+  },
+  "STUMBLER_OBSERVATIONS_PER_DAY": {
+    "expires_in_version": "45",
+    "kind": "exponential",
+    "n_buckets": 50,
+    "high": 10000,
+    "description": "Stumbler: The number of observations between upload events, normalized to per day."
+  },
+  "STUMBLER_TIME_BETWEEN_RECEIVED_LOCATIONS_SEC": {
+    "expires_in_version": "45",
+    "kind": "exponential",
+    "n_buckets": 50,
+    "high": 86400,
+    "description": "Stumbler: The time between receiving passive locations."
+  },
+  "DATA_STORAGE_ENTRIES": {
+    "expires_in_version": "default",
+    "kind": "linear",
+    "high": 1024,
+    "n_buckets": 16,
+    "description": "The number of entries in persistent DataStorage (HSTS and HPKP data, basically)"
+  },
+  "VIDEO_EME_PLAY_SUCCESS": {
+    "expires_in_version": "45",
+    "kind": "boolean",
+    "description": "EME video playback success or failure"
+  },
+  "VIDEO_PLAY_TIME_MS" : {
+    "alert_emails": ["ajones@mozilla.com"],
+    "expires_in_version": "55",
+    "description": "Total time spent playing video in milliseconds. This reports the total play time for an HTML Media Element whenever it is suspended or resumed, such as when the page is unloaded, or when the mute status changes when the AudioChannelAPI pref is set.",
+    "kind": "exponential",
+    "high": 7200000,
+    "n_buckets": 100,
+    "bug_numbers": [1261955, 1127646]
+  },
+  "VIDEO_HIDDEN_PLAY_TIME_MS" : {
+    "alert_emails": ["ajones@mozilla.com", "gsquelart@mozilla.com"],
+    "expires_in_version": "55",
+    "description": "Total time spent playing video while element is hidden, in milliseconds. This reports the total hidden play time for an HTML Media Element whenever it is suspended or resumed, such as when the page is unloaded, or when the mute status changes when the AudioChannelAPI pref is set.",
+    "kind": "exponential",
+    "high": 7200000,
+    "n_buckets": 100,
+    "bug_numbers": [1285419]
+  },
+  "VIDEO_HIDDEN_PLAY_TIME_PERCENTAGE" : {
+    "alert_emails": ["ajones@mozilla.com", "gsquelart@mozilla.com"],
+    "expires_in_version": "55",
+    "description": "Percentage of total time spent playing video while element is hidden. Keyed by audio presence and by height ranges (boundaries: 240. 480, 576, 720, 1080, 2160), e.g.: 'V,0<h<=240', 'AV,h>2160'; and 'All' will accumulate all percentages. This is reported whenever an HTML Media Element is suspended or resumed, such as when the page is unloaded.",
+    "keyed": true,
+    "kind": "linear",
+    "high": 100,
+    "n_buckets": 50,
+    "bug_numbers": [1287987]
+  },
+  "VIDEO_INFERRED_DECODE_SUSPEND_PERCENTAGE" : {
+    "alert_emails": ["ajones@mozilla.com", "gsquelart@mozilla.com"],
+    "expires_in_version": "55",
+    "description": "Percentage of total time spent *not* fully decoding video while element is hidden (simulated, even when feature is not enabled). Keyed by audio presence and by height ranges (boundaries: 240. 480, 576, 720, 1080, 2160), e.g.: 'V,0<h<=240', 'AV,h>2160'; and 'All' will accumulate all percentages. This is reported whenever an HTML Media Element is suspended or resumed, such as when the page is unloaded.",
+    "keyed": true,
+    "kind": "linear",
+    "high": 100,
+    "n_buckets": 50,
+    "bug_numbers": [1293145]
+  },
+  "VIDEO_INTER_KEYFRAME_AVERAGE_MS" : {
+    "alert_emails": ["ajones@mozilla.com", "gsquelart@mozilla.com"],
+    "expires_in_version": "55",
+    "description": "Average interval between video keyframes in played videos, in milliseconds. Keyed by audio presence and by height ranges (boundaries: 240. 480, 576, 720, 1080, 2160), e.g.: 'V,0<h<=240', 'AV,h>2160'; and 'All' will accumulate all percentages. This is reported whenever an HTML Media Element is suspended or resumed, such as when the page is unloaded.",
+    "keyed": true,
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 100,
+    "bug_numbers": [1289668]
+  },
+  "VIDEO_INTER_KEYFRAME_MAX_MS" : {
+    "alert_emails": ["ajones@mozilla.com", "gsquelart@mozilla.com"],
+    "expires_in_version": "55",
+    "description": "Maximum interval between video keyframes in played videos, in milliseconds; '0' means only 1 keyframe found. Keyed by audio presence and by height ranges (boundaries: 240. 480, 576, 720, 1080, 2160), e.g.: 'V,0<h<=240', 'AV,h>2160'; and 'All' will accumulate all percentages. This is reported whenever an HTML Media Element is suspended or resumed, such as when the page is unloaded.",
+    "keyed": true,
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 100,
+    "bug_numbers": [1289668]
+  },
+  "VIDEO_SUSPEND_RECOVERY_TIME_MS" : {
+    "alert_emails": ["ajones@mozilla.com", "gsquelart@mozilla.com"],
+    "expires_in_version": "55",
+    "description": "Time taken for a video to resume after decoding was suspended, in milliseconds. Keyed by audio presence, hw acceleration, and by height ranges (boundaries: 240. 480, 720, 1080, 2160), e.g.: 'V,0-240', 'AV(hw),2160+'; and 'All' will accumulate all percentages.",
+    "keyed": true,
+    "kind": "exponential",
+    "high": 10000,
+    "n_buckets": 100,
+    "bug_numbers": [1294349]
+  },
+  "VIDEO_AS_CONTENT_SOURCE" : {
+    "alert_emails": ["ajones@mozilla.com", "kaku@mozilla.com"],
+    "expires_in_version": "58",
+    "description": "Usage of a {visible / invisible} video element as the source of {drawImage(), createPattern(), createImageBitmap() and captureStream()} APIs. (0 = ALL_VISIBLE, 1 = ALL_INVISIBLE, 2 = drawImage_VISIBLE, 3 = drawImage_INVISIBLE, 4 = createPattern_VISIBLE, 5 = createPattern_INVISIBLE, 6 = createImageBitmap_VISIBLE, 7 = createImageBitmap_INVISIBLE, 8 = captureStream_VISIBLE, 9 = captureStream_INVISIBLE)",
+    "kind": "enumerated",
+    "n_values": 12,
+    "bug_numbers": [1299718]
+  },
+  "VIDEO_AS_CONTENT_SOURCE_IN_TREE_OR_NOT" : {
+    "alert_emails": ["ajones@mozilla.com", "kaku@mozilla.com"],
+    "expires_in_version": "58",
+    "description": "Usage of an invisible {in tree / not in tree} video element as the source of {drawImage(), createPattern(), createImageBitmap() and captureStream()} APIs. (0 = ALL_IN_TREE, 1 = ALL_NOT_IN_TREE, 2 = drawImage_IN_TREE, 3 = drawImage_NOT_IN_TREE, 4 = createPattern_IN_TREE, 5 = createPattern_NOT_IN_TREE, 6 = createImageBitmap_IN_TREE, 7 = createImageBitmap_NOT_IN_TREE, 8 = captureStream_IN_TREE, 9 = captureStream_NOT_IN_TREE)",
+    "kind": "enumerated",
+    "n_values": 12,
+    "bug_numbers": [1337301]
+  },
+  "VIDEO_UNLOAD_STATE": {
+    "alert_emails": ["ajones@mozilla.com"],
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 5,
+    "description": "HTML Media Element state when unloading. ended = 0, paused = 1, stalled = 2, seeking = 3, other = 4",
+    "bug_numbers": [1261955, 1261955]
+  },
+  "VIDEO_VP9_BENCHMARK_FPS": {
+    "alert_emails": ["ajones@mozilla.com"],
+    "expires_in_version": "55",
+    "bug_numbers": [1230265],
+    "kind": "linear",
+    "high": 1000,
+    "n_buckets": 100,
+    "description": "720p VP9 decode benchmark measurement in frames per second",
+    "releaseChannelCollection": "opt-out"
+  },
+  "VIDEO_CDM_CREATED": {
+    "alert_emails": ["cpearce@mozilla.com"],
+    "expires_in_version": "58",
+    "bug_numbers": [1304207],
+    "kind": "enumerated",
+    "n_values": 6,
+    "description": "Note the type of CDM (0=ClearKey, 1=Primetime, 2=Widevine, 3=unknown) every time we successfully instantiate an EME MediaKeys object.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "MEDIA_CODEC_USED": {
+    "alert_emails": ["cpearce@mozilla.com"],
+    "expires_in_version": "never",
+    "keyed": true,
+    "kind": "count",
+    "description": "Count of use of audio/video codecs in HTMLMediaElements and WebAudio. Those with 'resource' prefix are approximate; report based on HTTP ContentType or sniffing. Those with 'webaudio' prefix are for WebAudio."
+  },
+  "FX_SANITIZE_TOTAL": {
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 20,
+    "description": "Sanitize: Total time it takes to sanitize (ms)"
+  },
+  "FX_SANITIZE_CACHE": {
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 20,
+    "description": "Sanitize: Time it takes to sanitize the cache (ms)"
+  },
+  "FX_SANITIZE_COOKIES_2": {
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 20,
+    "description": "Sanitize: Time it takes to sanitize firefox cookies (ms). A subset of FX_SANITIZE_COOKIES."
+  },
+  "FX_SANITIZE_HISTORY": {
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 20,
+    "description": "Sanitize: Time it takes to sanitize history (ms)"
+  },
+  "FX_SANITIZE_FORMDATA": {
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 20,
+    "description": "Sanitize: Time it takes to sanitize stored form data (ms)"
+  },
+  "FX_SANITIZE_DOWNLOADS": {
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 20,
+    "description": "Sanitize: Time it takes to sanitize recent downloads (ms)"
+  },
+  "FX_SANITIZE_SESSIONS": {
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 20,
+    "description": "Sanitize: Time it takes to sanitize saved sessions (ms)"
+  },
+  "FX_SANITIZE_SITESETTINGS": {
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 20,
+    "description": "Sanitize: Time it takes to sanitize site-specific settings (ms)"
+  },
+  "FX_SANITIZE_OPENWINDOWS": {
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 30000,
+    "n_buckets": 20,
+    "description": "Sanitize: Time it takes to sanitize the open windows list (ms)"
+  },
+  "PWMGR_BLOCKLIST_NUM_SITES": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 100,
+    "n_buckets" : 10,
+    "description": "The number of sites for which the user has explicitly rejected saving logins"
+  },
+  "PWMGR_FORM_AUTOFILL_RESULT": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values" : 20,
+    "description": "The result of auto-filling a login form. See http://mzl.la/1Mbs6jL for bucket descriptions."
+  },
+  "PWMGR_LOGIN_LAST_USED_DAYS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 750,
+    "n_buckets" : 40,
+    "description": "Time in days each saved login was last used"
+  },
+  "PWMGR_LOGIN_PAGE_SAFETY": {
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 8,
+    "description": "The safety of a page where we see a password field. (0: safe page & safe submit; 1: safe page & unsafe submit; 2: safe page & unknown submit; 3: unsafe page & safe submit; 4: unsafe page & unsafe submit; 5: unsafe page & unknown submit)"
+  },
+  "PWMGR_MANAGE_COPIED_PASSWORD": {
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Count of passwords copied from the password management interface"
+  },
+  "PWMGR_MANAGE_COPIED_USERNAME": {
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Count of usernames copied from the password management interface"
+  },
+  "PWMGR_MANAGE_DELETED": {
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Count of passwords deleted from the password management interface (including via Remove All)"
+  },
+  "PWMGR_MANAGE_DELETED_ALL": {
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Count of times that Remove All was used from the password management interface"
+  },
+  "PWMGR_MANAGE_OPENED": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values" : 5,
+    "description": "Accumulates how the password management interface was opened. (0=Preferences, 1=Page Info)"
+  },
+  "PWMGR_MANAGE_SORTED": {
+    "expires_in_version": "never",
+    "keyed": true,
+    "kind": "count",
+    "description": "Reports the column that logins are sorted by"
+  },
+  "PWMGR_MANAGE_VISIBILITY_TOGGLED": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Whether the visibility of passwords was toggled (0=Hide, 1=Show)"
+  },
+  "PWMGR_NUM_PASSWORDS_PER_HOSTNAME": {
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": 21,
+    "n_buckets" : 20,
+    "description": "The number of passwords per hostname"
+  },
+  "PWMGR_NUM_SAVED_PASSWORDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 750,
+    "n_buckets" : 50,
+    "description": "Total number of saved logins, including those that cannot be decrypted"
+  },
+  "PWMGR_NUM_HTTPAUTH_PASSWORDS": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 750,
+    "n_buckets" : 50,
+    "description": "Number of HTTP Auth logins"
+  },
+  "PWMGR_PASSWORD_INPUT_IN_FORM": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Whether an <input type=password> is associated with a <form> when it is added to a document"
+  },
+  "PWMGR_PROMPT_REMEMBER_ACTION" : {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 5,
+    "description": "Action taken by user through prompt for creating a login. (0=Prompt displayed [always recorded], 1=Add login, 2=Don't save now, 3=Never save)"
+  },
+  "PWMGR_PROMPT_UPDATE_ACTION" : {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 5,
+    "description": "Action taken by user through prompt for modifying a login. (0=Prompt displayed [always recorded], 1=Update login)"
+  },
+  "PWMGR_SAVING_ENABLED": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Number of users who have password saving on globally"
+  },
+  "PWMGR_USERNAME_PRESENT": {
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "description": "Whether a saved login has a username"
+  },
+  "FENNEC_SYNC11_MIGRATION_SENTINELS_SEEN": {
+    "expires_in_version": "45",
+    "kind": "count",
+    "description": "The number of Sync 1.1 -> Sync 1.5 migration sentinels seen by Android Sync."
+  },
+  "FENNEC_SYNC11_MIGRATIONS_FAILED": {
+    "expires_in_version": "45",
+    "kind": "count",
+    "description": "The number of Sync 1.1 -> Sync 1.5 migrations that failed during Android Sync."
+  },
+  "FENNEC_SYNC11_MIGRATIONS_SUCCEEDED": {
+    "expires_in_version": "45",
+    "kind": "count",
+    "description": "The number of Sync 1.1 -> Sync 1.5 migrations that succeeded during Android Sync."
+  },
+  "FENNEC_SYNC11_MIGRATION_NOTIFICATIONS_OFFERED": {
+    "expires_in_version": "45",
+    "kind": "exponential",
+    "high": 500,
+    "n_buckets": 5,
+    "description": "The number of Sync 1.5 'complete upgrade/migration' notifications offered by Android Sync."
+  },
+  "FENNEC_SYNC11_MIGRATIONS_COMPLETED": {
+    "expires_in_version": "45",
+    "kind": "count",
+    "description": "The number of Sync 1.5 migrations completed by Android Sync."
+  },
+  "FENNEC_SYNC_NUMBER_OF_SYNCS_STARTED": {
+    "expires_in_version": "45",
+    "kind": "count",
+    "description": "Counts the number of times that a sync has started."
+  },
+  "FENNEC_SYNC_NUMBER_OF_SYNCS_COMPLETED": {
+    "expires_in_version": "45",
+    "kind": "count",
+    "description": "Counts the number of times that a sync has completed with no errors."
+  },
+  "FENNEC_SYNC_NUMBER_OF_SYNCS_FAILED": {
+    "expires_in_version": "45",
+    "kind": "count",
+    "description": "Counts the number of times that a sync has failed with errors."
+  },
+  "FENNEC_SYNC_NUMBER_OF_SYNCS_FAILED_BACKOFF": {
+    "expires_in_version": "45",
+    "kind": "count",
+    "description": "Counts the number of times that a sync has failed because of trying to sync before server backoff interval has passed."
+  },
+  "SLOW_SCRIPT_NOTICE_COUNT": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Count slow script notices"
+  },
+  "SLOW_SCRIPT_PAGE_COUNT": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "bug_numbers": [1251667],
+    "description": "The number of pages that trigger slow script notices"
+  },
+  "SLOW_SCRIPT_NOTIFY_DELAY": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 50,
+    "bug_numbers": [1271978],
+    "description": "The difference between the js slow script timeout for content set in prefs and the actual time we waited before displaying the notification (msec)."
+  },
+  "PLUGIN_HANG_NOTICE_COUNT": {
+    "alert_emails": ["perf-telemetry-alerts@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Count plugin hang notices in e10s"
+  },
+  "SERVICE_WORKER_SPAWN_ATTEMPTS": {
+    "expires_in_version": "50",
+    "kind": "count",
+    "description": "Count attempts to spawn a ServiceWorker for a domain. File bugs in Core::DOM in case of a Telemetry regression."
+  },
+  "SERVICE_WORKER_WAS_SPAWNED": {
+    "expires_in_version": "50",
+    "kind": "count",
+    "description": "Count ServiceWorkers that really did get a thread created for them. File bugs in Core::DOM in case of a Telemetry regression."
+  },
+  "SERVICE_WORKER_SPAWN_GETS_QUEUED": {
+    "alert_emails": ["amarchesini@mozilla.com"],
+    "bug_numbers": [1286895],
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Tracking whether a ServiceWorker spawn gets queued due to hitting max workers per domain limit. File bugs in Core::DOM in case of a Telemetry regression."
+  },
+  "SHARED_WORKER_SPAWN_GETS_QUEUED": {
+    "alert_emails": ["amarchesini@mozilla.com"],
+    "bug_numbers": [1286895],
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Tracking whether a SharedWorker spawn gets queued due to hitting max workers per domain limit. File bugs in Core::DOM in case of a Telemetry regression."
+  },
+  "DEDICATED_WORKER_SPAWN_GETS_QUEUED": {
+    "alert_emails": ["amarchesini@mozilla.com"],
+    "bug_numbers": [1286895],
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Tracking whether a DedicatedWorker spawn gets queued due to hitting max workers per domain limit. File bugs in Core::DOM in case of a Telemetry regression."
+  },
+  "SERVICE_WORKER_REGISTRATIONS": {
+    "expires_in_version": "50",
+    "kind": "count",
+    "description": "Count how many registrations occurs. File bugs in Core::DOM in case of a Telemetry regression."
+  },
+  "SERVICE_WORKER_CONTROLLED_DOCUMENTS": {
+    "expires_in_version": "50",
+    "kind": "count",
+    "description": "Count whenever a document is controlled. File bugs in Core::DOM in case of a Telemetry regression."
+  },
+  "SERVICE_WORKER_UPDATED": {
+    "expires_in_version": "50",
+    "kind": "count",
+    "description": "Count ServiceWorkers scripts that are updated. File bugs in Core::DOM in case of a Telemetry regression."
+  },
+  "SERVICE_WORKER_LIFE_TIME": {
+    "expires_in_version": "50",
+    "kind": "exponential",
+    "high": 120000,
+    "n_buckets": 20,
+    "description": "Tracking how long a ServiceWorker stays alive after it is spawned. File bugs in Core::DOM in case of a Telemetry regression."
+  },
+  "FILE_EMBEDDED_SERVICEWORKERS": {
+    "alert_emails": ["dparks@mozilla.com"],
+    "expires_in_version": "58",
+    "kind": "count",
+    "bug_numbers": [1312788],
+    "description": "Count ServiceWorkers that are embedded in pages loading with the file:/// protocol."
+  },
+  "GRAPHICS_SANITY_TEST": {
+    "expires_in_version": "never",
+    "alert_emails": ["gfx-telemetry-alerts@mozilla.com","msreckovic@mozilla.com"],
+    "kind": "enumerated",
+    "n_values": 20,
+    "releaseChannelCollection": "opt-out",
+    "description": "Reports results from the graphics sanity test to track which drivers are having problems (0=TEST_PASSED, 1=TEST_FAILED_RENDER, 2=TEST_FAILED_VIDEO, 3=TEST_CRASHED)"
+  },
+  "READER_MODE_PARSE_RESULT" : {
+    "expires_in_version": "58",
+    "alert_emails": ["firefox-dev@mozilla.org", "gijs@mozilla.com"],
+    "kind": "enumerated",
+    "n_values": 5,
+    "description": "The result of trying to parse a document to show in reader view (0=Success, 1=Error too many elements, 2=Error in worker, 3=Error no article)"
+  },
+  "READER_MODE_DOWNLOAD_RESULT" : {
+    "expires_in_version": "58",
+    "alert_emails": ["firefox-dev@mozilla.org", "gijs@mozilla.com"],
+    "kind": "enumerated",
+    "n_values": 5,
+    "description": "The result of trying to download a document to show in reader view (0=Success, 1=Error XHR, 2=Error no document)"
+  },
+  "FENNEC_LOAD_SAVED_PAGE": {
+    "expires_in_version": "60",
+    "alert_emails": ["mobile-frontend@mozilla.com"],
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "How often users load saved items when online/offline (0=RL online, 1=RL offline, 2=BM online, 3=BM offline)",
+    "bug_numbers": [1243387]
+  },
+  "PERMISSIONS_SQL_CORRUPTED": {
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Record the permissions.sqlite init failure"
+  },
+  "DEFECTIVE_PERMISSIONS_SQL_REMOVED": {
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Record the removal of defective permissions.sqlite"
+  },
+  "FENNEC_TABQUEUE_QUEUESIZE" : {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 50,
+    "n_buckets": 10,
+    "description": "The number of tabs queued when opened."
+  },
+  "FENNEC_CUSTOM_HOMEPAGE": {
+    "expires_in_version": "60",
+    "alert_emails": ["mobile-frontend@mozilla.com"],
+    "bug_numbers": [1239102],
+    "kind": "boolean",
+    "description": "Whether the user has set a custom homepage."
+  },
+  "GRAPHICS_DRIVER_STARTUP_TEST": {
+    "alert_emails": ["gfx-telemetry-alerts@mozilla.com","danderson@mozilla.com","msreckovic@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 20,
+    "releaseChannelCollection": "opt-out",
+    "description": "Reports whether or not graphics drivers crashed during startup."
+  },
+  "GRAPHICS_SANITY_TEST_OS_SNAPSHOT": {
+    "alert_emails": ["gfx-telemetry-alerts@mozilla.com","danderson@mozilla.com","msreckovic@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 10,
+    "releaseChannelCollection": "opt-out",
+    "description": "Reports whether the graphics sanity test passed an OS snapshot test. 0=Pass, 1=Fail, 2=Error, 3=Timed out."
+  },
+  "DEVTOOLS_MEMORY_TAKE_SNAPSHOT_COUNT": {
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1221619],
+    "description": "The number of heap snapshots taken by a user"
+  },
+  "DEVTOOLS_MEMORY_IMPORT_SNAPSHOT_COUNT": {
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1221619],
+    "description": "The number of heap snapshots imported by a user"
+  },
+  "DEVTOOLS_MEMORY_EXPORT_SNAPSHOT_COUNT": {
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1221619],
+    "description": "The number of heap snapshots exported by a user"
+  },
+  "DEVTOOLS_MEMORY_FILTER_CENSUS": {
+    "expires_in_version": "56",
+    "kind": "boolean",
+    "bug_numbers": [1221619],
+    "description": "Whether a census tree was filtered or not"
+  },
+  "DEVTOOLS_MEMORY_DIFF_CENSUS": {
+    "expires_in_version": "56",
+    "kind": "boolean",
+    "bug_numbers": [1221619],
+    "description": "Whether a census was the result of diffing or not"
+  },
+  "DEVTOOLS_MEMORY_INVERTED_CENSUS": {
+    "expires_in_version": "56",
+    "kind": "boolean",
+    "bug_numbers": [1221619],
+    "description": "Whether a census tree was inverted or not"
+  },
+  "DEVTOOLS_MEMORY_BREAKDOWN_CENSUS_COUNT": {
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1221619],
+    "keyed": true,
+    "description": "The number of times a given type of breakdown was used for a census"
+  },
+  "DEVTOOLS_MEMORY_DOMINATOR_TREE_COUNT": {
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1221619],
+    "description": "The number of times a user requested a dominator tree be computed"
+  },
+  "DEVTOOLS_MEMORY_BREAKDOWN_DOMINATOR_TREE_COUNT": {
+    "expires_in_version": "56",
+    "kind": "count",
+    "bug_numbers": [1221619],
+    "keyed": true,
+    "description": "The number of times a given type of breakdown was used for a dominator tree"
+  },
+  "GRAPHICS_SANITY_TEST_REASON": {
+    "alert_emails": ["gfx-telemetry-alerts@mozilla.com","danderson@mozilla.com","msreckovic@mozilla.com"],
+    "expires_in_version": "43",
+    "kind": "enumerated",
+    "n_values": 20,
+    "releaseChannelCollection": "opt-out",
+    "description": "Reports why a graphics sanity test was run. 0=First Run, 1=App Updated, 2=Device Change, 3=Driver Change."
+  },
+  "TRANSLATION_OPPORTUNITIES": {
+    "expires_in_version": "default",
+    "kind": "boolean",
+    "description": "A number of successful and failed attempts to translate a document"
+  },
+  "TRANSLATION_OPPORTUNITIES_BY_LANGUAGE": {
+    "expires_in_version": "default",
+    "kind": "boolean",
+    "keyed": true,
+    "description": "A number of successful and failed attempts to translate a document grouped by language"
+  },
+  "TRANSLATED_PAGES": {
+    "expires_in_version": "default",
+    "kind": "count",
+    "description": "A number of sucessfully translated pages"
+  },
+  "TRANSLATED_PAGES_BY_LANGUAGE": {
+    "expires_in_version": "default",
+    "kind": "count",
+    "keyed": true,
+    "description": "A number of sucessfully translated pages by language"
+  },
+  "TRANSLATED_CHARACTERS": {
+    "expires_in_version": "default",
+    "kind": "exponential",
+    "high": 10240,
+    "n_buckets": 50,
+    "description": "A number of sucessfully translated characters"
+  },
+  "DENIED_TRANSLATION_OFFERS": {
+    "expires_in_version": "default",
+    "kind": "count",
+    "description": "A number of tranlation offers the user denied"
+  },
+  "AUTO_REJECTED_TRANSLATION_OFFERS": {
+    "expires_in_version": "default",
+    "kind": "count",
+    "description": "A number of auto-rejected tranlation offers"
+  },
+  "REQUESTS_OF_ORIGINAL_CONTENT": {
+    "expires_in_version": "default",
+    "kind": "count",
+    "description": "A number of times the user requested to see the original content of a translated page"
+  },
+  "CHANGES_OF_TARGET_LANGUAGE": {
+    "expires_in_version": "default",
+    "kind": "count",
+    "description": "A number of times when the target language was changed by the user"
+  },
+  "CHANGES_OF_DETECTED_LANGUAGE": {
+    "expires_in_version": "default",
+    "kind": "boolean",
+    "description": "A number of changes of detected language before (true) or after (false) translating a page for the first time."
+  },
+  "SHOULD_TRANSLATION_UI_APPEAR": {
+    "expires_in_version": "default",
+    "kind": "flag",
+    "description": "Tracks situations when the user opts for displaying translation UI"
+  },
+  "SHOULD_AUTO_DETECT_LANGUAGE": {
+    "expires_in_version": "default",
+    "kind": "flag",
+    "description": "Tracks situations when the user opts for auto-detecting the language of a page"
+  },
+  "PERMISSIONS_REMIGRATION_COMPARISON": {
+    "alert_emails": ["michael@thelayzells.com"],
+    "expires_in_version": "44",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "Reports a comparison between row count of original and re-migration of the v7 permissions DB. 0=New == 0, 1=New < Old, 2=New == Old, 3=New > Old"
+  },
+  "PERMISSIONS_MIGRATION_7_ERROR": {
+    "alert_emails": ["michael@thelayzells.com"],
+    "expires_in_version": "44",
+    "kind": "boolean",
+    "description": "Was there an error while performing the v7 permissions DB migration?"
+  },
+  "PERF_MONITORING_TEST_CPU_RESCHEDULING_PROPORTION_MOVED": {
+    "alert_emails": ["dteller@mozilla.com"],
+    "expires_in_version": "48",
+    "kind": "linear",
+    "high": 100,
+    "n_buckets": 20,
+    "description": "Proportion (%) of reschedulings of the main process to another CPU during the execution of code inside a JS compartment. Updated while we are measuring jank."
+  },
+  "PERF_MONITORING_SLOW_ADDON_JANK_US": {
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "low": 1,
+    "high": 10000000,
+    "n_buckets": 20,
+    "keyed": true,
+    "description": "Contiguous time spent by an add-on blocking the main loop (microseconds, keyed by add-on ID)."
+  },
+  "PERF_MONITORING_SLOW_ADDON_CPOW_US": {
+    "expires_in_version": "70",
+    "kind": "exponential",
+    "low": 1,
+    "high": 10000000,
+    "n_buckets": 20,
+    "keyed": true,
+    "description": "Contiguous time spent by an add-on blocking the main loop by performing a blocking cross-process call (microseconds, keyed by add-on ID)."
+  },
+  "VIDEO_EME_REQUEST_SUCCESS_LATENCY_MS": {
+    "alert_emails": ["cpearce@mozilla.com"],
+    "expires_in_version": "55",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 60,
+    "releaseChannelCollection": "opt-out",
+    "description": "Time spent waiting for a navigator.requestMediaKeySystemAccess call to succeed."
+  },
+  "VIDEO_EME_REQUEST_FAILURE_LATENCY_MS": {
+    "alert_emails": ["cpearce@mozilla.com"],
+    "expires_in_version": "55",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 60,
+    "releaseChannelCollection": "opt-out",
+    "description": "Time spent waiting for a navigator.requestMediaKeySystemAccess call to fail."
+  },
+  "FXA_CONFIGURED": {
+    "alert_emails": ["sync-dev@mozilla.org"],
+    "bug_numbers": [1236383],
+    "expires_in_version": "never",
+    "kind": "flag",
+    "releaseChannelCollection": "opt-out",
+    "description": "If the user is signed in to a Firefox Account on this device. Recorded once per session just after startup as Sync is initialized."
+  },
+  "WEAVE_DEVICE_COUNT_DESKTOP": {
+    "alert_emails": ["sync-dev@mozilla.org"],
+    "bug_numbers": [1232050],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 10,
+    "releaseChannelCollection": "opt-out",
+    "description": "Number of desktop devices (including this device) associated with this Sync account. Recorded each time Sync successfully completes the 'clients' engine."
+  },
+  "WEAVE_DEVICE_COUNT_MOBILE": {
+    "alert_emails": ["sync-dev@mozilla.org"],
+    "bug_numbers": [1232050],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 10,
+    "releaseChannelCollection": "opt-out",
+    "description": "Number of mobile devices associated with this Sync account. Recorded each time Sync successfully completes the 'clients' engine."
+  },
+  "WEAVE_ENGINE_SYNC_ERRORS": {
+    "alert_emails": ["sync-dev@mozilla.org"],
+    "bug_numbers": [1236383],
+    "expires_in_version": "never",
+    "kind": "count",
+    "keyed": true,
+    "releaseChannelCollection": "opt-out",
+    "description": "Exceptions thrown by a Sync engine. Keyed on the engine name."
+  },
+  "CONTENT_DOCUMENTS_DESTROYED": {
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Number of content documents destroyed; used in conjunction with use counter histograms"
+  },
+  "TOP_LEVEL_CONTENT_DOCUMENTS_DESTROYED": {
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Number of top-level content documents destroyed; used in conjunction with use counter histograms"
+  },
+  "PUSH_API_NOTIFY": {
+    "releaseChannelCollection": "opt-out",
+    "alert_emails": ["push@mozilla.com"],
+    "expires_in_version": "60",
+    "kind": "count",
+    "description": "Number of push messages that were successfully decrypted and delivered to a ServiceWorker."
+  },
+  "D3D11_SYNC_HANDLE_FAILURE": {
+    "alert_emails": ["gfx-telemetry-alerts@mozilla.com","bschouten@mozilla.com","danderson@mozilla.com","msreckovic@mozilla.com","ashughes@mozilla.com"],
+    "expires_in_version": "60",
+    "releaseChannelCollection": "opt-out",
+    "kind": "count",
+    "description": "Number of times the D3D11 compositor failed to get a texture sync handle."
+  },
+  "GFX_CONTENT_FAILED_TO_ACQUIRE_DEVICE": {
+    "alert_emails": ["gfx-telemetry-alerts@mozilla.com","msreckovic@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 6,
+    "description": "Failed to create a gfx content device. 0=content d3d11, 1=image d3d11, 2=d2d1."
+  },
+  "GFX_CRASH": {
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 100,
+    "releaseChannelCollection": "opt-out",
+    "description": "Graphics Crash Reason (...)"
+  },
+  "PLUGIN_ACTIVATION_COUNT": {
+    "alert_emails": ["cpeterson@mozilla.com"],
+    "expires_in_version": "53",
+    "kind": "count",
+    "keyed": true,
+    "releaseChannelCollection": "opt-out",
+    "bug_numbers": [722110,1260065],
+    "description": "Counts number of times a certain plugin has been activated."
+  },
+  "SCROLL_INPUT_METHODS": {
+    "alert_emails": ["botond@mozilla.com"],
+    "bug_numbers": [1238137],
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 64,
+    "description": "Count of scroll actions triggered by different input methods. See gfx/layers/apz/util/ScrollInputMethods.h for a list of possible values and their meanings."
+  },
+  "TOTAL_SCROLL_Y": {
+    "alert_emails": ["hkirschner@mozilla.com"],
+    "bug_numbers": [1297867],
+    "expires_in_version": "58",
+    "kind": "count",
+    "description": "Count of the total number of CSS pixels scrolled up or down in the vertical axis of the root frame of all the pages visited in a subsession. This doesn't include any scrolling of nested scroll frames such as inputs, iframes, or scrollable divs."
+  },
+  "PAGE_MAX_SCROLL_Y": {
+    "alert_emails": ["hkirschner@mozilla.com"],
+    "bug_numbers": [1312881],
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "high": 100000,
+    "n_buckets": 50,
+    "description": "Maximum distance in CSS pixels a user scrolls down the vertical axis of the root frame of a page. This doesn't include any scrolling of nested scroll frames such as inputs, iframes, or scrollable divs."
+  },
+  "WEB_NOTIFICATION_CLICKED": {
+    "releaseChannelCollection": "opt-out",
+    "alert_emails": ["firefox-dev@mozilla.org", "push@mozilla.com"],
+    "bug_numbers": [1225336],
+    "expires_in_version": "60",
+    "kind": "count",
+    "description": "Count of times a web notification was clicked"
+  },
+  "WEB_NOTIFICATION_MENU": {
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "bug_numbers": [1225336],
+    "expires_in_version": "50",
+    "kind": "enumerated",
+    "n_values": 5,
+    "description": "Count of times a contextual menu item was used from a Notification (0: DND, 1: Disable, 2: Settings)"
+  },
+  "WEB_NOTIFICATION_SHOWN": {
+    "releaseChannelCollection": "opt-out",
+    "alert_emails": ["firefox-dev@mozilla.org", "push@mozilla.com"],
+    "bug_numbers": [1225336],
+    "expires_in_version": "60",
+    "kind": "count",
+    "description": "Count of times a Notification was rendered (accounting for XUL DND). A system backend may put the notification directly into the tray if its own DND is on."
+  },
+  "WEBFONT_DOWNLOAD_TIME": {
+    "alert_emails": ["jdaggett@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 50,
+    "description": "Time to download a webfont (ms)"
+  },
+  "WEBFONT_DOWNLOAD_TIME_AFTER_START": {
+    "alert_emails": ["jdaggett@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 60000,
+    "n_buckets": 50,
+    "description": "Time after navigationStart webfont download completed (ms)"
+  },
+  "WEBFONT_FONTTYPE": {
+    "alert_emails": ["jdaggett@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "Font format type (woff/woff2/ttf/...)"
+  },
+  "WEBFONT_SRCTYPE": {
+    "alert_emails": ["jdaggett@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 5,
+    "description": "Font src type loaded (1 = local, 2 = url, 3 = data)"
+  },
+  "WEBFONT_PER_PAGE": {
+    "alert_emails": ["jdaggett@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "description": "Number of fonts loaded at page load"
+  },
+  "WEBFONT_SIZE_PER_PAGE": {
+    "alert_emails": ["jdaggett@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 5000,
+    "n_buckets": 50,
+    "description": "Size of all fonts loaded at page load (kb)"
+  },
+  "WEBFONT_SIZE": {
+    "alert_emails": ["jdaggett@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 5000,
+    "n_buckets": 50,
+    "description": "Size of font loaded (kb)"
+  },
+  "WEBFONT_COMPRESSION_WOFF": {
+    "alert_emails": ["jdaggett@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 50,
+    "description": "Compression ratio of WOFF data (%)"
+  },
+  "WEBFONT_COMPRESSION_WOFF2": {
+    "alert_emails": ["jdaggett@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 50,
+    "description": "Compression ratio of WOFF2 data (%)"
+  },
+  "WEBRTC_ICE_CHECKING_RATE": {
+    "alert_emails": ["webrtc-ice-telemetry-alerts@mozilla.com"],
+    "bug_numbers": [1319268],
+    "expires_in_version": "58",
+    "kind": "boolean",
+    "bug_numbers": [1188391],
+    "description": "The number of ICE connections which immediately failed (0) vs. reached at least checking state (1)."
+  },
+  "ALERTS_SERVICE_DND_ENABLED": {
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "bug_numbers": [1219030],
+    "expires_in_version": "50",
+    "kind": "boolean",
+    "description": "XUL-only: whether the user has toggled do not disturb."
+  },
+  "ALERTS_SERVICE_DND_SUPPORTED_FLAG": {
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "bug_numbers": [1219030],
+    "expires_in_version": "50",
+    "kind": "flag",
+    "description": "Whether the do not disturb option is supported. True if the browser uses XUL alerts."
+  },
+  "WEB_NOTIFICATION_EXCEPTIONS_OPENED": {
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "bug_numbers": [1219030],
+    "expires_in_version": "50",
+    "kind": "count",
+    "description": "Number of times the Notification Permissions dialog has been opened."
+  },
+  "WEB_NOTIFICATION_PERMISSIONS": {
+    "releaseChannelCollection": "opt-out",
+    "alert_emails": ["firefox-dev@mozilla.org", "push@mozilla.com"],
+    "bug_numbers": [1219030],
+    "expires_in_version": "60",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "Number of origins with the web notifications permission (0 = denied, 1 = allowed)."
+  },
+  "WEB_NOTIFICATION_PERMISSION_REMOVED": {
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "bug_numbers": [1219030],
+    "expires_in_version": "50",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "Number of removed web notifications permissions (0 = remove deny, 1 = remove allow)."
+  },
+  "WEB_NOTIFICATION_SENDERS": {
+    "releaseChannelCollection": "opt-out",
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "bug_numbers": [1219030],
+    "expires_in_version": "50",
+    "kind": "count",
+    "description": "Number of origins that have shown a web notification. Excludes system alerts like update reminders and add-ons."
+  },
+  "YOUTUBE_REWRITABLE_EMBED_SEEN": {
+    "alert_emails": ["cpeterson@mozilla.com"],
+    "expires_in_version": "53",
+    "kind": "flag",
+    "bug_numbers": [1229971],
+    "releaseChannelCollection": "opt-out",
+    "description": "Flag activated whenever a rewritable youtube flash embed is seen during a session."
+  },
+  "YOUTUBE_NONREWRITABLE_EMBED_SEEN": {
+    "alert_emails": ["cpeterson@mozilla.com"],
+    "expires_in_version": "53",
+    "kind": "flag",
+    "bug_numbers": [1237401],
+    "releaseChannelCollection": "opt-out",
+    "description": "Flag activated whenever a non-rewritable (enablejsapi=1) youtube flash embed is seen during a session."
+  },
+  "PLUGIN_DRAWING_MODEL": {
+    "alert_emails": ["danderson@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "bug_numbers": [1229961],
+    "n_values": 12,
+    "description": "Plugin drawing model. 0 when windowed, otherwise NPDrawingModel + 1."
+  },
+  "DOM_SCRIPT_SRC_ENCODING": {
+    "alert_emails": ["dteller@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "keyed": true,
+    "bug_numbers": [1344152],
+    "description": "Encoding used in a <script src>."
+  },
+  "VIDEO_FASTSEEK_USED": {
+    "alert_emails": ["lchristie@mozilla.com", "cpearce@mozilla.com"],
+    "expires_in_version": "55",
+    "bug_numbers": [1245982],
+    "kind": "count",
+    "description": "Uses of HTMLMediaElement.fastSeek"
+  },
+  "VIDEO_DROPPED_FRAMES_PROPORTION" : {
+    "alert_emails": ["lchristie@mozilla.com", "cpearce@mozilla.com"],
+    "expires_in_version": "55",
+    "kind": "linear",
+    "high": 100,
+    "n_buckets": 50,
+    "bug_numbers": [1238433],
+    "description": "Percentage of frames decoded frames dropped in an HTMLVideoElement"
+  },
+  "TAB_SWITCH_CACHE_POSITION": {
+    "expires_in_version": "55",
+    "bug_numbers": [1242013],
+    "kind": "linear",
+    "high": 100,
+    "n_buckets": 50,
+    "description": "Position in (theoretical) tab cache of tab being switched to"
+  },
+  "REMOTE_JAR_PROTOCOL_USED": {
+    "alert_emails": ["dev-platform@lists.mozilla.org"],
+    "expires_in_version": "55",
+    "bug_numbers": [1255934],
+    "kind": "count",
+    "description": "Remote JAR protocol usage"
+  },
+  "MEDIA_DECODER_BACKEND_USED": {
+    "alert_emails": ["danderson@mozilla.com"],
+    "bug_numbers": [1259695],
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 10,
+    "description": "Media decoder backend (0=WMF Software, 1=DXVA2D3D9, 2=DXVA2D3D11)"
+  },
+  "PLUGIN_BLOCKED_FOR_STABILITY": {
+    "alert_emails": ["cpeterson@mozilla.com"],
+    "expires_in_version": "52",
+    "kind": "count",
+    "bug_numbers": [1237198],
+    "description": "Count plugins blocked for stability"
+  },
+  "PLUGIN_TINY_CONTENT": {
+    "alert_emails": ["cpeterson@mozilla.com"],
+    "expires_in_version": "52",
+    "kind": "count",
+    "bug_numbers": [1237198],
+    "description": "Count tiny plugin content"
+  },
+  "IPC_MESSAGE_SIZE": {
+    "alert_emails": ["wmccloskey@mozilla.com"],
+    "bug_numbers": [1260908],
+    "expires_in_version": "55",
+    "kind": "exponential",
+    "high": 8000000,
+    "n_buckets": 50,
+    "keyed": true,
+    "description": "Measures the size of IPC messages by message name"
+  },
+  "IPC_REPLY_SIZE": {
+    "alert_emails": ["wmccloskey@mozilla.com"],
+    "bug_numbers": [1264820],
+    "expires_in_version": "55",
+    "kind": "exponential",
+    "high": 8000000,
+    "n_buckets": 50,
+    "keyed": true,
+    "description": "Measures the size of IPC messages by message name"
+  },
+  "IPC_SYNC_MAIN_LATENCY_MS": {
+    "alert_emails": ["cpearce@mozilla.com"],
+    "bug_numbers": [1333489],
+    "expires_in_version": "60",
+    "kind": "exponential",
+    "low": 32,
+    "high": 750,
+    "n_buckets": 40,
+    "keyed": true,
+    "description": "Measures the number of milliseconds we spend waiting for sync IPC messages to finish sending, keyed by message name. Note: only messages that wait for more than 500 microseconds and block the main thread are included in this probe."
+  },
+  "MESSAGE_MANAGER_MESSAGE_SIZE2": {
+    "alert_emails": ["wmccloskey@mozilla.com","amccreight@mozilla.com"],
+    "bug_numbers": [1260908],
+    "expires_in_version": "55",
+    "kind": "exponential",
+    "low": 8192,
+    "high": 8000000,
+    "n_buckets": 50,
+    "keyed": true,
+    "description": "Each key is the message name, with digits removed, from an async message manager message that was larger than 8192 bytes, recorded in the sending process at the time of sending."
+  },
+  "REJECTED_MESSAGE_MANAGER_MESSAGE": {
+    "alert_emails": ["amccreight@mozilla.com"],
+    "bug_numbers": [1272423],
+    "expires_in_version": "55",
+    "kind": "count",
+    "keyed": true,
+    "description": "Each key is the message name, with digits removed, from an async message manager message that was rejected for being over approximately 128MB, recorded in the sending process at the time of sending."
+  },
+  "SANDBOX_BROKER_INITIALIZED": {
+    "alert_emails": ["bowen@mozilla.com"],
+    "bug_numbers": [1256992],
+    "expires_in_version": "55",
+    "kind": "boolean",
+    "description": "Result of call to SandboxBroker::Initialize"
+  },
+  "SANDBOX_HAS_SECCOMP_BPF": {
+    "alert_emails": ["gcp@mozilla.com"],
+    "bug_numbers": [1098428],
+    "expires_in_version": "55",
+    "kind": "boolean",
+    "cpp_guard": "XP_LINUX",
+    "description": "Whether the system has seccomp-bpf capability"
+  },
+  "SANDBOX_HAS_SECCOMP_TSYNC": {
+    "alert_emails": ["gcp@mozilla.com"],
+    "bug_numbers": [1098428],
+    "expires_in_version": "55",
+    "kind": "boolean",
+    "cpp_guard": "XP_LINUX",
+    "description": "Whether the system has seccomp-bpf thread-sync capability"
+  },
+  "SANDBOX_HAS_USER_NAMESPACES": {
+    "alert_emails": ["gcp@mozilla.com"],
+    "bug_numbers": [1098428],
+    "expires_in_version": "55",
+    "kind": "boolean",
+    "cpp_guard": "XP_LINUX",
+    "description": "Whether our process succedeed in creating a user namespace"
+  },
+  "SANDBOX_HAS_USER_NAMESPACES_PRIVILEGED": {
+    "alert_emails": ["gcp@mozilla.com"],
+    "bug_numbers": [1098428],
+    "expires_in_version": "55",
+    "kind": "boolean",
+    "cpp_guard": "XP_LINUX",
+    "description": "Whether the system has the capability to create privileged user namespaces"
+  },
+ "SANDBOX_MEDIA_ENABLED": {
+    "alert_emails": ["gcp@mozilla.com"],
+    "bug_numbers": [1098428],
+    "expires_in_version": "55",
+    "kind": "boolean",
+    "cpp_guard": "XP_LINUX",
+    "description": "Whether the sandbox is enabled for media/GMP plugins"
+  },
+ "SANDBOX_CONTENT_ENABLED": {
+    "alert_emails": ["gcp@mozilla.com"],
+    "bug_numbers": [1098428],
+    "expires_in_version": "55",
+    "kind": "boolean",
+    "cpp_guard": "XP_LINUX",
+    "description": "Whether the sandbox is enabled for the content process"
+  },
+  "SANDBOX_REJECTED_SYSCALLS": {
+    "alert_emails": ["jld@mozilla.com", "gcp@mozilla.com"],
+    "bug_numbers": [1286865],
+    "expires_in_version": "never",
+    "releaseChannelCollection": "opt-out",
+    "kind": "count",
+    "keyed": true,
+    "cpp_guard": "XP_LINUX",
+    "description": "System calls blocked by a seccomp-bpf sandbox policy; limited to syscalls where we would crash on Nightly.  The key is generally the architecture and syscall ID but in some cases we include non-personally-identifying information from the syscall arguments; see the function SubmitToTelemetry in security/sandbox/linux/reporter/SandboxReporter.cpp for details."
+  },
+  "SYNC_WORKER_OPERATION": {
+    "alert_emails": ["amarchesini@mozilla.com", "khuey@mozilla.com" ],
+    "bug_numbers": [1267904],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": 5000,
+    "n_buckets": 20,
+    "keyed": true,
+    "description": "Tracking how long a Worker thread is blocked when a sync operation is executed on the main-thread."
+  },
+  "SUBPROCESS_KILL_HARD": {
+    "alert_emails": ["wmccloskey@mozilla.com"],
+    "bug_numbers": [1269961],
+    "expires_in_version": "never",
+    "kind": "count",
+    "keyed": true,
+    "releaseChannelCollection": "opt-out",
+    "description": "Counts the number of times a subprocess was forcibly killed, and the reason."
+  },
+  "FX_CONTENT_CRASH_DUMP_UNAVAILABLE": {
+    "alert_emails": ["wmccloskey@mozilla.com"],
+    "bug_numbers": [1269961],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Counts the number of times that about:tabcrashed was unable to find a crash dump."
+  },
+  "FX_CONTENT_CRASH_PRESENTED": {
+    "alert_emails": ["wmccloskey@mozilla.com"],
+    "bug_numbers": [1269961],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Counts the number of times that about:tabcrashed appeared and found a crash dump."
+  },
+  "FX_CONTENT_CRASH_NOT_SUBMITTED": {
+    "alert_emails": ["wmccloskey@mozilla.com"],
+    "bug_numbers": [1269961],
+    "expires_in_version": "never",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out",
+    "description": "Counts the number of times that about:tabcrashed was unloaded without submitting."
+  },
+  "ABOUTCRASHES_OPENED_COUNT": {
+    "alert_emails": ["gfx-telemetry-alerts@mozilla.com","bgirard@mozilla.com","msreckovic@mozilla.com"],
+    "expires_in_version": "55",
+    "kind": "count",
+    "bug_numbers": [1276714, 1276716],
+    "description": "Number of times about:crashes has been opened.",
+    "releaseChannelCollection": "opt-out"
+  },
+   "D3D9_COMPOSITING_FAILURE_ID": {
+    "alert_emails": ["bgirard@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "keyed": true,
+    "description": "D3D9 compositor runtime and dynamic failure IDs. This will record a count for each context creation success or failure. Each failure id is a unique identifier that can be traced back to a particular failure branch or blocklist rule.",
+    "bug_numbers": [1002846]
+  },
+    "D3D11_COMPOSITING_FAILURE_ID": {
+    "alert_emails": ["bgirard@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "keyed": true,
+    "description": "D3D11 compositor runtime and dynamic failure IDs. This will record a count for each context creation success or failure. Each failure id is a unique identifier that can be traced back to a particular failure branch or blocklist rule.",
+    "bug_numbers": [1002846]
+  },
+    "OPENGL_COMPOSITING_FAILURE_ID": {
+    "alert_emails": ["bgirard@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "keyed": true,
+    "description": "OpenGL compositor runtime and dynamic failure IDs. This will record a count for each context creation success or failure. Each failure id is a unique identifier that can be traced back to a particular failure branch or blocklist rule.",
+    "bug_numbers": [1002846]
+  },
+  "WEBVTT_TRACK_KINDS": {
+    "alert_emails": ["alwu@mozilla.com"],
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "n_values": 10,
+    "bug_numbers": [1280644],
+    "description": "Number of the use of the subtitles kind track. 0=Subtitles, 1=Captions, 2=Descriptions, 3=Chapters, 4=Metadata, 5=Undefined Error",
+    "releaseChannelCollection": "opt-out"
+  },
+  "WEBVTT_USED_VTT_CUES": {
+    "alert_emails": ["alwu@mozilla.com"],
+    "expires_in_version": "55",
+    "kind": "count",
+    "bug_numbers": [1280644],
+    "description": "Number of the use of the vtt cues.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "BLINK_FILESYSTEM_USED": {
+    "alert_emails": ["amarchesini@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "bug_numbers": [1272501],
+    "releaseChannelCollection": "opt-out",
+    "description": "Webkit/Blink filesystem used"
+  },
+  "WEBKIT_DIRECTORY_USED": {
+    "alert_emails": ["amarchesini@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "bug_numbers": [1272501],
+    "releaseChannelCollection": "opt-out",
+    "description": "HTMLInputElement.webkitdirectory attribute used"
+  },
+  "CONTAINER_USED": {
+    "alert_emails": ["amarchesini@mozilla.com"],
+    "expires_in_version": "58",
+    "kind": "enumerated",
+    "bug_numbers": [1276006],
+    "n_values": 5,
+    "description": "Records a value each time a builtin container is opened. 1=personal 2=work 3=banking 4=shopping. Does not record usage of user-created containers."
+  },
+  "UNIQUE_CONTAINERS_OPENED": {
+    "alert_emails": ["amarchesini@mozilla.com"],
+    "expires_in_version": "58",
+    "bug_numbers": [1276006],
+    "kind": "count",
+    "description": "Tracking the unique number of opened Containers."
+  },
+  "TOTAL_CONTAINERS_OPENED": {
+    "alert_emails": ["amarchesini@mozilla.com"],
+    "expires_in_version": "58",
+    "bug_numbers": [1276006],
+    "kind": "count",
+    "description": "Tracking the total number of opened Containers."
+  },
+  "STORAGE_SYNC_GET_OPS_SIZE": {
+    "alert_emails": ["eglassercamp@mozilla.com"],
+    "expires_in_version": "58",
+    "bug_numbers": [1328974],
+    "kind": "exponential",
+    "high": 100000,
+    "n_buckets": 30,
+    "keyed": true,
+    "description": "Track the size of results of get() operations performed this subsession. The key is the addon ID.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "STORAGE_SYNC_SET_OPS_SIZE": {
+    "alert_emails": ["eglassercamp@mozilla.com"],
+    "expires_in_version": "58",
+    "bug_numbers": [1328974],
+    "kind": "exponential",
+    "high": 100000,
+    "n_buckets": 30,
+    "keyed": true,
+    "description": "Track the size of set() operations performed by addons this subsession. The key is the addon ID.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "STORAGE_SYNC_REMOVE_OPS": {
+    "alert_emails": ["eglassercamp@mozilla.com"],
+    "expires_in_version": "58",
+    "bug_numbers": [1328974],
+    "kind": "count",
+    "keyed": true,
+    "description": "Track the number of remove() operations addons perform this subsession. The key is the addon ID.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "FENNEC_SESSIONSTORE_DAMAGED_SESSION_FILE": {
+    "alert_emails": ["jh+bugzilla@buttercookie.de"],
+    "expires_in_version": "61",
+    "kind": "flag",
+    "bug_numbers": [1284017],
+    "description": "When restoring tabs on startup, reading from sessionstore.js failed, even though the file exists and is not containing an explicitly empty window.",
+    "cpp_guard": "ANDROID"
+  },
+  "FENNEC_SESSIONSTORE_RESTORING_FROM_BACKUP": {
+    "alert_emails": ["jh+bugzilla@buttercookie.de"],
+    "expires_in_version": "61",
+    "kind": "flag",
+    "bug_numbers": [1190627],
+    "description": "When restoring tabs on startup, reading from sessionstore.js failed, but sessionstore.bak was read successfully.",
+    "cpp_guard": "ANDROID"
+  },
+  "FENNEC_SESSIONSTORE_ALL_FILES_DAMAGED": {
+    "alert_emails": ["jh+bugzilla@buttercookie.de"],
+    "expires_in_version": "61",
+    "kind": "flag",
+    "bug_numbers": [1337115],
+    "description": "Both the main session file and its backup could not be read and and the first run pref is false.",
+    "cpp_guard": "ANDROID"
+  },
+  "SHARED_WORKER_COUNT": {
+    "alert_emails": ["amarchesini@mozilla.com"],
+    "expires_in_version": "58",
+    "kind": "count",
+    "bug_numbers": [1295980],
+    "description": "Number of the use of SharedWorkers."
+  },
+  "NUMBER_OF_PROFILES": {
+    "alert_emails": ["amarchesini@mozilla.com"],
+    "expires_in_version": "58",
+    "bug_numbers": [1296606],
+    "kind": "count",
+    "description": "Number of named browser profiles for the current user, as reported by the profile service at startup."
+  },
+  "WEB_PERMISSION_CLEARED": {
+    "alert_emails": ["firefox-dev@mozilla.org"],
+    "bug_numbers": [1286118],
+    "expires_in_version": "55",
+    "kind": "enumerated",
+    "keyed": true,
+    "n_values": 6,
+    "description": "Number of revoke actions on permissions in the control center, keyed by permission id. Values represent the permission type that was revoked. (0=unknown, 1=permanently allowed, 2=permanently blocked, 3=temporarily allowed, 4=temporarily blocked)"
+  },
+  "JS_AOT_USAGE": {
+    "alert_emails": ["luke@mozilla.com", "bbouvier@mozilla.com"],
+    "bug_numbers": [1288778],
+    "expires_in_version": "56",
+    "kind": "enumerated",
+    "n_values": 4,
+    "description": "Counts the number of asm.js vs WebAssembly modules instanciations, at the time modules are getting instanciated."
+  },
+  "TIME_TO_FIRST_CLICK_MS": {
+    "alert_emails": ["hkirschner@mozilla.com"],
+    "bug_numbers": [1307675, 1332511],
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "high": 50000,
+    "n_buckets": 100,
+    "description": "Time in milliseconds from the first non-blank paint to the creation time of the next click event per top-level content browsing context."
+  },
+  "TIME_TO_FIRST_KEY_INPUT_MS": {
+    "alert_emails": ["hkirschner@mozilla.com"],
+    "bug_numbers": [1307675, 1332511],
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "high": 50000,
+    "n_buckets": 100,
+    "description": "Time in milliseconds from the first non-blank paint to the creation time of the next key event per top-level content browsing context."
+  },
+  "TIME_TO_FIRST_MOUSE_MOVE_MS": {
+    "alert_emails": ["hkirschner@mozilla.com"],
+    "bug_numbers": [1307675, 1332511],
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "high": 50000,
+    "n_buckets": 100,
+    "description": "Time in milliseconds from the first non-blank paint to the creation time of the next mouse move event per top-level content browsing context."
+  },
+  "TIME_TO_FIRST_SCROLL_MS": {
+    "alert_emails": ["hkirschner@mozilla.com"],
+    "bug_numbers": [1307675, 1332511],
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "high": 50000,
+    "n_buckets": 100,
+    "description": "Time in milliseconds from the first non-blank paint to the creation time of the next scroll event per top-level content browsing context."
+  },
+  "TIME_TO_FIRST_INTERACTION_MS": {
+    "alert_emails": ["hkirschner@mozilla.com"],
+    "bug_numbers": [1332511],
+    "expires_in_version": "58",
+    "kind": "exponential",
+    "high": 50000,
+    "n_buckets": 100,
+    "description": "Time in milliseconds from the first non-blank paint to the creation time of the next click, key, mouse or scroll event per top-level content browsing context."
+  },
+  "DOCUMENT_WITH_EXPANDED_PRINCIPAL": {
+    "alert_emails": ["dev-platform@lists.mozilla.org"],
+    "bug_numbers": [1301123],
+    "expires_in_version": "58",
+    "kind": "count",
+    "description": "Number of documents encountered using an expanded principal."
+  },
+  "CONTENT_PAINT_TIME": {
+    "alert_emails": ["danderson@mozilla.com"],
+    "bug_numbers": [1309442],
+    "expires_in_version": "56",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 50,
+    "description": "Time spent in the paint pipeline for content."
+  },
+  "CONTENT_LARGE_PAINT_PHASE_WEIGHT": {
+    "alert_emails": ["danderson@mozilla.com"],
+    "bug_numbers": [1309442],
+    "expires_in_version": "56",
+    "keyed": true,
+    "kind": "linear",
+    "high": 100,
+    "n_buckets": 10,
+    "description": "Percentage of time taken by phases in expensive content paints."
+  },
+  "NARRATE_CONTENT_BY_LANGUAGE_2": {
+    "alert_emails": ["eisaacson@mozilla.com"],
+    "bug_numbers": [1308030, 1324868],
+    "releaseChannelCollection": "opt-out",
+    "expires_in_version": "56",
+    "kind": "enumerated",
+    "keyed": true,
+    "n_values": 4,
+    "description": "Number of Narrate initialization attempts and successes broken up by content's language (ISO 639-1 code) (0 = initialization attempt, 1 = successfully initialized)"
+  },
+  "NARRATE_CONTENT_SPEAKTIME_MS": {
+    "alert_emails": ["eisaacson@mozilla.com"],
+    "bug_numbers": [1308030],
+    "releaseChannelCollection": "opt-out",
+    "expires_in_version": "56",
+    "kind": "linear",
+    "high": 300000,
+    "n_buckets": 30,
+    "description": "Time in MS that content is narrated in 10 second increments up to 5 minutes"
+  },
+  "TABCHILD_PAINT_TIME": {
+    "alert_emails": ["mconley@mozilla.com"],
+    "bug_numbers": [1313686],
+    "expires_in_version": "56",
+    "kind": "exponential",
+    "high": 1000,
+    "n_buckets": 50,
+    "description": "Time spent painting the contents of a remote browser (ms).",
+    "releaseChannelCollection": "opt-out"
+  },
+  "TIME_TO_NON_BLANK_PAINT_MS": {
+    "alert_emails": ["hkirschner@mozilla.com"],
+    "expires_in_version": "55",
+    "kind": "exponential",
+    "high": 100000,
+    "n_buckets": 100,
+    "bug_numbers": [1307242],
+    "description": "The time between navigation start and the first non-blank paint of a foreground root content document, in milliseconds. This only records documents that were in an active docshell throughout the whole time between navigation start and non-blank paint. The non-blank paint timestamp is taken during display list building and does not include rasterization or compositing of that paint."
+  },
+  "TAB_AUDIO_INDICATOR_USED": {
+    "alert_emails": ["alwu@mozilla.com"],
+    "expires_in_version": "58",
+    "kind": "enumerated",
+    "n_values": 6,
+    "bug_numbers": [1314220],
+    "description": "The total usage amount of the operations of tab audio indicator, mute=0 , unmuted=1, unblockByVisitingTab=2, unblockingByClickingIcon=3",
+    "releaseChannelCollection": "opt-out"
+  },
+  "TAB_MEDIA_BLOCKING_TIME_MS": {
+    "alert_emails": ["alwu@mozilla.com"],
+    "expires_in_version": "58",
+    "kind": "linear",
+    "low": 1000,
+    "high": 90000,
+    "n_buckets": 91,
+    "bug_numbers": [1314220],
+    "description": "The time duration from tab's media was blocked to unblocked. Now we record from 1 to 90 seconds, but the record by milliseconds, so the bucket is like [1000ms, 2000ms], [2000ms, 3000ms], e.t.c.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "MAIN_THREAD_RUNNABLE_MS": {
+    "alert_emails": ["wmccloskey@mozilla.com"],
+    "expires_in_version": "60",
+    "kind": "exponential",
+    "keyed": true,
+    "high": 10000,
+    "n_buckets": 10,
+    "bug_numbers": [1331804],
+    "description": "The time a given main thread runnable took to run (in milliseconds). The key comes from the runnables nsINamed::name value."
+  },
+  "MOZ_BLOB_IN_XHR": {
+    "alert_emails": ["amarchesini@mozilla.com"],
+    "expires_in_version": "58",
+    "kind": "boolean",
+    "bug_numbers": [1335365],
+    "releaseChannelCollection": "opt-out",
+    "description": "XMLHttpRequest.responseType set to moz-blob"
+  },
+  "MOZ_CHUNKED_TEXT_IN_XHR": {
+    "alert_emails": ["amarchesini@mozilla.com"],
+    "expires_in_version": "58",
+    "kind": "boolean",
+    "bug_numbers": [1335365],
+    "releaseChannelCollection": "opt-out",
+    "description": "XMLHttpRequest.responseType set to moz-chunked-text"
+  },
+  "MOZ_CHUNKED_ARRAYBUFFER_IN_XHR": {
+    "alert_emails": ["amarchesini@mozilla.com"],
+    "expires_in_version": "58",
+    "kind": "boolean",
+    "bug_numbers": [1335365],
+    "releaseChannelCollection": "opt-out",
+    "description": "XMLHttpRequest.responseType set to moz-chunked-arraybuffer"
+  },
+  "BUSY_TAB_ABANDONED": {
+    "alert_emails": ["hkirschner@mozilla.com"],
+    "expires_in_version": "60",
+    "kind": "categorical",
+    "bug_numbers": [1307689],
+    "description": "Records a value each time a tab that is showing the loading throbber is interrupted. Desktop only.",
+    "labels": ["stop", "back", "forward", "historyNavigation", "reload", "tabClosed", "newURI"]
+  },
+  "EXTENSION_INSTALL_PROMPT_RESULT": {
+    "alert_emails": ["aswan@mozilla.com", "andym@mozilla.com"],
+    "bug_numbers": [1338713],
+    "expires_in_version": "60",
+    "kind": "categorical",
+    "labels": ["installAmoAccepted", "installAmoRejected", "installLocalAccepted", "installLocalRejected", "installWebAccepted", "installWebRejected", "sideloadAccepted", "sideloadRejected", "updateAccepted", "updateRejected"],
+    "description": "Results of displaying add-on installation notifications.",
+    "releaseChannelCollection": "opt-out"
+  },
+  "IPC_READ_MAIN_THREAD_LATENCY_MS": {
+    "alert_emails": ["mlayzell@mozilla.com"],
+    "bug_numbers": [1342635],
+    "expires_in_version": "60",
+    "kind": "exponential",
+    "high": 500,
+    "n_buckets": 20,
+    "keyed": true,
+    "description": "Measures the number of milliseconds we spend waiting on the main thread for IPC messages to deserialize their parameters. Note: only messages that take more than 500 microseconds are included in this probe. This probe is keyed on the IPDL message name."
+  },
+  "IPC_WRITE_MAIN_THREAD_LATENCY_MS": {
+    "alert_emails": ["mlayzell@mozilla.com"],
+    "bug_numbers": [1342635],
+    "expires_in_version": "60",
+    "kind": "exponential",
+    "high": 500,
+    "n_buckets": 20,
+    "keyed": true,
+    "description": "Measures the number of milliseconds we spend waiting on the main thread for IPC messages to serialize their parameters. Note: only messages that take more than 500 microseconds are included in this probe. This probe is keyed on the IPDL message name."
+  }
+}

--- a/src/test/resources/Scalars.yaml
+++ b/src/test/resources/Scalars.yaml
@@ -1,0 +1,262 @@
+telemetry.test:
+  unsigned_int_kind:
+    bug_numbers:
+      - 1276190
+    description: >
+      This is a test uint type with a really long description, maybe spanning even multiple
+      lines, to just prove a point: everything works just fine.
+    expires: never
+    kind: uint
+    notification_emails:
+      - telemetry-client-dev@mozilla.com
+    record_in_processes:
+      - 'main'
+
+  string_kind:
+    bug_numbers:
+      - 1276190
+    description: A string test type with a one line comment that works just fine!
+    expires: never
+    kind: string
+    notification_emails:
+      - telemetry-client-dev@mozilla.com
+    record_in_processes:
+      - 'main'
+
+  boolean_kind:
+    bug_numbers:
+      - 1281214
+    description: A boolean test type with a one line comment that works just fine!
+    expires: never
+    kind: boolean
+    notification_emails:
+      - telemetry-client-dev@mozilla.com
+    record_in_processes:
+      - 'main'
+
+  expired:
+    bug_numbers:
+      - 1276190
+    description: This is an expired testing scalar; not meant to be touched.
+    expires: 4.0a1
+    kind: uint
+    notification_emails:
+      - telemetry-client-dev@mozilla.com
+    record_in_processes:
+      - 'main'
+
+  unexpired:
+    bug_numbers:
+      - 1276190
+    description: This is an unexpired testing scalar; not meant to be touched.
+    expires: "375.0"
+    kind: uint
+    notification_emails:
+      - telemetry-client-dev@mozilla.com
+    record_in_processes:
+      - 'main'
+
+  release_optin:
+    bug_numbers:
+      - 1276190
+    description: A testing scalar; not meant to be touched.
+    expires: never
+    kind: uint
+    notification_emails:
+      - telemetry-client-dev@mozilla.com
+    release_channel_collection: opt-in
+    record_in_processes:
+      - 'main'
+
+  release_optout:
+    bug_numbers:
+      - 1276190
+    description: A testing scalar; not meant to be touched.
+    expires: never
+    kind: uint
+    notification_emails:
+      - telemetry-client-dev@mozilla.com
+    release_channel_collection: opt-out
+    record_in_processes:
+      - 'main'
+
+  keyed_release_optin:
+    bug_numbers:
+      - 1277806
+    description: A testing scalar; not meant to be touched.
+    expires: never
+    kind: uint
+    keyed: true
+    notification_emails:
+      - telemetry-client-dev@mozilla.com
+    release_channel_collection: opt-in
+    record_in_processes:
+      - 'main'
+
+  keyed_release_optout:
+    bug_numbers:
+      - 1277806
+    description: A testing scalar; not meant to be touched.
+    expires: never
+    kind: uint
+    keyed: true
+    notification_emails:
+      - telemetry-client-dev@mozilla.com
+    release_channel_collection: opt-out
+    record_in_processes:
+      - 'main'
+
+  keyed_expired:
+    bug_numbers:
+      - 1277806
+    description: This is an expired testing scalar; not meant to be touched.
+    expires: 4.0a1
+    kind: uint
+    keyed: true
+    notification_emails:
+      - telemetry-client-dev@mozilla.com
+    record_in_processes:
+      - 'main'
+
+  keyed_unsigned_int:
+    bug_numbers:
+      - 1277806
+    description: A testing keyed uint scalar; not meant to be touched.
+    expires: never
+    kind: uint
+    keyed: true
+    notification_emails:
+      - telemetry-client-dev@mozilla.com
+    record_in_processes:
+      - 'main'
+
+  keyed_boolean_kind:
+    bug_numbers:
+      - 1277806
+    description: A testing keyed boolean scalar; not meant to be touched.
+    expires: never
+    kind: boolean
+    keyed: true
+    notification_emails:
+      - telemetry-client-dev@mozilla.com
+    record_in_processes:
+      - 'main'
+      - 'content'
+
+  content_only_uint:
+    bug_numbers:
+      - 1278556
+    description: A testing uint scalar; not meant to be touched.
+    expires: never
+    kind: uint
+    notification_emails:
+      - telemetry-client-dev@mozilla.com
+    record_in_processes:
+      - 'content'
+
+  all_processes_uint:
+    bug_numbers:
+      - 1278556
+    description: A testing uint scalar; not meant to be touched.
+    expires: never
+    kind: uint
+    notification_emails:
+      - telemetry-client-dev@mozilla.com
+    record_in_processes:
+      - 'all'
+
+  all_child_processes_string:
+    bug_numbers:
+      - 1278556
+    description: A testing string scalar; not meant to be touched.
+    expires: never
+    kind: string
+    notification_emails:
+      - telemetry-client-dev@mozilla.com
+    record_in_processes:
+      - 'all_childs'
+
+mock:
+  scalar.uint:
+    bug_numbers:
+      - 1318709
+    description: A mocked scalar; not meant to be touched.
+    expires: never
+    kind: uint
+    notification_emails:
+      - noop@mozilla.com
+    release_channel_collection: opt-out
+
+  scalar.bool:
+    bug_numbers:
+      - 1318709
+    description: A mocked scalar; not meant to be touched.
+    expires: never
+    kind: boolean
+    notification_emails:
+      - noop@mozilla.com
+    release_channel_collection: opt-out
+
+  scalar.string:
+    bug_numbers:
+      - 1318709
+    description: A mocked scalar; not meant to be touched.
+    expires: never
+    kind: string
+    notification_emails:
+      - noop@mozilla.com
+    release_channel_collection: opt-out
+
+  keyed.scalar.uint:
+    bug_numbers:
+      - 1318709
+    description: A mocked scalar; not meant to be touched.
+    expires: never
+    kind: uint
+    keyed: true
+    notification_emails:
+      - noop@mozilla.com
+    release_channel_collection: opt-out
+
+  keyed.scalar.bool:
+    bug_numbers:
+      - 1318709
+    description: A mocked scalar; not meant to be touched.
+    expires: never
+    kind: boolean 
+    keyed: true
+    notification_emails:
+      - noop@mozilla.com
+    release_channel_collection: opt-out
+
+  keyed.scalar.string:
+    bug_numbers:
+      - 1318709
+    description: A mocked scalar; not meant to be touched.
+    expires: never
+    kind: string
+    keyed: true
+    notification_emails:
+      - noop@mozilla.com
+    release_channel_collection: opt-out
+
+  uint.optout:
+    bug_numbers:
+      - 1318709
+    description: A mocked scalar; not meant to be touched.
+    expires: never
+    kind: uint
+    release_channel_collection: opt-out
+    notification_emails:
+      - noop@mozilla.com
+
+  uint.optin:
+    bug_numbers:
+      - 1318709
+    description: A mocked scalar; not meant to be touched.
+    expires: never
+    kind: uint
+    release_channel_collection: opt-in
+    notification_emails:
+      - noop@mozilla.com
+

--- a/src/test/resources/ShortHistograms.json
+++ b/src/test/resources/ShortHistograms.json
@@ -1,0 +1,101 @@
+{
+  "BROWSER_IS_USER_DEFAULT": {
+    "description": "The result of the startup default desktop browser check.",
+    "expires_in_version": "never",
+    "kind": "boolean",
+    "releaseChannelCollection": "opt-out"
+  },
+  "FIPS_ENABLED": {
+    "alert_emails": ["seceng@mozilla.org"],
+    "bug_numbers": [1241317],
+    "description": "Has FIPS mode been enabled?",
+    "expires_in_version": "54",
+    "kind": "flag",
+    "releaseChannelCollection": "opt-out"
+  },
+  "FX_MIGRATION_ERRORS": {
+    "bug_numbers": [731025],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "57",
+    "kind": "enumerated",
+    "keyed": true,
+    "n_values": 12,
+    "releaseChannelCollection": "opt-out",
+    "description": "Errors encountered during migration in buckets defined by the datatype, keyed by the string description of the browser."
+  },
+  "FX_MIGRATION_LOGINS_IMPORT_MS": {
+    "bug_numbers": [1289436],
+    "alert_emails": ["gijs@mozilla.com"],
+    "expires_in_version": "57",
+    "kind": "exponential",
+    "n_buckets": 70,
+    "high": 100000,
+    "releaseChannelCollection": "opt-out",
+    "keyed": true,
+    "description": "How long it took to import logins (passwords) from another browser, keyed by the name of the browser."
+  },
+  "FX_TAB_SWITCH_TOTAL_MS": {
+    "description": "Firefox: Time in ms till a tab switch is complete including the first paint",
+    "expires_in_version": "56",
+    "high": 1000,
+    "kind": "exponential",
+    "n_buckets": 20,
+    "releaseChannelCollection": "opt-out"
+  },
+  "GC_MS": {
+    "alert_emails": ["dev-telemetry-gc-alerts@mozilla.org"],
+    "description": "Time spent running JS GC (ms)",
+    "expires_in_version": "never",
+    "high": 10000,
+    "kind": "exponential",
+    "n_buckets": 50},
+  "GFX_CRASH": {
+    "description": "Graphics Crash Reason (...)",
+    "expires_in_version": "never",
+    "kind": "enumerated",
+    "n_values": 100,
+    "releaseChannelCollection": "opt-out"
+  },
+  "MOCK_OPTIN": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": "10",
+    "n_buckets": 10,
+    "releaseChannelCollection": "opt-in",
+    "description": "a testing histogram; not meant to be touched"
+  },
+  "MOCK_OPTOUT": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "linear",
+    "high": "10",
+    "n_buckets": 10,
+    "releaseChannelCollection": "opt-out",
+    "description": "a testing histogram; not meant to be touched"
+  },
+  "PUSH_API_NOTIFY": {
+    "alert_emails": ["push@mozilla.com"],
+    "description": "Number of push messages that were successfully decrypted and delivered to a ServiceWorker.",
+    "expires_in_version": "60",
+    "kind": "count",
+    "releaseChannelCollection": "opt-out"
+  },
+  "SEARCH_SERVICE_ENGINE_COUNT": {
+    "alert_emails": ["florian@mozilla.com"],
+    "bug_numbers": [1268424],
+    "description": "Recorded once per session near startup: records the search plugin count, including both built-in plugins (including the ones the user has hidden) and user-installed plugins.",
+    "expires_in_version": "55",
+    "high": 200,
+    "kind": "linear",
+    "n_buckets": 50,
+    "releaseChannelCollection": "opt-out"
+  },
+  "SEARCH_COUNTS": {
+    "expires_in_version": "never",
+    "kind": "count",
+    "keyed": true,
+    "releaseChannelCollection": "opt-out",
+    "description": "Record the search counts for search engines"
+  }
+}

--- a/src/test/scala/com/mozilla/telemetry/CrossSectionalViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/CrossSectionalViewTest.scala
@@ -4,7 +4,7 @@ import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.SQLContext
 import com.mozilla.telemetry.views._
 import CrossSectionalView._
-import org.scalatest.{FlatSpec, TestFailedException}
+import org.scalatest.FlatSpec
 import org.apache.spark.sql.Dataset
 
 class CrossSectionalViewTest extends FlatSpec {

--- a/src/test/scala/com/mozilla/telemetry/LongitudinalTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/LongitudinalTest.scala
@@ -1,7 +1,9 @@
 package com.mozilla.telemetry.views
+import java.io.PrintWriter
 
 import com.mozilla.telemetry.parquet.ParquetFile
-import com.mozilla.telemetry.scalars._
+import com.mozilla.telemetry.scalars.ScalarsClass
+import com.mozilla.telemetry.histograms.HistogramsClass
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
 import org.apache.spark.sql.{Row, SQLContext}
@@ -13,80 +15,105 @@ import org.scalatest.{FlatSpec, Matchers, PrivateMethodTester}
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable.WrappedArray
+import scala.io.Source
+
+import org.apache.avro.io.EncoderFactory
+import org.apache.avro.generic.{GenericDatumReader, GenericDatumWriter, GenericRecord, GenericRecordBuilder}
+import java.io.ByteArrayOutputStream
 
 class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
+  val parentConstant = 42
+  val contentConstant = 24
+  val gpuConstant = 17
+
   val fixture = {
     def createPayload(idx: Int): Map[String, Any] = {
-      val histograms =
+      val histograms = (constant: Int) => {
         ("FIPS_ENABLED" ->
           ("values" -> ("0" -> 0)) ~
           ("sum" -> 0)) ~
         ("BROWSER_IS_USER_DEFAULT" ->
-          ("values" -> ("0" -> 42)) ~
+          ("values" -> ("0" -> constant)) ~
           ("sum" -> 0)) ~
         ("PUSH_API_NOTIFY" ->
-          ("values" -> ("0" -> 42)) ~
-          ("sum" -> 42)) ~
+          ("values" -> ("0" -> constant)) ~
+          ("sum" -> 0)) ~
         ("GFX_CRASH" ->
-          ("values" -> ("1" -> 42)) ~
-          ("sum" -> 42)) ~
+          ("values" -> ("1" -> constant)) ~
+          ("sum" -> constant)) ~
         ("SEARCH_SERVICE_ENGINE_COUNT" ->
-          ("values" -> ("1" -> 42)) ~
-          ("sum" -> 42)) ~
+          ("values" -> ("1" -> constant)) ~
+          ("sum" -> constant)) ~
         ("FX_TAB_SWITCH_TOTAL_MS" ->
-          ("values" -> ("1" -> 42)) ~
-          ("sum" -> 42)) ~
+          ("values" -> ("1" -> constant)) ~
+          ("sum" -> constant)) ~
         ("GC_MS" ->
-          ("values" -> ("1" -> 42)) ~
-          ("sum" -> 42))
+          ("values" -> ("1" -> constant)) ~
+          ("sum" -> constant)) ~
+        ("MOCK_OPTIN" ->
+          ("values" -> ("1" -> constant)) ~
+          ("sum" -> constant)) ~
+        ("MOCK_OPTOUT" ->
+          ("values" -> ("1" -> constant)) ~
+          ("sum" -> constant))
+      }
 
-      val keyedHistograms =
+      val keyedHistograms = (constant: Int) => {
         ("FX_MIGRATION_ERRORS" ->
           ("foo" ->
-            ("values" -> ("1" -> 42)) ~
-            ("sum" -> 42))) ~
+            ("values" -> ("1" -> constant)) ~
+            ("sum" -> constant))) ~
         ("SEARCH_COUNTS" ->
           ("foo" ->
-            ("values" -> ("0" -> 42)) ~
-            ("sum" -> 42))) ~
+            ("values" -> ("0" -> constant)) ~
+            ("sum" -> constant))) ~
         ("FX_MIGRATION_LOGINS_IMPORT_MS" ->
           ("foo" ->
-            ("values" -> ("1" -> 42)) ~
-            ("sum" -> 42)))
+            ("values" -> ("1" -> constant)) ~
+            ("sum" -> constant)))
+      }
 
-      val scalars =
-        ("telemetry.test.unsigned_int_kind" -> 37 ) ~
-        ("mock.scalar.uint" -> 3) ~
+      val scalars = (constant: Int) => {
+        ("telemetry.test.unsigned_int_kind" -> constant ) ~
+        ("mock.scalar.uint" -> constant) ~
         ("mock.scalar.bool" -> true) ~
-        ("mock.scalar.string" -> "a nice string scalar")
+        ("mock.scalar.string" -> constant.toString) ~
+        ("mock.uint.optin" -> constant) ~
+        ("mock.uint.optout" -> constant)
+      }
 
-      val keyedScalars =
+      val keyedScalars = (constant: Int) => {
         ("mock.keyed.scalar.uint" ->
-          ("a_key" -> 37) ~
-          ("second_key" -> 42)) ~
+          ("a_key" -> constant) ~
+          ("second_key" -> constant)) ~
         ("mock.keyed.scalar.bool" ->
           ("foo" -> true) ~
           ("bar" -> false)) ~
         ("mock.keyed.scalar.string" ->
-          ("fizz" -> "buzz") ~
-          ("other" -> "some"))
+          ("fizz" -> constant.toString) ~
+          ("other" -> constant.toString))
+      }
 
       val parent =
         if (idx == 1) {
           // Skip the scalar section for the first payload.
           ("bogus" -> "other") ~
-          ("keyedScalars" -> keyedScalars)
+          ("keyedScalars" -> keyedScalars(parentConstant))
         } else {
-          ("scalars" -> scalars) ~
-          ("keyedScalars" -> keyedScalars)
+          ("scalars" -> scalars(parentConstant)) ~
+          ("keyedScalars" -> keyedScalars(parentConstant))
         }
 
       val pingPayload =
         ("processes" ->
           ("parent" -> parent) ~
           ("content" ->
-            ("histograms" -> histograms) ~
-            ("keyedHistograms" -> keyedHistograms)
+            ("histograms" -> histograms(contentConstant)) ~
+            ("keyedHistograms" -> keyedHistograms(contentConstant))
+          ) ~
+          ("gpu" ->
+            ("histograms" -> histograms(gpuConstant)) ~
+            ("keyedHistograms" -> keyedHistograms(gpuConstant))
           )
         )
 
@@ -110,7 +137,7 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
 
       val settings =
         ("e10sEnabled" -> true) ~
-        ("userPrefs" -> 
+        ("userPrefs" ->
           ("network.proxy.http" -> "proxy http") ~
           ("dom.ipc.processCount" -> 2) ~
           ("browser.zoom.full" -> false) ~
@@ -185,8 +212,8 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
         "DNT" -> "1",
         "payload.info" -> compact(render(info)),
         "payload.simpleMeasurements" -> compact(render(simpleMeasurements)),
-        "payload.histograms" -> compact(render(histograms)),
-        "payload.keyedHistograms" -> compact(render(keyedHistograms)),
+        "payload.histograms" -> compact(render(histograms(parentConstant))),
+        "payload.keyedHistograms" -> compact(render(keyedHistograms(parentConstant))),
         "payload" -> compact(render(pingPayload)),
         "environment.build" -> compact(render(build)),
         "environment.partner" -> compact(render(partner)),
@@ -197,34 +224,55 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
     }
 
     new {
-      // Mock the scalars definitions to ease testing.
-      Scalars.definitions =
-        Map(
-          ("mock.scalar.uint", UintScalar(false)),
-          ("mock.scalar.bool", BooleanScalar(false)),
-          ("mock.scalar.string", StringScalar(false)),
-          ("mock.keyed.scalar.uint", UintScalar(true)),
-          ("mock.keyed.scalar.bool", BooleanScalar(true)),
-          ("mock.keyed.scalar.string", StringScalar(true))
-        )
+      val scalarUrlMock = (a: String, b: String) => Source.fromFile("src/test/resources/Scalars.yaml")
+      val histogramUrlMock = (a: String, b: String) => Source.fromFile("src/test/resources/ShortHistograms.json")
+
+      val scalars =  new ScalarsClass {
+        override protected val getURL = scalarUrlMock
+      }
+
+      val histograms = new HistogramsClass {
+        override protected val getURL = histogramUrlMock
+      }
 
       private val buildSchema = PrivateMethod[Schema]('buildSchema)
       private val buildRecord = PrivateMethod[Option[GenericRecord]]('buildRecord)
 
-      private val schema = LongitudinalView invokePrivate buildSchema()
       val payloads = for (i <- 1 to 10) yield createPayload(i)
       private val dupes = for (i <- 1 to 10) yield createPayload(1)
-      private val record = (LongitudinalView  invokePrivate buildRecord(payloads ++ dupes, schema)).get
-      private val path = ParquetFile.serialize(List(record).toIterator, schema)
-      private val filename = path.toString.replace("file:", "")
 
       private val sparkConf = new SparkConf().setAppName("Longitudinal")
       sparkConf.setMaster(sparkConf.get("spark.master", "local[1]"))
+
       private val sc = new SparkContext(sparkConf)
       sc.setLogLevel("WARN")
+
       private val sqlContext = new SQLContext(sc)
-      val rows = sqlContext.read.load(filename).collect()
-      val row =  rows(0)
+
+      // Opt-out only schema
+      private val optoutHistogramDefs = histograms.definitions(includeOptin = false)
+      private val optoutScalarDefs = scalars.definitions(includeOptin = false)
+
+      private val optoutSchema = LongitudinalView invokePrivate buildSchema(optoutHistogramDefs, optoutScalarDefs)
+      private val optoutRecord = (LongitudinalView  invokePrivate buildRecord(payloads ++ dupes, optoutSchema, optoutHistogramDefs, optoutScalarDefs)).get
+      private val optoutPath = ParquetFile.serialize(List(optoutRecord).toIterator, optoutSchema)
+      private val optoutFilename = optoutPath.toString.replace("file:", "")
+
+      val optoutRows = sqlContext.read.load(optoutFilename).collect()
+      val optoutRow =  optoutRows(0)
+
+      // Opt-out and Opt-in schema
+      private val optinHistogramDefs = histograms.definitions(includeOptin = true)
+      private val optinScalarDefs = scalars.definitions(includeOptin = true)
+
+      private val optinSchema = LongitudinalView invokePrivate buildSchema(optinHistogramDefs, optinScalarDefs)
+      private val optinRecord = (LongitudinalView  invokePrivate buildRecord(payloads ++ dupes, optinSchema, optinHistogramDefs, optinScalarDefs)).get
+      private val optinPath = ParquetFile.serialize(List(optinRecord).toIterator, optinSchema)
+      private val optinFilename = optinPath.toString.replace("file:", "")
+
+      val optinRows = sqlContext.read.load(optinFilename).collect()
+      val optinRow =  optinRows(0)
+
       sc.stop()
     }
   }
@@ -247,37 +295,37 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
 
     def compareFields[T](fields: Array[(String, T)]) {
       for ((key, reference) <- fields) {
-        val records = fixture.row.getList[T](fixture.row.fieldIndex(key))
+        val records = fixture.optoutRow.getList[T](fixture.optoutRow.fieldIndex(key))
         assert(records.size == fixture.payloads.size)
         records.foreach(x => assert(x == reference))
       }
     }
 
-    assert(fixture.rows.length == 1)
+    assert(fixture.optoutRows.length == 1)
     compareFields(stringFields)
     compareFields(floatFields)
   }
 
   "Top-level measurements" must "be converted correctly" in {
-    assert(fixture.row.getAs[String]("client_id") == fixture.payloads(0)("clientId"))
-    assert(fixture.row.getAs[String]("os") == fixture.payloads(0)("os"))
-    assert(fixture.row.getAs[String]("normalized_channel") == fixture.payloads(0)("normalizedChannel"))
+    assert(fixture.optoutRow.getAs[String]("client_id") == fixture.payloads(0)("clientId"))
+    assert(fixture.optoutRow.getAs[String]("os") == fixture.payloads(0)("os"))
+    assert(fixture.optoutRow.getAs[String]("normalized_channel") == fixture.payloads(0)("normalizedChannel"))
   }
 
   "payload.info" must "be converted correctly" in {
-    val reasonRecords = fixture.row.getList[String](fixture.row.fieldIndex("reason"))
+    val reasonRecords = fixture.optoutRow.getList[String](fixture.optoutRow.fieldIndex("reason"))
     assert(reasonRecords.length == fixture.payloads.length)
     reasonRecords.foreach(x => assert(x == "shutdown"))
   }
 
   "environment.build" must "be converted correctly" in {
-    val records = fixture.row.getList[Row](fixture.row.fieldIndex("build"))
+    val records = fixture.optoutRow.getList[Row](fixture.optoutRow.fieldIndex("build"))
     assert(records.length == fixture.payloads.length)
     records.foreach(x => assert(x.getAs[String]("build_id") == "20160101001100"))
   }
 
   "environment.partner" must "be converted correctly" in {
-    val records = fixture.row.getList[Row](fixture.row.fieldIndex("partner"))
+    val records = fixture.optoutRow.getList[Row](fixture.optoutRow.fieldIndex("partner"))
     assert(records.length == fixture.payloads.length)
     records.foreach{ x =>
       val partner_names = x.getList[String](x.fieldIndex("partner_names"))
@@ -286,31 +334,31 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
   }
 
   "environment.system" must "be converted correctly" in {
-    val records = fixture.row.getList[Row](fixture.row.fieldIndex("system"))
+    val records = fixture.optoutRow.getList[Row](fixture.optoutRow.fieldIndex("system"))
     assert(records.length == fixture.payloads.length)
     records.foreach(x => assert(x.getAs[Int]("memory_mb") == 2048))
   }
 
   "environment.system/cpu" must "be converted correctly" in {
-    val records = fixture.row.getList[Row](fixture.row.fieldIndex("system_cpu"))
+    val records = fixture.optoutRow.getList[Row](fixture.optoutRow.fieldIndex("system_cpu"))
     assert(records.length == fixture.payloads.length)
     records.foreach(x => assert(x.getAs[Int]("count") == 4))
   }
 
   "environment.system/device" must "be converted correctly" in {
-    val records = fixture.row.getList[Row](fixture.row.fieldIndex("system_device"))
+    val records = fixture.optoutRow.getList[Row](fixture.optoutRow.fieldIndex("system_device"))
     assert(records.length == fixture.payloads.length)
     records.foreach(x => assert(x.getAs[String]("model") == "SHARP"))
   }
 
   "environment.system/os" must "be converted correctly" in {
-    val records = fixture.row.getList[Row](fixture.row.fieldIndex("system_os"))
+    val records = fixture.optoutRow.getList[Row](fixture.optoutRow.fieldIndex("system_os"))
     assert(records.length == fixture.payloads.length)
     records.foreach(x => assert(x.getAs[String]("name") == "Windows_NT"))
   }
 
   "environment.system/os windows fields" must "be converted correctly" in {
-    val records = fixture.row.getList[Row](fixture.row.fieldIndex("system_os"))
+    val records = fixture.optoutRow.getList[Row](fixture.optoutRow.fieldIndex("system_os"))
     assert(records.length == fixture.payloads.length)
     records.foreach(x => assert(x.getAs[Int]("windows_build_number") == 10586))
     records.foreach(x => assert(x.getAs[Int]("windows_ubr") == 446))
@@ -318,7 +366,7 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
   }
 
   "environment.system/hdd" must "be converted correctly" in {
-    val records = fixture.row.getList[Row](fixture.row.fieldIndex("system_hdd"))
+    val records = fixture.optoutRow.getList[Row](fixture.optoutRow.fieldIndex("system_hdd"))
     assert(records.length == fixture.payloads.length)
     records.foreach { x =>
       val p = x.getAs[Row]("profile")
@@ -327,7 +375,7 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
   }
 
   "environment.system/gfx" must "be converted correctly" in {
-    val records = fixture.row.getList[Row](fixture.row.fieldIndex("system_gfx"))
+    val records = fixture.optoutRow.getList[Row](fixture.optoutRow.fieldIndex("system_gfx"))
     assert(records.length == fixture.payloads.length)
     records.foreach{ x =>
       val a = x.getList[Row](x.fieldIndex("adapters"))(0)
@@ -336,13 +384,13 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
   }
 
   "environment.settings" must "be converted correctly" in {
-    val records = fixture.row.getList[Row](fixture.row.fieldIndex("settings"))
+    val records = fixture.optoutRow.getList[Row](fixture.optoutRow.fieldIndex("settings"))
     assert(records.length == fixture.payloads.length)
     records.foreach(x => assert(x.getAs[Boolean]("e10s_enabled")))
   }
 
   "environment.settings.userPrefs" must "be converted correctly" in {
-    val records = fixture.row.getList[Row](fixture.row.fieldIndex("settings"))
+    val records = fixture.optoutRow.getList[Row](fixture.optoutRow.fieldIndex("settings"))
     val prefs  = records.map(
       record => record.getAs[Map[String, String]](record.fieldIndex("user_prefs"))
     )
@@ -352,7 +400,7 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
   }
 
   "environment.addons.activeAddons" must "be converted correctly" in {
-    val records = fixture.row.getList[Map[String, Row]](fixture.row.fieldIndex("active_addons"))
+    val records = fixture.optoutRow.getList[Map[String, Row]](fixture.optoutRow.fieldIndex("active_addons"))
     assert(records.length == fixture.payloads.length)
     records.foreach{ x =>
       val addon = x.get("jid0-edalmuivkozlouyij0lpdx548bc@jetpack").get
@@ -362,13 +410,13 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
   }
 
   "environment.addons.theme" must "be converted correctly" in {
-    val records = fixture.row.getList[Row](fixture.row.fieldIndex("theme"))
+    val records = fixture.optoutRow.getList[Row](fixture.optoutRow.fieldIndex("theme"))
     assert(records.length == fixture.payloads.length)
     records.foreach(x => assert(x.getAs[String]("description") == "The default theme."))
   }
 
   "environment.addons.activePlugins" must "be converted correctly" in {
-    val records = fixture.row.getList[WrappedArray[Row]](fixture.row.fieldIndex("active_plugins"))
+    val records = fixture.optoutRow.getList[WrappedArray[Row]](fixture.optoutRow.fieldIndex("active_plugins"))
     assert(records.length == fixture.payloads.length)
     records.foreach{ x =>
       assert(!x(0).getAs[Boolean]("blocklisted"))
@@ -376,7 +424,7 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
   }
 
   "environment.addons.activeGMPlugins" must "be converted correctly" in {
-    val records = fixture.row.getList[Map[String, Row]](fixture.row.fieldIndex("active_gmp_plugins"))
+    val records = fixture.optoutRow.getList[Map[String, Row]](fixture.optoutRow.fieldIndex("active_gmp_plugins"))
     assert(records.length == fixture.payloads.length)
     records.foreach{ x =>
       val plugin = x.get("gmp-eme-adobe").get
@@ -385,37 +433,37 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
   }
 
   "environment.addons.activeExperiment" must "be converted correctly" in {
-    val records = fixture.row.getList[Row](fixture.row.fieldIndex("active_experiment"))
+    val records = fixture.optoutRow.getList[Row](fixture.optoutRow.fieldIndex("active_experiment"))
     assert(records.length == fixture.payloads.length)
     records.foreach(x => assert(x.getAs[String]("id") == "A"))
   }
 
   "payload.simpleMeasurements" must "be converted correctly" in {
-    val records = fixture.row.getList[Row](fixture.row.fieldIndex("simple_measurements"))
+    val records = fixture.optoutRow.getList[Row](fixture.optoutRow.fieldIndex("simple_measurements"))
     assert(records.length == fixture.payloads.length)
     records.foreach(x => assert(x.getAs[Long]("uptime") == 18))
   }
 
   "Flag histograms" must "be converted correctly" in {
-    val histograms = fixture.row.getList[Boolean](fixture.row.fieldIndex("fips_enabled"))
+    val histograms = fixture.optoutRow.getList[Boolean](fixture.optoutRow.fieldIndex("fips_enabled"))
     assert(histograms.length == fixture.payloads.length)
     histograms.foreach(x => assert(x))
   }
 
   "Boolean histograms" must "be converted correctly" in {
-    val histograms = fixture.row.getList[WrappedArray[Long]](fixture.row.fieldIndex("browser_is_user_default"))
+    val histograms = fixture.optoutRow.getList[WrappedArray[Long]](fixture.optoutRow.fieldIndex("browser_is_user_default"))
     assert(histograms.length == fixture.payloads.length)
-    histograms.foreach(x => assert(x.toList == List(42, 0)))
+    histograms.foreach(x => assert(x.toList == List(parentConstant, 0)))
   }
 
   "Count histograms" must "be converted correctly" in {
-    val histograms = fixture.row.getList[Int](fixture.row.fieldIndex("push_api_notify"))
+    val histograms = fixture.optoutRow.getList[Int](fixture.optoutRow.fieldIndex("push_api_notify"))
     assert(histograms.length == fixture.payloads.length)
-    histograms.foreach(x => assert(x == 42))
+    histograms.foreach(x => assert(x == parentConstant))
   }
 
   "Enumerated histograms" must "be converted correctly" in {
-    val histograms = fixture.row.getList[WrappedArray[Int]](fixture.row.fieldIndex("gfx_crash"))
+    val histograms = fixture.optoutRow.getList[WrappedArray[Int]](fixture.optoutRow.fieldIndex("gfx_crash"))
     assert(histograms.length == fixture.payloads.length)
 
     for (h <- histograms) {
@@ -423,7 +471,7 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
 
       for ((value, key) <- h.zipWithIndex) {
         if (key == 1)
-          assert(value == 42)
+          assert(value == parentConstant)
         else
           assert(value == 0)
       }
@@ -431,29 +479,29 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
   }
 
   "Linear histograms" must "be converted correctly" in {
-    val histograms = fixture.row.getList[Row](fixture.row.fieldIndex("search_service_engine_count"))
+    val histograms = fixture.optoutRow.getList[Row](fixture.optoutRow.fieldIndex("search_service_engine_count"))
     assert(histograms.length == fixture.payloads.length)
 
-    val reference = List(0, 42) ++ List.fill(48)(0)
+    val reference = List(0, parentConstant) ++ List.fill(48)(0)
     histograms.foreach{ x =>
-      assert(x.getAs[Long]("sum") == 42L)
+      assert(x.getAs[Long]("sum") == parentConstant.toLong)
       assert(x.getList[Int](x.fieldIndex("values")).toList == reference)
     }
   }
 
   "Exponential histograms" must "be converted correctly" in {
-    val histograms = fixture.row.getList[Row](fixture.row.fieldIndex("fx_tab_switch_total_ms"))
+    val histograms = fixture.optoutRow.getList[Row](fixture.optoutRow.fieldIndex("fx_tab_switch_total_ms"))
     assert(histograms.length == fixture.payloads.length)
 
-    val reference = List(0, 42) ++ List.fill(18)(0)
+    val reference = List(0, parentConstant) ++ List.fill(18)(0)
     histograms.foreach{ x =>
-      assert(x.getAs[Long]("sum") == 42L)
+      assert(x.getAs[Long]("sum") == parentConstant.toLong)
       assert(x.getList[Int](x.fieldIndex("values")).toList == reference.toList)
     }
   }
 
   "Keyed enumerated histograms" must "be converted correctly" in {
-    val entries = fixture.row.getMap[String, WrappedArray[WrappedArray[Int]]](fixture.row.fieldIndex("fx_migration_errors"))
+    val entries = fixture.optoutRow.getMap[String, WrappedArray[WrappedArray[Int]]](fixture.optoutRow.fieldIndex("fx_migration_errors"))
     assert(entries.size == 1)
 
     for (h <- entries("foo")) {
@@ -461,7 +509,7 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
 
       for ((value, key) <- h.zipWithIndex) {
         if (key == 1)
-          assert(value == 42)
+          assert(value == parentConstant)
         else
           assert(value == 0)
       }
@@ -469,48 +517,76 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
   }
 
   "Keyed count histograms" must "be converted correctly" in {
-    val entries = fixture.row.getMap[String, WrappedArray[Int]](fixture.row.fieldIndex("search_counts"))
+    val entries = fixture.optoutRow.getMap[String, WrappedArray[Int]](fixture.optoutRow.fieldIndex("search_counts"))
     assert(entries.size == 1)
     assert(entries("foo").size == fixture.payloads.length)
-    entries("foo").foreach(x => assert(x == 42))
+    entries("foo").foreach(x => assert(x == parentConstant))
   }
 
   "Keyed exponential histograms" must "be converted correctly" in {
-    val entries = fixture.row.getMap[String, WrappedArray[Row]](fixture.row.fieldIndex("fx_migration_logins_import_ms"))
+    val entries = fixture.optoutRow.getMap[String, WrappedArray[Row]](fixture.optoutRow.fieldIndex("fx_migration_logins_import_ms"))
     assert(entries.size == 1)
 
     val histograms = entries("foo")
     assert(histograms.length == fixture.payloads.length)
 
-    val reference = List(0, 42) ++ List.fill(68)(0)
+    val reference = List(0, parentConstant) ++ List.fill(68)(0)
     histograms.foreach{ x =>
-      assert(x.getAs[Long]("sum") == 42L)
+      assert(x.getAs[Long]("sum") == parentConstant.toLong)
       assert(x.getList[Int](x.fieldIndex("values")).toList == reference.toList)
     }
   }
 
   "Keyed Content Histograms" must "be included" in {
-    val entries = fixture.row.getMap[String, WrappedArray[Int]](fixture.row.fieldIndex("search_counts_content"))
+    val entries = fixture.optoutRow.getMap[String, WrappedArray[Int]](fixture.optoutRow.fieldIndex("search_counts_content"))
     assert(entries.size == 1)
     assert(entries("foo").size == fixture.payloads.length)
-    entries("foo").foreach(x => assert(x == 42))
+    entries("foo").foreach(x => assert(x == contentConstant))
   }
 
-  "Opt-in Histograms" must "be ignored" in {
-    intercept[IllegalArgumentException](fixture.row.fieldIndex("gc_ms"))
+  "Opt-in Histograms" must "be ignored for optout only" in {
+    intercept[IllegalArgumentException](fixture.optoutRow.fieldIndex("mock_optin"))
   }
+
+  "Opt-in Histograms" must "not be ignored when opt-in included" in {
+    val histograms = fixture.optinRow.getList[Row](fixture.optinRow.fieldIndex("mock_optin"))
+    assert(histograms.length == fixture.payloads.length)
+
+    val reference = List(0, parentConstant) ++ List.fill(8)(0)
+    histograms.foreach{ x =>
+      assert(x.getAs[Long]("sum") == parentConstant.toLong)
+      assert(x.getList[Int](x.fieldIndex("values")).toList == reference.toList)
+    }
+   }
+
+  "Opt-out Histograms" must "not be ignored when opt-in included" in {
+    val histograms = fixture.optinRow.getList[Row](fixture.optinRow.fieldIndex("mock_optout"))
+    assert(histograms.length == fixture.payloads.length)
+
+    val reference = List(0, parentConstant) ++ List.fill(8)(0)
+    histograms.foreach{ x =>
+      assert(x.getAs[Long]("sum") == parentConstant.toLong)
+      assert(x.getList[Int](x.fieldIndex("values")).toList == reference.toList)
+    }
+   }
 
   "Content Histograms" must "be included" in {
-    val histograms = fixture.row.getList[Boolean](fixture.row.fieldIndex("fips_enabled_content"))
-    histograms.foreach(x => assert(x))
+    val histograms = fixture.optoutRow.getList[Row](fixture.optoutRow.fieldIndex("mock_optout_content"))
+    assert(histograms.length == fixture.payloads.length)
+
+    val reference = List(0, contentConstant) ++ List.fill(8)(0)
+    histograms.foreach{ x =>
+      assert(x.getAs[Long]("sum") == contentConstant.toLong)
+      assert(x.getList[Int](x.fieldIndex("values")).toList == reference.toList)
+    }
   }
 
   "ClientIterator" should "not trim histories of size < 1000" in {
     val template = ("foo", Map("client" -> "foo"))
-    val history = List.fill(42)(template)
+    val history = List.fill(parentConstant)(template)
     val split_history = new ClientIterator(history.iterator).toList
     assert(split_history.length == 1)
-    split_history(0).length === 42
+    split_history(0).length === parentConstant
   }
 
   it should "not trim histories of size 1000" in {
@@ -531,20 +607,20 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
   }
 
   "Unsigned scalars" must "be converted correctly" in {
-    val scalars = fixture.row.getList[Row](fixture.row.fieldIndex("scalar_parent_mock_scalar_uint"))
+    val scalars = fixture.optoutRow.getList[Row](fixture.optoutRow.fieldIndex("scalar_parent_mock_scalar_uint"))
     assert(scalars.length == fixture.payloads.length)
     scalars.zipWithIndex.foreach { case (x, index) =>
       // The first payload in the fixture is missing the scalars section. The scalars
       // must contain null for it.
       Option(x.getAs[Long]("value")) match {
-        case Some(value) => assert(value == 3)
+        case Some(value) => assert(value == parentConstant)
         case None => assert(index == 0)
       }
     }
   }
 
   "Boolean scalars" must "be converted correctly" in {
-    val scalars = fixture.row.getList[Row](fixture.row.fieldIndex("scalar_parent_mock_scalar_bool"))
+    val scalars = fixture.optoutRow.getList[Row](fixture.optoutRow.fieldIndex("scalar_parent_mock_scalar_bool"))
     assert(scalars.length == fixture.payloads.length)
     scalars.zipWithIndex.foreach { case (x, index) =>
       // The first payload in the fixture is missing the scalars section. The scalars
@@ -557,13 +633,13 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
   }
 
   "String scalars" must "be converted correctly" in {
-    val scalars = fixture.row.getList[Row](fixture.row.fieldIndex("scalar_parent_mock_scalar_string"))
+    val scalars = fixture.optoutRow.getList[Row](fixture.optoutRow.fieldIndex("scalar_parent_mock_scalar_string"))
     assert(scalars.length == fixture.payloads.length)
     scalars.zipWithIndex.foreach { case (x, index) =>
       // The first payload in the fixture is missing the scalars section. The scalars
       // must contain null for it.
       Option(x.getAs[String]("value")) match {
-        case Some(value) => assert(value == "a nice string scalar")
+        case Some(value) => assert(value == parentConstant.toString)
         case None => assert(index == 0)
       }
     }
@@ -571,17 +647,17 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
 
   "Keyed unsigned scalars" must "be converted correctly" in {
     val entries =
-      fixture.row.getMap[String, WrappedArray[Row]](fixture.row.fieldIndex("scalar_parent_mock_keyed_scalar_uint"))
+      fixture.optoutRow.getMap[String, WrappedArray[Row]](fixture.optoutRow.fieldIndex("scalar_parent_mock_keyed_scalar_uint"))
     assert(entries.size == 2)
     assert(entries("a_key").size == fixture.payloads.length)
-    entries("a_key").foreach(x => assert(x.getAs[Long]("value") == 37))
+    entries("a_key").foreach(x => assert(x.getAs[Long]("value") == parentConstant))
     assert(entries("second_key").size == fixture.payloads.length)
-    entries("second_key").foreach(x => assert(x.getAs[Long]("value") == 42))
+    entries("second_key").foreach(x => assert(x.getAs[Long]("value") == parentConstant))
   }
 
   "Keyed boolean scalars" must "be converted correctly" in {
     val entries =
-      fixture.row.getMap[String, WrappedArray[Row]](fixture.row.fieldIndex("scalar_parent_mock_keyed_scalar_bool"))
+      fixture.optoutRow.getMap[String, WrappedArray[Row]](fixture.optoutRow.fieldIndex("scalar_parent_mock_keyed_scalar_bool"))
     assert(entries.size == 2)
     assert(entries("foo").size == fixture.payloads.length)
     entries("foo").foreach(x => assert(x.getAs[Boolean]("value") == true))
@@ -591,17 +667,62 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
 
   "Keyed string scalars" must "be converted correctly" in {
     val entries =
-      fixture.row.getMap[String, WrappedArray[Row]](fixture.row.fieldIndex("scalar_parent_mock_keyed_scalar_string"))
+      fixture.optoutRow.getMap[String, WrappedArray[Row]](fixture.optoutRow.fieldIndex("scalar_parent_mock_keyed_scalar_string"))
     assert(entries.size == 2)
     assert(entries("fizz").size == fixture.payloads.length)
-    entries("fizz").foreach(x => assert(x.getAs[String]("value") == "buzz"))
+    entries("fizz").foreach(x => assert(x.getAs[String]("value") == parentConstant.toString))
     assert(entries("other").size == fixture.payloads.length)
-    entries("other").foreach(x => assert(x.getAs[String]("value") == "some"))
+    entries("other").foreach(x => assert(x.getAs[String]("value") == parentConstant.toString))
   }
 
-  "Test scalars" must "not be adedd to the dataset" in {
+  "Test scalars" must "not be added to the dataset" in {
     intercept[IllegalArgumentException] {
-      fixture.row.fieldIndex("scalar_parent_telemetry_test_unsigned_int_kind")
+      fixture.optoutRow.fieldIndex("scalar_parent_telemetry_test_unsigned_int_kind")
+    }
+  }
+
+  "Opt-in scalars" must "not be added to opt-out dataset" in {
+    intercept[IllegalArgumentException] {
+      fixture.optoutRow.fieldIndex("scalar_parent_mock_uint_optin")
+    }
+  }
+
+  "Opt-in scalars" must "be added to opt-in dataset" in {
+    val scalars = fixture.optinRow.getList[Row](fixture.optinRow.fieldIndex("scalar_parent_mock_uint_optin"))
+    assert(scalars.length == fixture.payloads.length)
+    scalars.zipWithIndex.foreach { case (x, index) =>
+      // The first payload in the fixture is missing the scalars section. The scalars
+      // must contain null for it.
+      Option(x.getAs[Long]("value")) match {
+        case Some(value) => assert(value == parentConstant)
+        case None => assert(index == 0)
+      }
+    }
+  }
+
+  "Opt-out scalars" must "be added to opt-out dataset" in {
+    val scalars = fixture.optoutRow.getList[Row](fixture.optoutRow.fieldIndex("scalar_parent_mock_uint_optout"))
+    assert(scalars.length == fixture.payloads.length)
+    scalars.zipWithIndex.foreach { case (x, index) =>
+      // The first payload in the fixture is missing the scalars section. The scalars
+      // must contain null for it.
+      Option(x.getAs[Long]("value")) match {
+        case Some(value) => assert(value == parentConstant)
+        case None => assert(index == 0)
+      }
+    }
+  }
+
+  "Opt-out scalars" must "be added to opt-in dataset" in {
+    val scalars = fixture.optinRow.getList[Row](fixture.optinRow.fieldIndex("scalar_parent_mock_uint_optout"))
+    assert(scalars.length == fixture.payloads.length)
+    scalars.zipWithIndex.foreach { case (x, index) =>
+      // The first payload in the fixture is missing the scalars section. The scalars
+      // must contain null for it.
+      Option(x.getAs[Long]("value")) match {
+        case Some(value) => assert(value == parentConstant)
+        case None => assert(index == 0)
+      }
     }
   }
 }

--- a/src/test/scala/com/mozilla/telemetry/histograms/HistogramsTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/histograms/HistogramsTest.scala
@@ -1,0 +1,45 @@
+import com.mozilla.telemetry.histograms.HistogramsClass
+
+import scala.io.Source
+import org.scalatest.{FlatSpec, Matchers, PrivateMethodTester}
+
+class HistogramsTest extends FlatSpec with Matchers {
+
+  val fixture = {
+    new {
+      val histograms = new HistogramsClass{
+        override protected val getURL = (a: String, b: String) => Source.fromFile("src/test/resources/ShortHistograms.json")
+      }
+
+      private val optStatuses = List(false, true)
+
+      val names = optStatuses map {
+        optStatus =>
+            optStatus -> histograms.definitions(optStatus).map{
+              case (k, value) =>
+                k.toLowerCase
+            }
+      } toMap
+    }
+  }
+
+  "Optout histograms" must "be included when optout only" in {
+    val histograms = fixture.names(false)
+    assert(histograms.exists(_ == "mock_optout"))
+  }
+
+  "Optin histograms" must "not be included when optout only" in {
+    val histograms = fixture.names(false)
+    assert(!histograms.exists(_ == "mock_optin"))
+  }
+
+  "Optout histograms" must "be included when optin and optout" in {
+    val histograms = fixture.names(true)
+    assert(histograms.exists(_ == "mock_optout"))
+  }
+
+  "Optin histograms" must "be included when optin and optout" in {
+    val histograms = fixture.names(true)
+    assert(histograms.exists(_ == "mock_optin"))
+  }
+}

--- a/src/test/scala/com/mozilla/telemetry/scalars/ScalarsTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/scalars/ScalarsTest.scala
@@ -1,0 +1,45 @@
+import com.mozilla.telemetry.scalars.ScalarsClass
+
+import scala.io.Source
+import org.scalatest.{FlatSpec, Matchers, PrivateMethodTester}
+
+class ScalarsTest extends FlatSpec with Matchers {
+
+  val fixture = {
+    new {
+      val scalars = new ScalarsClass{
+        override protected val getURL = (a: String, b: String) => Source.fromFile("src/test/resources/Scalars.yaml")
+      }
+
+      private val optStatuses = List(true, false)
+
+      val names = optStatuses map {
+        optStatus => 
+            optStatus -> scalars.definitions(optStatus).map{
+              case (k, value) => 
+                k.toLowerCase
+            }
+      } toMap
+    }
+  }
+
+  "Optout scalars" must "be included when optout only" in {
+    val scalars = fixture.names(false)
+    assert(scalars.exists(_ == "mock.uint.optout"))
+  }
+
+  "Optin scalars" must "not be included when optout only" in {
+    val scalars = fixture.names(false)
+    assert(!scalars.exists(_ == "mock.uint.optin"))
+  }
+
+  "Optout scalars" must "be included when optin and optout" in {
+    val scalars = fixture.names(true)
+    assert(scalars.exists(_ == "mock.uint.optout"))
+  }
+
+  "Optin scalars" must "be included when optin and optout" in {
+    val scalars = fixture.names(true)
+    assert(scalars.exists(_ == "mock.uint.optin"))
+  }
+}


### PR DESCRIPTION
This is similar to my previous PR but without the per-process stuff. As such we won't be able to actually create this dataset yet, but the ability is there. I just wanted to use the scalar and histogram parts I created in here for some main_summary work.

Also, now the options are: an opt-out only dataset, or an opt-out and opt-in dataset. No more of the confusing "just opt-in" parts.