### PR TITLE
Bug 1329541: ... `session_start_date` is null for all records

### DIFF
--- a/src/test/scala/com/mozilla/telemetry/LongitudinalTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/LongitudinalTest.scala
@@ -196,6 +196,7 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
 
       val info =
         ("subsessionStartDate" -> "2015-12-09T00:00:00.0-14:00") ~
+        ("sessionStartDate" -> "2015-12-09T00:00:00.0-14:00") ~
         ("profileSubsessionCounter" -> (1000 - idx)) ~
         ("reason" -> "shutdown")
 
@@ -284,6 +285,7 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
       "geo_city"              -> "New York",
       "dnt_header"            -> "1",
       "subsession_start_date" -> "2015-12-09T12:00:00.000-02:00",
+      "session_start_date"    -> "2015-12-09T12:00:00.000-02:00",
       "profile_creation_date" -> "2014-02-21T00:00:00.000Z",
       "profile_reset_date"    -> "2014-03-03T00:00:00.000Z"
     )


### PR DESCRIPTION
This change adds session_start_date to the longitudinal dataset.

Note that this change removes the calls to `return` and consequentially
changes the behavior of the code in the case of missing
`subsession_start_date` values. However, these values are not missing in
practice, and this appears to be an undefined edge case currently.