### PR TITLE
Add generalized longitudinal job

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/utils/udfs.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/udfs.scala
@@ -1,0 +1,159 @@
+package com.mozilla.telemetry.utils
+
+import java.math.BigDecimal
+import java.sql.{Date, Timestamp}
+import org.apache.spark.sql.expressions.{MutableAggregationBuffer, UserDefinedAggregateFunction}
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+
+class CollectList(inputStruct: StructType, orderCols: List[String], maxLength: Option[Int]) extends UserDefinedAggregateFunction {
+  /**
+   * This transforms the groups to arrays. It is similar to collect_list, but
+   * we can't use that because it throws out null values, which we want to retain.
+   * Additionally, it sorts and trims them before outputting.
+   **/
+
+  private val outputSchema = StructType(
+    inputStruct.fields.map{
+      sf => StructField(sf.name, ArrayType(sf.dataType), sf.nullable)
+    }
+  )
+
+  private val numFields = inputStruct.fields.length
+
+  override def inputSchema: StructType = inputStruct
+
+  override def bufferSchema: StructType = outputSchema
+
+  override def dataType: DataType = outputSchema
+
+  override def deterministic: Boolean = false
+
+  override def initialize(buffer: MutableAggregationBuffer): Unit = {
+    (0 to numFields - 1).foreach{
+      n => buffer(n) = Nil
+    }
+  }
+
+  override def update(buffer: MutableAggregationBuffer, input: Row): Unit = {
+    (0 to numFields - 1).foreach{
+      n => buffer(n) = buffer.getSeq(n) :+ input(n)
+    }
+  }
+
+  override def merge(buffer1: MutableAggregationBuffer, buffer2: Row): Unit = {
+    (0 to numFields - 1).foreach{
+      n => buffer1(n) = buffer1.getSeq(n) ++ buffer2.getSeq(n)
+    }
+  }
+
+  /**
+   * SORTING
+   *
+   * We want a descending, stable sort - this includes null values.
+   * As such, our sorting is:
+   *
+   * case e1==null, e2==null  => given ordering
+   * case e1, e2==null => e1 before e2
+   * case e1==null, e2 => e2 before e1
+   * case e1 > e2 => e1 before e2
+   * case e1 < e2 => e2 before e1
+   * case e1 == e2 => given ordering
+   **/
+
+  private def sortInt(arr: Seq[Integer])(e0: Int, e1: Int): Boolean = {
+    val v1 = arr(e0)
+    val v2 = arr(e1)
+    (v1 != null) && ((v2 == null) || v1 > v2)
+  }
+
+  private def sortString(arr: Seq[String])(e0: Int, e1: Int): Boolean = {
+    val v1 = arr(e0)
+    val v2 = arr(e1)
+    (v1 != null) && ((v2 == null) || v1 > v2)
+  }
+
+  private def sortLong(arr: Seq[java.lang.Long])(e0: Int, e1: Int): Boolean = {
+    val v1 = arr(e0)
+    val v2 = arr(e1)
+    (v1 != null) && ((v2 == null) || v1 > v2)
+  }
+
+  private def sort(order: Seq[Int], orderType: DataType, seq: Seq[Any]): Seq[Int] = {
+    orderType match {
+      case _: IntegerType => order.sortWith(sortInt(seq.asInstanceOf[Seq[Integer]]))
+      case _: StringType => order.sortWith(sortString(seq.asInstanceOf[Seq[String]]))
+      case _: LongType => order.sortWith(sortLong(seq.asInstanceOf[Seq[java.lang.Long]]))
+      case other =>
+        throw new UnsupportedOperationException(s"Unsupported sort column type ${other.simpleString}")
+    }
+  }
+
+  private def rsort(input: Seq[Int], buffer: Row, orderColumns: Seq[String]): Seq[Int] = {
+    orderColumns match {
+      case Nil => input
+      case oc => rsort(
+        sort(input,
+             inputSchema(orderColumns.head).dataType,
+             buffer.getSeq(outputSchema.fieldIndex(orderColumns.head))),
+        buffer,
+        orderColumns.tail
+      )
+    }
+  }
+
+  private def sortTrimTypedArray[T](array: Seq[Any], sortOrder: Seq[Int]): Seq[T] = {
+    val typedArray =
+      array
+      .asInstanceOf[Seq[T]]
+
+    val sorted =
+      sortOrder
+      .map(typedArray)
+
+    maxLength match {
+      case Some(m) => sorted.take(m)
+      case _ => sorted
+    }
+  }
+
+  /* We need the specific type of the Seq. For a mapping of Spark Type => Scala Type,
+   * see http://spark.apache.org/docs/latest/sql-programming-guide.html#data-types
+   */
+  private def sortTrimArrayBySeq(dataType: DataType, buffer: Row, arrayIndex: Int, sortOrder: Seq[Int]): Seq[Any] = {
+    dataType match {
+      case _: ByteType      => sortTrimTypedArray[Byte](buffer.getSeq(arrayIndex), sortOrder)
+      case _: ShortType     => sortTrimTypedArray[Short](buffer.getSeq(arrayIndex), sortOrder)
+      case _: IntegerType   => sortTrimTypedArray[Int](buffer.getSeq(arrayIndex), sortOrder)
+      case _: LongType      => sortTrimTypedArray[Long](buffer.getSeq(arrayIndex), sortOrder)
+      case _: FloatType     => sortTrimTypedArray[Float](buffer.getSeq(arrayIndex), sortOrder)
+      case _: DoubleType    => sortTrimTypedArray[Double](buffer.getSeq(arrayIndex), sortOrder)
+      case _: DecimalType   => sortTrimTypedArray[BigDecimal](buffer.getSeq(arrayIndex), sortOrder)
+      case _: StringType    => sortTrimTypedArray[String](buffer.getSeq(arrayIndex), sortOrder)
+      case _: BinaryType    => sortTrimTypedArray[Array[Byte]](buffer.getSeq(arrayIndex), sortOrder)
+      case _: BooleanType   => sortTrimTypedArray[Boolean](buffer.getSeq(arrayIndex), sortOrder)
+      case _: TimestampType => sortTrimTypedArray[Timestamp](buffer.getSeq(arrayIndex), sortOrder)
+      case _: DateType      => sortTrimTypedArray[Date](buffer.getSeq(arrayIndex), sortOrder)
+      case _: ArrayType     => sortTrimTypedArray[Seq[Any]](buffer.getSeq(arrayIndex), sortOrder)
+      case _: MapType       => sortTrimTypedArray[Map[Any, Any]](buffer.getSeq(arrayIndex), sortOrder)
+      case _: StructType    => sortTrimTypedArray[Row](buffer.getSeq(arrayIndex), sortOrder)
+      case other            =>
+        throw new UnsupportedOperationException(s"${other.simpleString} column types are not supported")
+    }
+  }
+
+  private def getOrderedTrimmedArrays(buffer: Row, sortOrder: Seq[Int]): Seq[Seq[Any]] = {
+    (0 to (inputSchema.length - 1)).toList.map{
+        n => sortTrimArrayBySeq(inputSchema(n).dataType, buffer, n, sortOrder)
+    }
+  }
+
+  private def trimAndSort(buffer: Row): Row = {
+    val sortOrder = rsort((0 to (buffer.getSeq(0).length - 1)).toList, buffer, orderCols.reverse)
+    Row.fromSeq(getOrderedTrimmedArrays(buffer, sortOrder))
+  }
+
+  override def evaluate(buffer: Row): Any = {
+    trimAndSort(buffer)
+  }
+}

--- a/src/main/scala/com/mozilla/telemetry/views/GeneralizedLongitudinal.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/GeneralizedLongitudinal.scala
@@ -1,0 +1,148 @@
+package com.mozilla.telemetry.views
+
+import com.mozilla.telemetry.utils.CollectList
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.{DataFrame}
+import org.apache.spark.sql.hive.HiveContext
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.StructType
+
+import com.github.nscala_time.time.Imports._
+import org.rogach.scallop._
+
+object GeneralizedLongitudinalView {
+
+  private class Opts(args: Array[String]) extends ScallopConf(args) {
+    val inputTablename = opt[String](
+      "tablename",
+      descr = "Table to pull data from",
+      required = true)
+    val from = opt[String](
+      "from",
+       descr = "From submission date. Defaults to 6 months before `to`.",
+       required = false)
+    val to = opt[String](
+      "to",
+       descr = "To submission date",
+       required = true)
+    val groupingColumn = opt[String](
+      "grouping-column",
+      descr = "Column to group data by. Defaults to client_id",
+      required = false)
+    val orderingColumns = opt[String](
+      "ordering-columns",
+      descr = "Columns to order the arrays by (comma separated). Defaults to submissionDateCol",
+      required = false)
+    val outputPath = opt[String](
+      "output-path",
+      descr = "Path where data will be outputted",
+      required = true)
+    val submissionDateCol = opt[String](
+      "submission-date-col",
+      descr = "Name of the submission date column. Defaults to submission_date_s3",
+      required = false)
+    val maxArrayLength = opt[Int](
+      "max-array-length",
+      descr = "Max length of any groups history. Defaults to no limit. Negatives are ignored",
+      required = false)
+    val numParquetFiles = opt[Int](
+      "num-parquet-files",
+      descr = "Number of parquet files to output. Defaults to the number of input files",
+      required = false)
+    verify()
+  }
+
+  def main(args: Array[String]): Unit = {
+    val opts = new Opts(args)
+    val fmt = DateTimeFormat.forPattern("yyyyMMdd")
+
+    val inputTablename = opts.inputTablename()
+
+    val to = opts.to()
+
+    val from = opts.from.get match {
+      case Some(f) => f
+      case _ => fmt.print(fmt.parseDateTime(to).minusMonths(6))
+    }
+
+    val groupingColumn = opts.groupingColumn.get match {
+      case Some(gc) => gc
+      case _ => "client_id"
+    }
+
+    val submissionDateCol = opts.groupingColumn.get match {
+      case Some(sd) => sd
+      case _ => "submission_date_s3"
+    }
+
+    val orderingColumns = opts.orderingColumns.get match {
+      case Some(oc) => oc.split(",").toList
+      case _ => List(submissionDateCol)
+    }
+
+    val maxArrayLength = opts.maxArrayLength.get
+
+    val outputPath = opts.outputPath()
+
+    val sparkConf = new SparkConf().setAppName(this.getClass.getName)
+    sparkConf.setMaster(sparkConf.get("spark.master", "local[*]"))
+
+    val sc = new SparkContext(sparkConf)
+    val hiveContext = new HiveContext(sc)
+
+    import hiveContext.implicits._
+
+    val data = hiveContext.sql(s"""
+      SELECT *
+      FROM $inputTablename
+      WHERE $from <= $submissionDateCol
+        AND $submissionDateCol <= $to
+    """)
+
+    val numParquetFiles = opts.numParquetFiles.get match {
+      case Some(n) => n
+      case _ => data.rdd.getNumPartitions
+    }
+
+    group(data, groupingColumn, orderingColumns, maxArrayLength)
+      .repartition(numParquetFiles)
+      .write
+      .parquet(s"s3://$outputPath")
+
+    sc.stop()
+  }
+
+  def group(df: DataFrame, groupColumn: String = "client_id", orderColumns: List[String] = List("submission_date_s3"), maxLength: Option[Int] = None): DataFrame = {
+    // We can't order on the grouping column
+    assert(!orderColumns.contains(groupColumn))
+
+    // Group and create new array columns
+    val nonGroupColumns =
+      df.schema.fieldNames
+      .filter(_ != groupColumn)
+      .toList
+
+    val subSchema = df.schema(nonGroupColumns.toSet)
+    val colNames = groupColumn :: nonGroupColumns
+    val collectListUdf = new CollectList(subSchema, orderColumns, maxLength)
+    val newCol = collectListUdf(nonGroupColumns.map(col(_)): _*)
+    val aggregateColName = "aggcol"
+
+    val aggregated =
+      df.groupBy(groupColumn)
+      .agg(newCol)
+      .toDF(groupColumn, aggregateColName)
+
+    aggregated.select(col(groupColumn) :: getChildren(aggregateColName, aggregated): _*)
+  }
+
+  def getChildren(colname: String, df: DataFrame) = {
+    df.schema(colname)
+      .dataType
+      .asInstanceOf[StructType]
+      .fields
+      .map(x => col(s"$colname.${x.name}"))
+      .toList
+  }
+}

--- a/src/test/scala/com/mozilla/telemetry/views/GeneralizedLongitudinalTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/GeneralizedLongitudinalTest.scala
@@ -1,0 +1,166 @@
+package com.mozilla.telemetry.views
+
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.types._
+import org.scalatest.FlatSpec
+
+class GeneralizedLongitudinalTest extends FlatSpec {
+  val fixture = {
+    new {
+      private val spark = SparkSession.builder()
+        .appName("Generalized Longitudinal Test")
+        .master("local[1]")
+        .getOrCreate()
+
+      import spark.implicits._
+      private val colNames = List("random_data", "client_id", "submission_date_s3", "os", "ordering")
+
+      val data = List(
+        (201742, "1", "20170101", "Android", 1),
+        (199,"1", "20170103", "Android", 3),
+        (42, "1", "20170102", "iOS", 2),
+        (44, "1", "20171212", "nothing", 4),
+        (4242, "2", "20160101", "Android", 1),
+        (2424, "2", null, null, 2)
+      )
+
+      private val df = data.toDF(colNames: _*)
+      private val groupedDf = GeneralizedLongitudinalView.group(df, maxLength=Some(3))
+
+      val longitudinal = groupedDf.collect()
+      val fieldIndex: String => Integer = longitudinal.head.fieldIndex
+
+      val intOrdering = GeneralizedLongitudinalView.group(df, orderColumns=List("ordering")).collect()
+      val secondaryOrdering = GeneralizedLongitudinalView.group(df, orderColumns=List("os", "ordering")).collect()
+      val alternateGrouping = GeneralizedLongitudinalView.group(df, groupColumn="os").collect()
+
+      private val nestedDataColNames = List("group", "order", "nest1", "nest2", "map")
+      val nestedData = List(
+        (1, 2, ("hello", 42), ("hello", 42), Map("hello" -> "world")),
+        (1, 1, ("world", 84), ("world", 84), Map("answer" -> "42"))
+      )
+
+      val nestedGroup = GeneralizedLongitudinalView.group(
+        nestedData.toDF(nestedDataColNames: _*),
+        groupColumn="group",
+        orderColumns=List("order")
+      ).collect()
+
+      // Test Long sorting - can't use List.toDF for nulled Long
+      private val longVal: Long = 1
+      private val longRDD = spark.sparkContext.parallelize(List(Row("a", null, 2), Row("a", longVal, 1)))
+      private val longSchema =
+        StructType(List(
+          StructField("client_id", StringType, nullable = false),
+          StructField("long_val", LongType, nullable = true),
+          StructField("ordering", IntegerType, nullable = false)))
+
+      private val longDF = spark.createDataFrame(longRDD, longSchema)
+      val groupedLongDF = GeneralizedLongitudinalView.group(
+        longDF,
+        orderColumns=List("long_val")
+      ).collect()
+
+      spark.stop()
+    }
+  }
+
+  "longitudinal" must "have grouping column first" in {
+    assert(fixture.longitudinal.head.fieldIndex("client_id") == 0)
+  }
+
+  "longitudinal" must "contain all groups" in {
+    val clientIds = fixture.longitudinal.map(_.get(fixture.fieldIndex("client_id"))).toList
+    assert(clientIds == List("1", "2"))
+  }
+
+  "longitudinal" must "correctly aggregate strings" in {
+    val oss = fixture.longitudinal.map(_.getSeq(fixture.fieldIndex("os")).toList).toList
+    assert(oss == List(List("nothing", "Android", "iOS"), List("Android", null)))
+  }
+
+  "longitudinal" must "order output correctly" in {
+    val ordering = fixture.longitudinal
+                   .filter(_.get(fixture.fieldIndex("client_id")) == "1")
+                   .map(_.getSeq(fixture.fieldIndex("ordering")))
+                   .head
+                   .toList
+    assert(ordering == List(4, 3, 2))
+  }
+
+  "longitudinal" must "trim long histories" in {
+    val row = fixture.longitudinal.filter(_.get(fixture.fieldIndex("client_id")) == "1").head
+    for(i <- 1 to (row.size - 1)){
+      assert(row.getSeq(i).length == 3)
+    }
+  }
+
+  "longitudinal" must "allow for null elements" in {
+    val row = fixture.longitudinal
+              .filter(_.get(fixture.fieldIndex("client_id")) == "2")
+              .head
+
+    val numNulls =
+      (1 to (row.size - 1))
+      .map(row.getSeq(_).contains(null))
+      .map(if(_) 1 else 0)
+      .reduce(_ + _)
+
+    assert(numNulls == 2)
+  }
+
+  "longitudinal" must "sort null last" in {
+    val row = fixture.longitudinal
+              .filter(_.get(fixture.fieldIndex("client_id")) == "2")
+              .map(_.getSeq[String](fixture.fieldIndex("submission_date_s3")))
+              .head
+
+    assert(row.indexOf(null) == row.length - 1)
+  }
+
+  "ordering" must "work for integer type" in {
+    val ordering = fixture.intOrdering
+                   .filter(_.get(fixture.fieldIndex("client_id")) == "1")
+                   .map(_.getSeq[Int](fixture.fieldIndex("ordering")))
+                   .head
+                   .toList
+    assert(ordering == List(4, 3, 2, 1))
+  }
+
+  "secondary ordering" must "work for string-integer combination" in {
+    val ordering = fixture.secondaryOrdering
+                   .filter(_.get(fixture.fieldIndex("client_id")) == "1")
+                   .head
+                   .getSeq[Int](fixture.fieldIndex("ordering"))
+                   .toList
+    assert(ordering == List(4, 2, 3, 1))
+  }
+
+  "grouping" must "allow null values" in {
+    assert(fixture.alternateGrouping.length == 4)
+    assert(fixture.alternateGrouping.toList.map(_.get(0)).toSet == Set("Android", "iOS", "nothing", null))
+  }
+
+  "struct type" must "be converted correctly" in {
+    val nestedCol = fixture.nestedGroup
+                    .head.getSeq[Row](2)
+
+    assert(nestedCol(0) == Row("hello", 42))
+    assert(nestedCol(1) == Row("world", 84))
+  }
+
+  "map type" must "be converted correctly" in {
+    val mapCol = fixture.nestedGroup
+                 .head.getSeq[Map[String, String]](4)
+
+    assert(mapCol(0) == fixture.nestedData(0)._5)
+    assert(mapCol(1) == fixture.nestedData(1)._5)
+  }
+
+  "Long type" must "handle nulls correctly" in {
+    val orderCol = fixture.groupedLongDF
+                   .head
+                   .getSeq[Int](2)
+    assert(orderCol == List(1, 2))
+  }
+}


### PR DESCRIPTION
This will allow us to make Longitudinal-type datasets out of any parquet datasets. I'll be using this for the mobile ones to begin with. With Presto now supporting lambda-expressions, these datasets will be easy-to-use in STMO.

The basic idea here is to give it a dataset name, a grouping column, and any number of ordering columns. Most datasets will be grouped by client_id, and ordered by submission_date or activity_date.

Ideas for more test cases are welcome!