### PR TITLE
Move Histograms and Scalars under metrics package with common MetricD…

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/metrics/Histogram.scala
+++ b/src/main/scala/com/mozilla/telemetry/metrics/Histogram.scala
@@ -1,4 +1,4 @@
-package com.mozilla.telemetry.histograms
+package com.mozilla.telemetry.metrics
 
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
@@ -7,7 +7,7 @@ import scala.io.Source
 
 case class RawHistogram(values: Map[String, Int], sum: Long)
 
-sealed abstract class HistogramDefinition
+sealed abstract class HistogramDefinition extends MetricDefinition
 case class FlagHistogram(keyed: Boolean) extends HistogramDefinition
 case class BooleanHistogram(keyed: Boolean) extends HistogramDefinition
 case class CountHistogram(keyed: Boolean) extends HistogramDefinition

--- a/src/main/scala/com/mozilla/telemetry/metrics/MetricDefinition.scala
+++ b/src/main/scala/com/mozilla/telemetry/metrics/MetricDefinition.scala
@@ -1,0 +1,5 @@
+package com.mozilla.telemetry.metrics
+
+trait MetricDefinition {
+  val keyed: Boolean
+}

--- a/src/main/scala/com/mozilla/telemetry/metrics/Scalars.scala
+++ b/src/main/scala/com/mozilla/telemetry/metrics/Scalars.scala
@@ -1,4 +1,4 @@
-package com.mozilla.telemetry.scalars
+package com.mozilla.telemetry.metrics
 
 import java.util
 
@@ -6,7 +6,7 @@ import org.yaml.snakeyaml.Yaml
 import collection.JavaConversions._
 import scala.io.Source
 
-sealed abstract class ScalarDefinition
+sealed abstract class ScalarDefinition extends MetricDefinition
 case class UintScalar(keyed: Boolean) extends ScalarDefinition
 case class BooleanScalar(keyed: Boolean) extends ScalarDefinition
 case class StringScalar(keyed: Boolean) extends ScalarDefinition

--- a/src/main/scala/com/mozilla/telemetry/utils/MainPing.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/MainPing.scala
@@ -1,6 +1,6 @@
 package com.mozilla.telemetry.utils
 
-import com.mozilla.telemetry.scalars._
+import com.mozilla.telemetry.metrics._
 import org.apache.spark.sql.Row
 import org.json4s.JsonAST._
 

--- a/src/main/scala/com/mozilla/telemetry/views/Longitudinal.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/Longitudinal.scala
@@ -15,8 +15,7 @@ import scala.reflect.ClassTag
 import com.mozilla.telemetry.parquet.ParquetFile
 import com.mozilla.telemetry.avro
 import com.mozilla.telemetry.heka.{Dataset, Message}
-import com.mozilla.telemetry.histograms._
-import com.mozilla.telemetry.scalars._
+import com.mozilla.telemetry.metrics._
 import com.mozilla.telemetry.utils._
 
 protected class ClientIterator(it: Iterator[(String, Map[String, Any])], maxHistorySize: Int = 1000) extends Iterator[List[Map[String, Any]]] {

--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -10,7 +10,7 @@ import org.rogach.scallop._
 import com.mozilla.telemetry.heka.{Dataset, Message}
 import com.mozilla.telemetry.utils.{Addon, Attribution, Experiment, MainPing, S3Store, Events}
 import org.json4s.{DefaultFormats, JValue}
-import com.mozilla.telemetry.scalars._
+import com.mozilla.telemetry.metrics._
 
 import scala.util.{Success, Try}
 

--- a/src/test/scala/com/mozilla/telemetry/LongitudinalTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/LongitudinalTest.scala
@@ -2,8 +2,7 @@ package com.mozilla.telemetry.views
 import java.io.PrintWriter
 
 import com.mozilla.telemetry.parquet.ParquetFile
-import com.mozilla.telemetry.scalars.ScalarsClass
-import com.mozilla.telemetry.histograms.HistogramsClass
+import com.mozilla.telemetry.metrics.{ScalarsClass, HistogramsClass}
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
 import org.apache.spark.sql.{Row, SQLContext}

--- a/src/test/scala/com/mozilla/telemetry/MainSummaryViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/MainSummaryViewTest.scala
@@ -3,7 +3,7 @@ package com.mozilla.telemetry
 import com.mozilla.telemetry.heka.{File, RichMessage}
 import com.mozilla.telemetry.utils.{MainPing, Events}
 import com.mozilla.telemetry.views.MainSummaryView
-import com.mozilla.telemetry.scalars._
+import com.mozilla.telemetry.metrics._
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.types.StructType

--- a/src/test/scala/com/mozilla/telemetry/histograms/HistogramsTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/histograms/HistogramsTest.scala
@@ -1,4 +1,4 @@
-import com.mozilla.telemetry.histograms.HistogramsClass
+import com.mozilla.telemetry.metrics.HistogramsClass
 
 import scala.io.Source
 import org.scalatest.{FlatSpec, Matchers, PrivateMethodTester}

--- a/src/test/scala/com/mozilla/telemetry/scalars/ScalarsTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/scalars/ScalarsTest.scala
@@ -1,4 +1,4 @@
-import com.mozilla.telemetry.scalars.ScalarsClass
+import com.mozilla.telemetry.metrics.ScalarsClass
 
 import scala.io.Source
 import org.scalatest.{FlatSpec, Matchers, PrivateMethodTester}


### PR DESCRIPTION
…efinition ancestor

I've found myself working around this issue where I want to access the "keyed" value in both HistogramDefinitions and ScalarDefinitions yet it's not accessible from the base class. This fixes that issue and moves Histograms.scala and Scalars.scala under a common package, which I feel makes more sense.

Tests pass, and I checked moztelemetry to make sure there aren't references to these files, but if there are other external dependencies that I don't know about please let me know.