### PR TITLE
WIP: Experiments analysis job

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/experiments/analyzers/MetricAggregate.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/analyzers/MetricAggregate.scala
@@ -1,0 +1,49 @@
+package com.mozilla.telemetry.experiments.analyzers
+
+import org.apache.spark.sql.Row
+import scala.annotation.tailrec
+
+
+case class MetricAggregate(values: Seq[Long], keys: List[Int]) {
+  val n: Long = values.sum
+  val zipped: List[(Int, Long)] = keys zip values
+
+  val getSummaryStats: List[(String, Double)] = {
+    List(
+      ("mean", mean),
+      ("median", median),
+      ("standard deviation", standardDeviation)
+    )
+  }
+
+  def getSchematizedSummaryStats: List[Row] = {
+    getSummaryStats.map {
+      case (name: String, value: Double) => Row(null, name, value, null, null, null, null)
+    }
+  }
+
+  def mean: Double = {
+    // TODO: fix this for linear + exponential
+    zipped.map {case (k, v) => k * v}.sum.toDouble / n
+  }
+
+  def median: Double = {
+    // TODO: fix this for linear + exponential
+    (getNthValue(n / 2).toDouble + getNthValue((n / 2) + (n % 2)).toDouble) / 2
+  }
+
+  def standardDeviation: Double = {
+    // TODO: fix this for linear + exponential
+    val m = mean
+    scala.math.sqrt(zipped.map {case (k, v) => scala.math.pow(k.toDouble - m, 2) * v}.sum / n)
+  }
+
+  def getNthValue(i: Long): Int = {
+    @tailrec def _getNthValue(i: Long, l: List[(Int, Long)], cumulative: Long): Int = {
+      val (k, v) = l.head
+      if (cumulative + v >= i) k else _getNthValue(i, l.tail, cumulative + v)
+    }
+
+    _getNthValue(i, zipped, 0L)
+  }
+}

--- a/src/main/scala/com/mozilla/telemetry/experiments/analyzers/MetricAnalyzer.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/analyzers/MetricAnalyzer.scala
@@ -1,0 +1,95 @@
+package com.mozilla.telemetry.experiments.analyzers
+
+import com.mozilla.telemetry.utils.MetricDefinition
+import org.apache.spark.sql.expressions.{UserDefinedAggregateFunction, UserDefinedFunction}
+import org.apache.spark.sql.functions.{col, count, explode, lit}
+import org.apache.spark.sql.{Column, DataFrame, Row}
+import com.mozilla.telemetry.scalars._
+import com.mozilla.telemetry.histograms._
+
+import scala.util.{Failure, Success, Try}
+
+
+abstract class MetricAnalyzer(name: String, md: MetricDefinition, df: DataFrame) extends java.io.Serializable {
+  val reducer: UserDefinedAggregateFunction
+  def handleKeys: Column
+  val keyedUDF: UserDefinedFunction
+
+  def analyze(): List[Row] = {
+    println(name)
+    val filtered = formatAndFilter match {
+      case Some(x: DataFrame) => x.persist()
+      case _ => return List()
+    }
+    val rows = aggregate(explodeMetric(filtered)).rdd.collect.toList
+    val summary_stats = runSummaryStatistics(rows)
+    val test_stats = runTestStatistics(filtered, rows)
+    filtered.unpersist()
+    toFinalSchema(rows, summary_stats, test_stats)
+  }
+
+  // We want to keep this output since we'll need this to do the experimental distance metrics
+  // Question: for permutation tests, are the null values significant? e.g. should we be doing the tests on the DF before
+  // filtering out nulls?
+  def formatAndFilter: Option[DataFrame] = {
+    Try(df.select(
+      col("experiment").as("experiment_name"),
+      col("branch").as("experiment_branch"),
+      lit("All").as("subgroup"),
+      col(name).as("metric"))
+      .filter(col("metric").isNotNull)
+    ) match {
+      case Success(x) => Some(x)
+      // expected failure, if the dataset doesn't include this metric (e.g. it's newly added)
+      case Failure(_: org.apache.spark.sql.AnalysisException) => None
+      // Let other exceptions bubble up
+    }
+  }
+  def explodeMetric(filtered: DataFrame): DataFrame = {
+      filtered.select(
+        col("experiment_name"),
+        col("experiment_branch"),
+        col("subgroup"),
+        explode(handleKeys).as("metric"))
+        .filter(col("metric").isNotNull)
+  }
+
+  def aggregate(exploded: DataFrame): DataFrame = {
+    val aggregate = exploded
+      .groupBy(col("experiment_name"), col("experiment_branch"), col("subgroup"))
+      .agg(count("metric").as("n"), reducer(col("metric")).as("histogram_agg"))
+      .withColumn("metric_name", lit(name))
+      .withColumn("metric_type", lit(md.getClass.getSimpleName))
+      .coalesce(1)
+    aggregate.show()
+    aggregate
+  }
+
+  def runSummaryStatistics(rows: List[Row]): List[List[Row]] = {
+    // TODO: fill me in!
+    List()
+  }
+
+  def runTestStatistics(filtered: DataFrame, rows: List[Row]): List[List[Row]] = {
+    // TODO: fill me in!
+    List()
+  }
+
+  def toFinalSchema(rows: List[Row], summary_stats: List[List[Row]], test_stats: List[List[Row]]): List[Row]
+}
+
+object MetricAnalyzer {
+  def getAnalyzer(name: String, md: MetricDefinition, df: DataFrame): MetricAnalyzer = {
+    md match {
+      case t: FlagHistogram => new FlagHistogramAnalyzer(name, t, df)
+      case t: BooleanHistogram => new BooleanHistogramAnalyzer(name, t, df)
+      case t: CountHistogram => new CountHistogramAnalyzer(name, t, df)
+      case t: EnumeratedHistogram => new EnumeratedHistogramAnalyzer(name, t, df)
+      case t: LinearHistogram => new LinearHistogramAnalyzer(name, t, df)
+      case t: ExponentialHistogram => new ExponentialHistogramAnalyzer(name, t, df)
+      case t: UintScalar => new UintScalarAnalyzer(name, t, df)
+      case t: StringScalar => new StringScalarAnalyzer(name, t, df)
+      case t => throw new Exception("Unknown metric definition type " + t.getClass.getSimpleName)
+    }
+  }
+}

--- a/src/main/scala/com/mozilla/telemetry/experiments/analyzers/histograms.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/analyzers/histograms.scala
@@ -1,0 +1,164 @@
+package com.mozilla.telemetry.experiments.analyzers
+
+import com.mozilla.telemetry.histograms._
+import com.mozilla.telemetry.utils.userdefinedfunctions.AggregateHistograms
+import org.apache.spark.sql.{Column, DataFrame, Row}
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.functions._
+
+
+sealed abstract class HistogramAnalyzer(name: String, hd: HistogramDefinition, df: DataFrame) extends MetricAnalyzer(name, hd, df) {
+  val reducer: AggregateHistograms
+  val keys: List[Int]
+
+  val keyedUDF: UserDefinedFunction
+  def nonKeyedUDF: UserDefinedFunction
+  def handleKeys: Column = if (hd.keyed) keyedUDF(col("metric")) else nonKeyedUDF(col("metric"))
+
+  def filterExp(df: DataFrame): DataFrame
+
+  override def runSummaryStatistics(rows: List[Row]): List[List[Row]] = {
+    rows.map { case Row(_, _, _, _, histogram_agg: Seq[Long], _, _) => _runSummaryStatistics(histogram_agg) }
+  }
+
+  def _runSummaryStatistics(histogram_agg: Seq[Long]): List[Row] = {
+    MetricAggregate(histogram_agg, keys).getSchematizedSummaryStats
+  }
+
+  def toFinalSchema(rows: List[Row], summary_stats: List[List[Row]], test_stats: List[List[Row]]): List[Row] = {
+    def aggToMap(values: Seq[Long]): Map[Long, Row] = {
+      val n = values.sum.toDouble
+      // Histograms are output as Key -> Row(prob dist (pdf), count, label)
+      // Labels are none for histograms for now (meant for string scalars) -- may be useful for enum histograms
+      // in the future
+      (keys zip values).map { case (k, v) => k.toLong -> Row(v.toDouble / n, v, null) }.toMap
+    }
+
+    rows.map {
+      case Row(experiment:    String,
+               branch:        String,
+               subgroup:      String,
+               n:             Long,
+               histogram_seq: Seq[Long],
+               metric_name:   String,
+               metric_type:   String) => Row(experiment, branch, subgroup, n, metric_name, metric_type,
+                                             aggToMap(histogram_seq), summary_stats ++ test_stats)
+    }
+  }
+}
+
+object HistogramAnalyzer {
+  def sumFilterExp(df: DataFrame): DataFrame = {
+    val sumArray: Seq[Int] => Int = _.sum
+    val sumArrayUDF = udf(sumArray)
+    df.filter(sumArrayUDF(col("metric")) > 0)
+  }
+
+  def collapseEnumKeys(m: Map[String, Seq[Seq[Int]]]): Seq[Seq[Int]] = {
+    m match {
+      case null => null
+      // h: array of each key's histogram array
+      // _: array of each key's values for a bucket
+      case _ => m.values.transpose.map(h => h.transpose.map(_.sum).toSeq).toSeq
+
+    }
+  }
+
+  def collapseRealKeys(m: Map[String, Seq[Row]]): Seq[Seq[Int]] = {
+    m match {
+      case null => List()
+      case _ => m.values.transpose.map(
+        h => h.map(r => r.getAs[Seq[Int]]("values")).transpose.map(_.sum).toSeq
+      ).toSeq
+    }
+  }
+
+  def prepEnumColumn(m: Seq[Seq[Int]]): Seq[Seq[Int]] = m
+  def prepRealColumn(m: Seq[Row]): Seq[Seq[Int]] = m.map(_.getSeq[Int](0))
+}
+
+class FlagHistogramAnalyzer(name: String, hd: FlagHistogram, df: DataFrame)
+  extends HistogramAnalyzer(name, hd, df) {
+  val reducer = new AggregateHistograms(2)
+  val keys = List(0, 1)
+
+  def filterExp(df: DataFrame): DataFrame = df
+
+  def collapseKeys(m: Map[String, Seq[Boolean]]): Seq[Seq[Int]] = {
+    m match {
+      case null => List()
+      case _ => m.values.transpose.map(
+        h => h.map(x => if (x) Array(0, 1) else Array(1, 0)).transpose.map(_.sum).toSeq
+      ).toSeq
+    }
+  }
+
+  def prepColumn(m: Seq[Boolean]): Seq[Seq[Int]] = m.map(if (_) Seq(0, 1) else Seq(1, 0))
+
+  lazy val keyedUDF: UserDefinedFunction = udf(collapseKeys _)
+  lazy val nonKeyedUDF: UserDefinedFunction = udf(prepColumn _)
+}
+
+class CountHistogramAnalyzer(name: String, hd: CountHistogram, df: DataFrame)
+  extends HistogramAnalyzer(name, hd, df) {
+  val reducer = new AggregateHistograms(1)
+  val keys = List(0)
+
+  def filterExp(df: DataFrame): DataFrame = HistogramAnalyzer.sumFilterExp(df)
+
+  def collapseKeys(m: Map[String, Seq[Int]]): Seq[Seq[Int]] = {
+    m match {
+      case null => List()
+      case _ => m.values.transpose.map(x => Seq(x.sum)).toSeq
+    }
+  }
+
+  def prepColumn(m: Seq[Int]): Seq[Seq[Int]] = m.map(Seq(_))
+
+  lazy val keyedUDF: UserDefinedFunction = udf(collapseKeys _)
+  lazy val nonKeyedUDF: UserDefinedFunction = udf(prepColumn _)
+}
+
+class BooleanHistogramAnalyzer(name: String, hd: BooleanHistogram, df: DataFrame)
+  extends HistogramAnalyzer(name, hd, df) {
+  val reducer = new AggregateHistograms(2)
+  val keys = List(0, 1)
+
+  def filterExp(df: DataFrame): DataFrame = HistogramAnalyzer.sumFilterExp(df)
+
+  lazy val keyedUDF = udf(HistogramAnalyzer.collapseEnumKeys _)
+  lazy val nonKeyedUDF = udf(HistogramAnalyzer.prepEnumColumn _)
+}
+
+class EnumeratedHistogramAnalyzer(name: String, hd: EnumeratedHistogram, df: DataFrame)
+  extends HistogramAnalyzer(name, hd, df) {
+  val reducer = new AggregateHistograms(hd.nValues)
+  val keys: List[Int] = (0 until hd.nValues).toList
+
+  def filterExp(df: DataFrame): DataFrame = HistogramAnalyzer.sumFilterExp(df)
+
+  lazy val keyedUDF = udf(HistogramAnalyzer.collapseEnumKeys _)
+  lazy val nonKeyedUDF = udf(HistogramAnalyzer.prepEnumColumn _)
+}
+
+class LinearHistogramAnalyzer(name: String, hd: LinearHistogram, df: DataFrame)
+  extends HistogramAnalyzer(name, hd, df) {
+  val reducer = new AggregateHistograms(hd.nBuckets)
+  val keys: List[Int] = Histograms.linearBuckets(hd.low, hd.high, hd.nBuckets).toList
+
+  def filterExp(df: DataFrame): DataFrame = HistogramAnalyzer.sumFilterExp(df)
+
+  lazy val keyedUDF = udf(HistogramAnalyzer.collapseRealKeys _)
+  lazy val nonKeyedUDF = udf(HistogramAnalyzer.prepRealColumn _)
+}
+
+class ExponentialHistogramAnalyzer(name: String, hd: ExponentialHistogram, df: DataFrame)
+  extends HistogramAnalyzer(name, hd, df) {
+  val reducer = new AggregateHistograms(hd.nBuckets)
+  val keys: List[Int] = Histograms.exponentialBuckets(hd.low, hd.high, hd.nBuckets).toList
+
+  def filterExp(df: DataFrame): DataFrame = HistogramAnalyzer.sumFilterExp(df)
+
+  lazy val keyedUDF = udf(HistogramAnalyzer.collapseRealKeys _)
+  lazy val nonKeyedUDF = udf(HistogramAnalyzer.prepRealColumn _)
+}

--- a/src/main/scala/com/mozilla/telemetry/experiments/analyzers/scalars.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/analyzers/scalars.scala
@@ -1,0 +1,87 @@
+package com.mozilla.telemetry.experiments.analyzers
+
+import com.mozilla.telemetry.scalars.{ScalarDefinition, StringScalar, UintScalar}
+import com.mozilla.telemetry.utils.userdefinedfunctions.AggregateScalars
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{LongType, StringType}
+import org.apache.spark.sql.{Column, DataFrame, Row}
+
+
+sealed abstract class ScalarAnalyzer(name: String, sd: ScalarDefinition, df: DataFrame) extends MetricAnalyzer(name, sd, df) {
+  def handleKeys: Column = if (sd.keyed) keyedUDF(col("metric")) else col(s"metric.value")
+}
+
+class UintScalarAnalyzer(name: String, sd: UintScalar, df: DataFrame) extends ScalarAnalyzer(name, sd, df) {
+  val reducer = new AggregateScalars[Long](LongType)
+  lazy val keyedUDF: UserDefinedFunction = udf(collapseKeys _)
+
+  def collapseKeys(m: Map[String, Seq[Row]]): Seq[Long] = {
+    m match {
+      case null => List()
+      case _ => m.values.transpose.map(_.map {
+        case Row(v: Long) => v
+        case _ => 0L
+      }).map(_.sum).toSeq
+    }
+  }
+
+  def toFinalSchema(rows: List[Row], summary_stats: List[List[Row]], test_stats: List[List[Row]]): List[Row] = {
+    def aggToMap(values: Map[Long, Long]): Map[Long, Row] = {
+      val sum = values.toSeq.map(_._2).sum.toDouble
+      // Histograms are output as Key -> Row(prob dist (pdf), count, label)
+      values.map {case (k: Long, v: Long) => k -> Row(v.toDouble / sum, v, null)}
+    }
+
+    rows.map {
+      case Row(experiment:    String,
+               branch:        String,
+               subgroup:      String,
+               n:             Long,
+               histogram_seq: Map[Long, Long],
+               metric_name:   String,
+               metric_type:   String) => Row(experiment, branch, subgroup, n, metric_name, metric_type,
+                                             aggToMap(histogram_seq), summary_stats ++ test_stats)
+    }
+  }
+}
+
+class StringScalarAnalyzer(name: String, sd: StringScalar, df: DataFrame) extends ScalarAnalyzer(name, sd, df) {
+  val reducer = new AggregateScalars[String](StringType)
+
+  def collapseKeys(m: Map[String, Seq[Row]]): Seq[String] = {
+    m match {
+      case null => List()
+      case _ => m.values.transpose.flatMap(_.map {
+        case Row(v: String) => v
+        case _ => null
+      }).toSeq
+    }
+  }
+
+  lazy val keyedUDF: UserDefinedFunction = udf(collapseKeys _)
+
+  def toFinalSchema(rows: List[Row], summary_stats: List[List[Row]], test_stats: List[List[Row]]): List[Row] = {
+    def aggToMap(values: Map[String, Long]): Map[Long, Row] = {
+      val sum = values.toSeq.map(_._2).sum.toDouble
+      // Sort the string keys by number of occurrences and assign each an index to fit the schema
+      values.toSeq.sortWith(_._2 > _._2).zipWithIndex.map {
+        // Histograms are output as Key -> Row(prob dist (pdf), count, label)
+        case ((k: String, v: Long), i: Int) => i.toLong -> Row(v.toDouble / sum, v, k)
+      }.toMap
+    }
+
+    rows.map {
+      case Row(experiment:    String,
+               branch:        String,
+               subgroup:      String,
+               n:             Long,
+               histogram_seq: Map[String, Long],
+               metric_name:   String,
+               metric_type:   String) => Row(experiment, branch, subgroup, n, metric_name, metric_type,
+                                             aggToMap(histogram_seq), summary_stats ++ test_stats)
+    }
+  }
+}
+
+// TODO: Boolean Scalars (we don't have any yet)

--- a/src/main/scala/com/mozilla/telemetry/histograms/Histogram.scala
+++ b/src/main/scala/com/mozilla/telemetry/histograms/Histogram.scala
@@ -1,13 +1,15 @@
 package com.mozilla.telemetry.histograms
 
+import com.mozilla.telemetry.utils.MetricDefinition
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
+
 import scala.collection.mutable.{Map => MMap}
 import scala.io.Source
 
 case class RawHistogram(values: Map[String, Int], sum: Long)
 
-sealed abstract class HistogramDefinition
+sealed abstract class HistogramDefinition extends MetricDefinition
 case class FlagHistogram(keyed: Boolean) extends HistogramDefinition
 case class BooleanHistogram(keyed: Boolean) extends HistogramDefinition
 case class CountHistogram(keyed: Boolean) extends HistogramDefinition

--- a/src/main/scala/com/mozilla/telemetry/scalars/Scalars.scala
+++ b/src/main/scala/com/mozilla/telemetry/scalars/Scalars.scala
@@ -2,11 +2,13 @@ package com.mozilla.telemetry.scalars
 
 import java.util
 
+import com.mozilla.telemetry.utils.MetricDefinition
 import org.yaml.snakeyaml.Yaml
+
 import collection.JavaConversions._
 import scala.io.Source
 
-sealed abstract class ScalarDefinition
+sealed abstract class ScalarDefinition extends MetricDefinition
 case class UintScalar(keyed: Boolean) extends ScalarDefinition
 case class BooleanScalar(keyed: Boolean) extends ScalarDefinition
 case class StringScalar(keyed: Boolean) extends ScalarDefinition

--- a/src/main/scala/com/mozilla/telemetry/utils/MetricDefinition.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/MetricDefinition.scala
@@ -1,0 +1,5 @@
+package com.mozilla.telemetry.utils
+
+trait MetricDefinition {
+  val keyed: Boolean
+}

--- a/src/main/scala/com/mozilla/telemetry/utils/UserDefinedFunctions.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/UserDefinedFunctions.scala
@@ -1,0 +1,77 @@
+package com.mozilla.telemetry.utils.userdefinedfunctions
+
+import org.apache.spark.sql.expressions.{MutableAggregationBuffer, UserDefinedAggregateFunction}
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.Row
+
+class AggregateScalars[T](U: DataType) extends UserDefinedAggregateFunction {
+  def add(m: Map[T, Long], k: T): Map[T, Long] = {
+    m + (k -> (m.getOrElse(k, 0L) + 1L))
+  }
+
+  def combine(l: Map[T, Long], r: Map[T, Long]): Map[T, Long] = {
+    l ++ r.map {case (k, v) => k -> (l.getOrElse(k, 0L) + v)}
+  }
+
+  override def inputSchema: StructType =
+    StructType(StructField("value", U) :: Nil)
+
+  override def bufferSchema: StructType = StructType(
+    StructField("aggregate", MapType(U, LongType)) :: Nil
+  )
+
+  override def dataType: DataType = MapType(U, LongType)
+
+  override def deterministic: Boolean = true
+
+  override def initialize(buffer: MutableAggregationBuffer): Unit = {
+    buffer(0) = Map[T, Long]()
+  }
+
+  override def update(buffer: MutableAggregationBuffer, input: Row): Unit = {
+    val m = buffer.getAs[Map[T, Long]](0)
+    val k = input.getAs[T](0)
+    buffer(0) = add(m, k)
+  }
+
+  override def merge(buffer1: MutableAggregationBuffer, buffer2: Row): Unit = {
+    buffer1(0) = combine(buffer1.getAs[Map[T, Long]](0), buffer2.getAs[Map[T, Long]](0))
+  }
+
+  override def evaluate(buffer: Row): Any = {
+    buffer.getAs[Map[T, Long]](0)
+  }
+}
+
+class AggregateHistograms(histogramLength: Int) extends UserDefinedAggregateFunction {
+  private def aggregateArrays(left: Seq[Long], right: Seq[Long]): Array[Long] = {
+    left.zip(right).map(x => x._1 + x._2).toArray
+  }
+
+  override def inputSchema: StructType =
+    StructType(StructField("value", ArrayType(IntegerType)) :: Nil)
+
+  override def bufferSchema: StructType = StructType(
+    StructField("aggregate", ArrayType(LongType)) :: Nil
+  )
+
+  override def dataType: DataType = ArrayType(LongType)
+
+  override def deterministic: Boolean = true
+
+  override def initialize(buffer: MutableAggregationBuffer): Unit = {
+    buffer(0) = Array.fill[Long](histogramLength)(0L)
+  }
+
+  override def update(buffer: MutableAggregationBuffer, input: Row): Unit = {
+    buffer(0) = aggregateArrays(buffer.getAs[Seq[Long]](0), input.getAs[Seq[Int]](0).map(_.longValue))
+  }
+
+  override def merge(buffer1: MutableAggregationBuffer, buffer2: Row): Unit = {
+    buffer1(0) = aggregateArrays(buffer1.getAs[Seq[Long]](0), buffer2.getAs[Seq[Long]](0))
+  }
+
+  override def evaluate(buffer: Row): Any = {
+    buffer.getAs[Array[Long]](0)
+  }
+}

--- a/src/main/scala/com/mozilla/telemetry/views/ExperimentAnalysisView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/ExperimentAnalysisView.scala
@@ -1,0 +1,104 @@
+package com.mozilla.telemetry.views
+
+import com.mozilla.telemetry.experiments.analyzers.MetricAnalyzer
+import com.mozilla.telemetry.histograms.{HistogramDefinition, Histograms}
+import com.mozilla.telemetry.scalars.{ScalarDefinition, Scalars}
+import org.apache.spark.sql.SparkSession
+import org.rogach.scallop.ScallopConf
+import org.apache.spark.sql.types._
+
+object ExperimentAnalysisView {
+  def schemaVersion: String = "v1"
+  def jobName: String = "experiment_analysis"
+
+  // Configuration for command line arguments
+  private class Conf(args: Array[String]) extends ScallopConf(args) {
+    // TODO: change to s3 bucket/keys
+    val inputLocation = opt[String]("input", descr = "Source for parquet data", required = true)
+    val outputLocation = opt[String]("output", descr = "Destination for parquet data", required = true)
+    val histo = opt[String]("histogram", descr = "Run job on just this histogram", required = false)
+    val scalar = opt[String]("scalar", descr = "Run job on just this scalar", required = false)
+    verify()
+  }
+
+  def main(args: Array[String]) {
+    // Spark/job setup stuff
+    val conf = new Conf(args)
+
+    val spark = SparkSession
+      .builder()
+      .master("local[*]")
+      .appName(jobName)
+      .getOrCreate()
+
+    val hadoopConf = spark.sparkContext.hadoopConfiguration
+    hadoopConf.set("fs.s3n.impl", "org.apache.hadoop.fs.s3native.NativeS3FileSystem")
+
+    // DEBUG -- remove before committing
+    spark.sparkContext.setLogLevel("WARN")
+    val parquetSize = 512 * 1024 * 1024
+    hadoopConf.setInt("parquet.block.size", parquetSize)
+    hadoopConf.setInt("dfs.blocksize", parquetSize)
+    hadoopConf.set("parquet.enable.summary-metadata", "false")
+
+    // Grab messages
+    val rows = spark.read.parquet(conf.inputLocation())
+
+    val histogramList = conf.histo.get match {
+      case Some(h) => Map(h -> Histograms.definitions()(h.toUpperCase))
+      case _ => Histograms.definitions()
+    }
+    val scalarList = conf.scalar.get match {
+      case Some(s) => Map(s -> Histograms.definitions()(s.toUpperCase))
+      case _ => Scalars.definitions()
+    }
+
+    val output = scalarList.flatMap {
+      case(name: String, sd: ScalarDefinition) =>
+        MetricAnalyzer.getAnalyzer(
+          Scalars.getParquetFriendlyScalarName(name.toLowerCase, "parent"), sd, rows
+        ).analyze()
+    } ++
+    histogramList.flatMap {
+      case(name: String, hd: HistogramDefinition) =>
+        MetricAnalyzer.getAnalyzer(
+          name.toLowerCase, hd, rows
+        ).analyze()
+      case _ => List()
+    }
+
+    output.foreach(println)
+
+    val o = spark.sparkContext.parallelize(output.toList)
+    val df = spark.sqlContext.createDataFrame(o, buildOutputSchema)
+    df.repartition(1).write.parquet(conf.outputLocation())
+    spark.stop()
+  }
+
+  def buildStatisticSchema = StructType(List(
+    StructField("comparison_branch", StringType, nullable = true),
+    StructField("name", StringType, nullable = false),
+    StructField("value", DoubleType, nullable = false),
+    StructField("confidence_low", DoubleType, nullable = true),
+    StructField("confidence_high", DoubleType, nullable = true),
+    StructField("confidence_level", DoubleType, nullable = true),
+    StructField("p_value", DoubleType, nullable = true)
+  ))
+
+  def buildHistogramPointSchema = StructType(List(
+    StructField("pdf", DoubleType),
+    StructField("count", LongType),
+    StructField("label", StringType, nullable = true)
+  ))
+
+  def buildOutputSchema = StructType(List(
+    StructField("experiment_name", StringType, nullable = false),
+    StructField("experiment_branch", StringType, nullable = false),
+    StructField("subgroup", StringType, nullable = true),
+    StructField("n", LongType, nullable = false),
+    StructField("metric_name", StringType, nullable = false),
+    StructField("metric_type", StringType, nullable = false),
+    StructField("histogram", MapType(LongType, buildHistogramPointSchema), nullable = false),
+    StructField("statistics", ArrayType(buildStatisticSchema, containsNull = false), nullable = true)
+  ))
+}

--- a/src/test/scala/com/mozilla/telemetry/ExperimentAnalysisViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/ExperimentAnalysisViewTest.scala
@@ -1,0 +1,132 @@
+package com.mozilla.telemetry
+
+import com.mozilla.telemetry.histograms._
+import com.mozilla.telemetry.views.ExperimentAnalysisView
+import com.mozilla.telemetry.experiments.analyzers.MetricAnalyzer
+import org.apache.spark.sql.{Row, SparkSession}
+import org.scalatest.{FlatSpec, Matchers}
+
+case class TestHistogram(values: Seq[Int])
+case class TestLongitudinal(experiment: String,
+                            branch: String,
+                            flag_histogram: Seq[Boolean],
+                            keyed_flag_histogram: Map[String, Seq[Boolean]],
+                            boolean_histogram: Seq[Seq[Int]],
+                            keyed_boolean_histogram: Map[String, Seq[Seq[Int]]],
+                            count_histogram: Seq[Int],
+                            keyed_count_histogram: Map[String, Seq[Int]],
+                            enum_histogram: Seq[Seq[Int]],
+                            keyed_enum_histogram: Map[String, Seq[Seq[Int]]],
+                            linear_histogram: Seq[TestHistogram],
+                            keyed_linear_histogram: Map[String, Seq[TestHistogram]],
+                            exponential_histogram: Seq[TestHistogram],
+                            keyed_exponential_histogram: Map[String, Seq[TestHistogram]],
+                            empty_histogram: Seq[Boolean]
+                           )
+
+
+class ExperimentAnalysisViewTest extends FlatSpec with Matchers{
+  "Histograms" can "be aggregated" in {
+    val spark = SparkSession
+      .builder()
+      .master("local[1]")
+      .appName("AnalysisTest")
+      .getOrCreate()
+    spark.sparkContext.setLogLevel("WARN")
+
+    import spark.implicits._
+
+    try {
+      val histogramList = Map(
+        "flag_histogram" -> FlagHistogram(false),
+        "keyed_flag_histogram" -> FlagHistogram(true),
+        "boolean_histogram" -> BooleanHistogram(false),
+        "keyed_boolean_histogram" -> BooleanHistogram(true),
+        "count_histogram" -> CountHistogram(false),
+        "keyed_count_histogram" -> CountHistogram(true),
+        "enum_histogram" -> EnumeratedHistogram(false, 4),
+        "keyed_enum_histogram" -> EnumeratedHistogram(true, 4),
+        "linear_histogram" -> LinearHistogram(false, 1, 30, 3),
+        "keyed_linear_histogram" -> LinearHistogram(true, 1, 30, 3),
+        "exponential_histogram" -> ExponentialHistogram(false, 1, 100, 3),
+        "keyed_exponential_histogram" -> ExponentialHistogram(true, 1, 100, 3),
+        "empty_histogram" -> FlagHistogram(false)
+      )
+
+      val df = Seq(
+        TestLongitudinal(
+          "experiment1",
+          "control",
+          Seq(true, false),
+          Map("key1" -> Seq(false, true), "key2" -> Seq(true, true)),
+          Seq(Seq(2, 3), Seq(0, 0)),
+          Map("key1" -> Seq(Seq(1, 1), Seq(2, 1)), "key2" -> Seq(Seq(0, 1), Seq(4, 5))),
+          Seq(5, 6),
+          Map("key1" -> Seq(2, 3), "key2" -> Seq(9, 8)),
+          Seq(Seq(1, 2, 3, 4), Seq(2, 3, 4, 5)),
+          Map("key1" -> Seq(Seq(0, 1, 0, 1), Seq(2, 1, 2, 1)), "key2" -> Seq(Seq(1, 0, 1, 0), Seq(1, 2, 1, 2))),
+          Seq(TestHistogram(Seq(1, 2, 3)), TestHistogram(Seq(3, 2, 1))),
+          Map("key1" -> Seq(TestHistogram(Seq(2, 3, 4)), TestHistogram(Seq(4, 3, 2)))),
+          Seq(TestHistogram(Seq(1, 2, 3)), TestHistogram(Seq(3, 2, 1))),
+          Map("key1" -> Seq(TestHistogram(Seq(2, 3, 4)), TestHistogram(Seq(4, 3, 2)))),
+          null
+        ),
+        TestLongitudinal(
+          "experiment1",
+          "branch1",
+          Seq(true, false),
+          Map("key1" -> Seq(false, true), "key2" -> Seq(true, true)),
+          Seq(Seq(2, 3), Seq(0, 0)),
+          Map("key1" -> Seq(Seq(1, 1), Seq(2, 1)), "key2" -> Seq(Seq(0, 1), Seq(4, 5))),
+          Seq(5, 6),
+          Map("key1" -> Seq(2, 3), "key2" -> Seq(9, 8)),
+          Seq(Seq(1, 2, 3, 4), Seq(2, 3, 4, 5)),
+          Map("key1" -> Seq(Seq(0, 1, 0, 1), Seq(2, 1, 2, 1)), "key2" -> Seq(Seq(1, 0, 1, 0), Seq(1, 2, 1, 2))),
+          Seq(TestHistogram(Seq(1, 2, 3)), TestHistogram(Seq(3, 2, 1))),
+          Map("key1" -> Seq(TestHistogram(Seq(2, 3, 4)), TestHistogram(Seq(4, 3, 2)))),
+          Seq(TestHistogram(Seq(1, 2, 3)), TestHistogram(Seq(3, 2, 1))),
+          Map("key1" -> Seq(TestHistogram(Seq(2, 3, 4)), TestHistogram(Seq(4, 3, 2)))),
+          null
+        ),
+        TestLongitudinal(
+          "experiment1",
+          "control",
+          Seq(true, false),
+          Map("key1" -> Seq(false, true), "key3" -> Seq(true, true)),
+          Seq(Seq(2, 3), Seq(0, 0)),
+          null,
+          Seq(5, 6),
+          Map("key1" -> Seq(2, 3)),
+          null,
+          Map("key1" -> Seq(Seq(0, 1, 0, 1), Seq(2, 1, 2, 1)), "key3" -> Seq(Seq(1, 0, 1, 0), Seq(1, 2, 1, 2))),
+          Seq(TestHistogram(Seq(1, 2, 3)), TestHistogram(Seq(3, 2, 1))),
+          Map("key1" -> Seq(TestHistogram(Seq(2, 3, 4)), TestHistogram(Seq(4, 3, 2)))),
+          Seq(TestHistogram(Seq(1, 2, 3)), TestHistogram(Seq(3, 2, 1))),
+          Map("key1" -> Seq(TestHistogram(Seq(2, 3, 4)), TestHistogram(Seq(4, 3, 2)))),
+          null
+        ),
+        TestLongitudinal(
+          "experiment1",
+          "control",
+          null, null, null, null, null, null, null, null, null, null, null, null, null
+        )
+      ).toDS().toDF()
+
+      df.count should be(4)
+      val results = histogramList.flatMap {
+        case(name: String, hd: HistogramDefinition) =>
+          MetricAnalyzer.getAnalyzer(
+            name.toLowerCase, hd, df
+          ).analyze
+      }.toList
+
+      results.length should be(24)
+      results.foreach(println)
+      noException should be thrownBy spark.sqlContext.createDataFrame(
+        spark.sparkContext.parallelize(results), ExperimentAnalysisView.buildOutputSchema
+      ).count()
+    } finally {
+      spark.stop
+    }
+  }
+}


### PR DESCRIPTION
This is the first PR to get reviews on the unfinished experiment analysis job. Currently, the job reads in a longitudinal-shaped parquet file (with two additional two columns: `experiment_name` and `experiment_branch`), aggregates histograms and scalars, runs a few simple summary statistics on the aggregate histograms and outputs a parquet file with a row for each grouping of: experiment branch, subpopulation (not yet implemented), and metric.

I'm specifically hoping to get suggestions for improvement on:
Class organization: this is a bit of a mess -- partly because I hacked up a first version to fake some output for the experiment-viewer team to work with and built up from there. I feel like I've been staring at this too long to be able to have a good perspective on this at this point. This includes structure as well as things like naming (I don't particularly like <MetricType>Analyzer class names, for instance and suggestions would be great.)
Performance: any obvious perf improvements? This currently runs reasonably fast, although aggregation time is significant, and the exploded dataset takes up a surprising amount of memory right now.
Histogram gotchas: I haven't worked much with the longitudinal dataset so I may be missing subtleties in working with histograms.

Suggested review order:
- com.mozilla.telemetry.views.ExperimentAnalysisView: This is the entrypoint to the job. The view loads the longitudinal-shaped data, loads the current list of histograms and scalars, and runs the aggregation & analysis on each metric, applies the output schema to the result and saves it to disk

- com.mozilla.telemetry.experiments.analyzers.MetricAnalyzer: This is the shared base for the histogram & scalar analyzers. `analyze()` should probably be the only public method (I'll change this for the next PR). This class encapsulates the common steps for aggregating and analyzing histogram and scalars. The companion object provides an interface for passing in a metric definition and getting the corresponding child analyzer back.

- com.mozilla.telemetry.experiments.analyzers.histograms: This is the specialized handling for the various types of histograms. Each histogram type is normalized into an Array of `Long` to standardize aggregation and summary statistics. There's a bit of duplicated code in the classes which I'd had abstracted out in a complicated trait-based inheritance tree but I'm much happier now to trade off the duplication for simplicity (but I'm happy to take suggestions on improving this.)

- com.mozilla.telemetry.experiments.analyzers.scalars: The scalar counterpart to the above. Scalars are *not* normalized into a common format before aggregation since we have things like string scalars. Note BooleanScalars are not yet implemented, in large part because we don't have any boolean scalars out in the wild yet so I don't have real data to work with while writing the code (but I'll develop this with tests before this job is done.)

- com.mozilla.telemetry.utils.userdefinedfunctions: These are the User Defined sparksql functions that aggregate histograms and scalars, and implement the base UserDefinedAggregateFunction interface. I note that Frank merged in a com.mozilla.telemetry.utils.udfs package and I should either move these there or under com.mozilla.telemetry.experiments.udfs. I'm a bit concerned about putting them until utils.udfs since our histograms need to be normalized into an Array of `Long` before running them through the aggregator. I suspect a good future refactoring that'd make this generally useful for folks would be to split out histogram/scalar aggregation so that you can feed in a raw longitudinal column and it'd do all the normalization and such under the hood.

- com.mozilla.telemetry.experiments.analyzers.MetricAggregate: This class takes an aggregated metric and spits out some summary statistics. I need to write unit tests for this class so I can check my math. Also, for Linear/exponential histograms, this should probably be taking the midpoint between buckets as the "value". I only have this working for histograms at the moment, and this doesn't make sense for all histograms (e.g. enum histograms) so this class might need a bit of refactoring.

-  com.mozilla.telemetry.histograms.HistogramDefinition & com.mozilla.telemetry.scalars.ScalarDefinition & com.mozilla.telemetry.util.MetricDefinition: Defines a base trait for HistogramDefinition and ScalarDefinition that exposes the "keyed" value, which greatly simplifies the analysis code. Thinking about this some more now, we should probably move the Histogram.scala, Scalars.scala and MetricDefinition.scala files under a com.mozilla.telemetry.metrics package and normalize the pluralization for the filenames (possibly as a separate PR to be merged in earlier?)

- com.mozilla.telemetry.ExperimentAnalysisViewTest: Pretty barebones for the moment, but exercises a keyed and not-keyed version of each histogram type. This should really be renamed as a test for HistogramAnalyzer, and I'll add separate ones for ScalarAnalyzer, MetricAggregate, and the UDFs with smaller unit tests.

The big outstanding task for this job is to write the distance function and the permutation test. I've added some scaffolding for where it's going to go but I'm sure I'll need to make changes as I implement it here. Other large outstanding tasks for this job are:
- Grouping by subpopulations (currently, these are just a list of OSes.)
- Supporting opt-in metrics (made easier by the recent changes to histogram definitions.)
- Implementing any other statistic functions that might be useful

Sorry for dumping this big of a PR -- future ones will be smaller and more frequent.