### PR TITLE
Allow adding experiment as a longitudinal column

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/Longitudinal.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/Longitudinal.scala
@@ -111,6 +111,7 @@ object LongitudinalView {
     val channels = opt[String]("channels", descr = "Comma separated string, which channels to include. Defaults to all channels.", required = false)
     val samples = opt[String]("samples", descr = "Comma separated string, which samples to include. Defaults to 42.", required = false)
     val telemetrySource = opt[String]("source", descr = "Source for Dataset.from_source. Defaults to telemetry-sample.", required = false)
+    val experimentId = opt[String]("experiment", descr = "Experiment name to add to as a field", required = false)
     verify()
   }
 
@@ -136,6 +137,8 @@ object LongitudinalView {
         case _ => "telemetry-sample"
     }
 
+    val experimentId = opts.experimentId.get
+
     val sparkConf = new SparkConf().setAppName("Longitudinal")
     sparkConf.setMaster(sparkConf.get("spark.master", "local[*]"))
     implicit val sc = new SparkContext(sparkConf)
@@ -153,6 +156,8 @@ object LongitudinalView {
         case sample if samples.contains(sample) => true
       }.where("appUpdateChannel") {
         case channel if channels.map(_.contains(channel)).getOrElse(true) => true
+      }.where("experimentId") {
+        case e => experimentId.isEmpty || e == experimentId.get
       }
 
     run(opts: Opts, messages)
@@ -169,6 +174,8 @@ object LongitudinalView {
         case Some(v) => v.toBoolean // fail loudly on invalid string
         case _ => false
     }
+
+    val experimentId = opts.experimentId.get
 
     require(S3Store.isPrefixEmpty(outputBucket, prefix), s"s3://${outputBucket}/${prefix} already exists!")
 
@@ -211,11 +218,11 @@ object LongitudinalView {
     val partitionCounts = clientMessages
       .mapPartitions{ case it =>
         val clientIterator = new ClientIterator(it)
-        val schema = buildSchema(histogramDefinitions, scalarDefinitions)
+        val schema = buildSchema(histogramDefinitions, scalarDefinitions, experimentId)
 
         val allRecords = for {
           client <- clientIterator
-          record = buildRecord(client, schema, histogramDefinitions, scalarDefinitions)
+          record = buildRecord(client, schema, histogramDefinitions, scalarDefinitions, experimentId)
         } yield record
 
         var ignoredCount = 0
@@ -248,7 +255,9 @@ object LongitudinalView {
     S3Store.deleteKey(outputBucket,  s"${prefix}/${lockfileName}")
   }
 
-  private def buildSchema(histogramDefinitions: Map[String, HistogramDefinition], scalarDefinitions: Map[String, ScalarDefinition]): Schema = {
+  private def buildSchema(histogramDefinitions: Map[String, HistogramDefinition],
+                          scalarDefinitions: Map[String, ScalarDefinition],
+                          experimentId: Option[String] = None): Schema = {
     // The $PROJECT_ROOT/scripts/generate-ping-schema.py script can be used to
     // generate these SchemaBuilder definitions, and the output of that script is
     // combined with data from http://gecko.readthedocs.org/en/latest/toolkit/components/telemetry/telemetry
@@ -580,6 +589,12 @@ object LongitudinalView {
         case _ =>
           throw new Exception("Unrecognized scalar type")
       }
+    }
+
+    experimentId match {
+      case Some(e) => builder.name("experiment_id").`type`().optional().stringType()
+                             .name("experiment_branch").`type`().optional().stringType()
+      case _ => Unit
     }
 
     builder.endRecord()
@@ -951,7 +966,25 @@ object LongitudinalView {
     }
   }
 
-  private def buildRecord(history: Iterable[Map[String, Any]], schema: Schema, histogramDefinitions: Map[String, HistogramDefinition], scalarDefinitions: Map[String, ScalarDefinition]): Option[GenericRecord] = {
+  private def experiment2Avro(payload: Map[String, Any], root: GenericRecordBuilder, experimentId: Option[String]): Unit = {
+    experimentId match {
+      case Some(e) => {
+        val branch = parse(payload.getOrElse(s"environment.experiments", return).asInstanceOf[String]) \ e \ "branch" match {
+          case JString(value) => value
+          case _ => return
+        }
+        root.set("experiment_id", e)
+            .set("experiment_branch", branch)
+      }
+      case _ => Unit
+    }
+  }
+
+  private def buildRecord(history: Iterable[Map[String, Any]],
+                          schema: Schema,
+                          histogramDefinitions: Map[String, HistogramDefinition],
+                          scalarDefinitions: Map[String, ScalarDefinition],
+                          experimentId: Option[String] = None): Option[GenericRecord] = {
     // De-dupe records
     val sorted = history.foldLeft((List[Map[String, Any]](), Set[String]()))(
       { case ((submissions, seen), current) =>
@@ -1013,6 +1046,7 @@ object LongitudinalView {
       keyedScalars2Avro(sorted, root, scalarDefinitions)
       sessionStartDates2Avro(sorted, root, schema)
       profileDates2Avro(sorted, root, schema)
+      experiment2Avro(sorted.head, root, experimentId)
     } catch {
       case e : Throwable =>
         // Ignore buggy clients

--- a/src/test/scala/com/mozilla/telemetry/LongitudinalTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/LongitudinalTest.scala
@@ -200,6 +200,11 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
         ("profileSubsessionCounter" -> (1000 - idx)) ~
         ("reason" -> "shutdown")
 
+      val experiments = Map(
+        "experiment1" -> Map("branch" -> "branch1"),
+        "experiment2" -> Map("branch" -> "control")
+      )
+
       Map("clientId" -> "26c9d181-b95b-4af5-bb35-84ebf0da795d",
         "os" -> "Windows_NT",
         "normalizedChannel" -> "aurora",
@@ -221,7 +226,8 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
         "environment.profile" -> compact(render(profile)),
         "environment.settings" -> compact(render(settings)),
         "environment.system" -> compact(render(system)),
-        "environment.addons" -> compact(render(addons)))
+        "environment.addons" -> compact(render(addons)),
+        "environment.experiments" -> compact(render(experiments)))
     }
 
     new {
@@ -254,8 +260,8 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
       private val optoutHistogramDefs = histograms.definitions(includeOptin = false)
       private val optoutScalarDefs = scalars.definitions(includeOptin = false)
 
-      private val optoutSchema = LongitudinalView invokePrivate buildSchema(optoutHistogramDefs, optoutScalarDefs)
-      private val optoutRecord = (LongitudinalView  invokePrivate buildRecord(payloads ++ dupes, optoutSchema, optoutHistogramDefs, optoutScalarDefs)).get
+      private val optoutSchema = LongitudinalView invokePrivate buildSchema(optoutHistogramDefs, optoutScalarDefs, None)
+      private val optoutRecord = (LongitudinalView  invokePrivate buildRecord(payloads ++ dupes, optoutSchema, optoutHistogramDefs, optoutScalarDefs, None)).get
       private val optoutPath = ParquetFile.serialize(List(optoutRecord).toIterator, optoutSchema)
       private val optoutFilename = optoutPath.toString.replace("file:", "")
 
@@ -266,13 +272,21 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
       private val optinHistogramDefs = histograms.definitions(includeOptin = true)
       private val optinScalarDefs = scalars.definitions(includeOptin = true)
 
-      private val optinSchema = LongitudinalView invokePrivate buildSchema(optinHistogramDefs, optinScalarDefs)
-      private val optinRecord = (LongitudinalView  invokePrivate buildRecord(payloads ++ dupes, optinSchema, optinHistogramDefs, optinScalarDefs)).get
+      private val optinSchema = LongitudinalView invokePrivate buildSchema(optinHistogramDefs, optinScalarDefs, None)
+      private val optinRecord = (LongitudinalView  invokePrivate buildRecord(payloads ++ dupes, optinSchema, optinHistogramDefs, optinScalarDefs, None)).get
       private val optinPath = ParquetFile.serialize(List(optinRecord).toIterator, optinSchema)
       private val optinFilename = optinPath.toString.replace("file:", "")
 
       val optinRows = sqlContext.read.load(optinFilename).collect()
       val optinRow =  optinRows(0)
+
+      private val experimentsSchema = LongitudinalView invokePrivate buildSchema(optoutHistogramDefs, optoutScalarDefs, Some("experiment1"))
+      private val experimentsRecord = (LongitudinalView  invokePrivate buildRecord(payloads ++ dupes, experimentsSchema, optoutHistogramDefs, optoutScalarDefs, Some("experiment1"))).get
+      private val experimentsPath = ParquetFile.serialize(List(experimentsRecord).toIterator, experimentsSchema)
+      private val experimentsFilename = experimentsPath.toString.replace("file:", "")
+
+      val experimentsRows = sqlContext.read.load(experimentsFilename).collect()
+      val experimentsRow =  experimentsRows(0)
 
       sc.stop()
     }
@@ -726,5 +740,19 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
         case None => assert(index == 0)
       }
     }
+  }
+
+  "No experiments column" must "be present in normal longitudinal dataset" in {
+    intercept[IllegalArgumentException] {
+      fixture.optoutRow.getAs[String]("experiment_id")
+    }
+    intercept[IllegalArgumentException] {
+      fixture.optoutRow.getAs[String]("experiment_branch")
+    }
+  }
+
+  "Experiments column" must "be added to experiments dataset" in {
+    assert(fixture.experimentsRow.getAs[String]("experiment_id") == "experiment1")
+    assert(fixture.experimentsRow.getAs[String]("experiment_branch") == "branch1")
   }
 }


### PR DESCRIPTION
Adds another CLI option to pass in an experiment_id, which should allow us to create a dataset of this shape to feed into the analysis job.