### PR TITLE
Automatically add hists to main_summary

### DIFF
--- a/src/test/resources/ShortHistograms.json
+++ b/src/test/resources/ShortHistograms.json
@@ -97,5 +97,34 @@
     "keyed": true,
     "releaseChannelCollection": "opt-out",
     "description": "Record the search counts for search engines"
+  },
+  "MOCK_EXPONENTIAL_OPTOUT": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "exponential",
+    "high": "100",
+    "n_buckets": 10,
+    "releaseChannelCollection": "opt-out",
+    "description": "a testing histogram; not meant to be touched"
+  },
+  "MOCK_KEYED_LINEAR": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "keyed": true,
+    "kind": "linear",
+    "high": "10",
+    "n_buckets": 10,
+    "releaseChannelCollection": "opt-out",
+    "description": "a testing histogram; not meant to be touched"
+  },
+  "MOCK_KEYED_EXPONENTIAL": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "keyed": true,
+    "kind": "exponential",
+    "high": "100",
+    "n_buckets": 10,
+    "releaseChannelCollection": "opt-out",
+    "description": "a testing histogram; not meant to be touched"
   }
 }


### PR DESCRIPTION
Currently this only includes Linear and Exponential opt-out hists.
The format is essentially exactly what we recieve from the client,
see the case class for the schema.