### PR TITLE
Remove `date` column from ToplineSummaryView

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/ToplineSummary.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/ToplineSummary.scala
@@ -373,10 +373,8 @@ object ToplineSummary {
       val reportData = createReportDataset(dataset, from, to)
       val crashData = createCrashDataset(from, to)
 
-      val reportFormat = format.DateTimeFormat.forPattern("yyyy-mm-dd")
       val finalReport = easyAggregates(reportData, crashData)
         .join(clientValues(reportData, from), Seq("country", "channel", "os"), "outer")
-        .withColumn("date", lit(reportFormat.print(fromDate)))
         .withColumnRenamed("country", "geo")
         // replace nulls in outer joins
         .na.fill(0, Seq("hours", "crashes", "google", "bing", "yahoo", "other", "actives", "new_records", "default"))


### PR DESCRIPTION
This column was previously added for compatibility with the original `v4_reformat.py` script. This was implemented incorrectly (it should have used yyyy-MM-dd) and is redundant because of report_start.

The topline_dashboard etl job will handle the date field instead.