### PR TITLE
Make all spark functions available to Generic Long

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/GenericLongitudinal.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/GenericLongitudinal.scala
@@ -5,7 +5,7 @@ import com.mozilla.telemetry.utils.CollectList
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.{DataFrame}
 import org.apache.spark.sql.hive.HiveContext
-import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StructType
 
 import com.github.nscala_time.time.Imports._


### PR DESCRIPTION
This will allow us to use any spark function in the `where` clause.

After this we can set this up with the mobile jobs :)