### PR TITLE
Add working histogram aggregation job

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/experiments/analyzers/HistogramAnalyzer.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/analyzers/HistogramAnalyzer.scala
@@ -1,0 +1,93 @@
+package com.mozilla.telemetry.experiments.analyzers
+
+import com.mozilla.telemetry.metrics.HistogramDefinition
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.expressions.Aggregator
+
+import scala.collection.{Map => CMap}
+import scala.util.{Failure, Success, Try}
+
+
+case class HistogramRow(experiment_id: String, branch: String, subgroup: String, metric: Option[CMap[Int, Int]])
+case class KeyedHistogramRow(experiment_id: String, branch: String, subgroup: String,
+                             metric: Option[CMap[String, CMap[Int, Int]]]) {
+  def collapsedMetric: Option[CMap[Int, Int]] = {
+    // The OKRs state that we collapse keyed metrics (for now)
+    metric match {
+      case Some(m) => Some(m.values.reduce(sumCMaps[Int](_: CMap[Int, Int], _: CMap[Int, Int])))
+      case _ => None
+    }
+  }
+
+  def toHistogramRow: HistogramRow = {
+    HistogramRow(experiment_id, branch, subgroup, collapsedMetric)
+  }
+}
+
+object HistogramAggregator
+  extends Aggregator[HistogramRow, Map[Int, Long], Map[Long, HistogramPoint]] {
+  def zero: Map[Int, Long] = Map[Int, Long]()
+
+  def reduce(b: Map[Int, Long], h: HistogramRow): Map[Int, Long] = {
+    h.metric match {
+      case Some(m: CMap[Int, Int]) => b ++ m.map { case (k: Int, v: Int) => k -> (v.toLong + b.getOrElse(k, 0L)) }
+      case _ => b
+    }
+  }
+
+  def merge(l: Map[Int, Long], r: Map[Int, Long]): Map[Int, Long] = {
+    l ++ r.map { case (k, v) => k -> (v + l.getOrElse(k, 0L)) }
+  }
+
+  def finish(b: Map[Int, Long]): Map[Long, HistogramPoint] = {
+    val sum = b.values.sum
+    b.map { case (k, v) => k.toLong -> HistogramPoint(v.toDouble / sum.toDouble, v.toDouble, None) }
+  }
+
+  def bufferEncoder: Encoder[Map[Int, Long]] = ExpressionEncoder()
+  def outputEncoder: Encoder[Map[Long, HistogramPoint]] = ExpressionEncoder()
+}
+
+class HistogramAnalyzer(name: String, hd: HistogramDefinition, df: DataFrame) extends java.io.Serializable {
+  import df.sparkSession.implicits._
+
+  def analyze(): Option[Dataset[HistogramAnalysis]] = {
+    val ds = format match {
+      case Some(d: DataFrame) => collapseKeys(d)
+      case _ => return None
+    }
+
+    val histogramAggregate = HistogramAggregator.toColumn.name("histogram_aggregate")
+    val output = ds.filter(r => r.metric.isDefined)
+      .groupByKey(x => MetricKey(x.experiment_id, x.branch, x.subgroup))
+      .agg(histogramAggregate, count("*"))
+      .map { toOutputSchema }
+
+    Some(output)
+  }
+
+  private def format: Option[DataFrame] = {
+    Try(df.select(
+      col("experiment_id"),
+      col("experiment_branch").as("branch"),
+      lit("All").as("subgroup"),
+      col(name).as("metric"))
+    ) match {
+      case Success(x) => Some(x)
+      // expected failure, if the dataset doesn't include this metric (e.g. it's newly added)
+      case Failure(_: org.apache.spark.sql.AnalysisException) => None
+      case Failure(x: Throwable) => throw x
+    }
+  }
+
+  private def collapseKeys(formatted: DataFrame): Dataset[HistogramRow] = {
+    if (hd.keyed) formatted.as[KeyedHistogramRow].map(_.toHistogramRow) else formatted.as[HistogramRow]
+  }
+
+  private def toOutputSchema(r: (MetricKey, Map[Long, HistogramPoint], Long)): HistogramAnalysis = r match {
+    case (k: MetricKey, h: Map[Long, HistogramPoint], n: Long) =>
+      HistogramAnalysis(k.experiment_id, k.branch, k.subgroup, n, name, hd.getClass.getSimpleName, h, None)
+  }
+}

--- a/src/main/scala/com/mozilla/telemetry/experiments/analyzers/package.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/analyzers/package.scala
@@ -1,0 +1,40 @@
+package com.mozilla.telemetry.experiments
+
+import scala.collection.{Map => CMap}
+
+
+package object analyzers {
+  def sumCMaps[T](l: CMap[T, Int], r: CMap[T, Int]): CMap[T, Int] = {
+    l ++ r.map { case (k, v) => k -> (v + l.getOrElse(k, 0)) }
+  }
+
+  def sumMaps[T](l: Map[T, Long], r: Map[T, Long]): Map[T, Long] = {
+    l ++ r.map { case (k, v) => k -> (v + l.getOrElse(k, 0L)) }
+  }
+
+  def addElement[T](m: CMap[T, Long], e: T): CMap[T, Long] = {
+    m + (e -> (m.getOrElse(e, 0L) + 1L))
+  }
+
+  case class MetricKey(experiment_id: String, branch: String, subgroup: String)
+
+  // pdf is the count normalized by counts for all buckets
+  case class HistogramPoint(pdf: Double, count: Double, label: Option[String])
+
+  case class Statistic(comparison_branch: Option[String],
+                       name: String,
+                       value: Double,
+                       confidence_low: Double,
+                       confidence_high: Double,
+                       confidence_level: Double,
+                       p_value: Double)
+
+  case class HistogramAnalysis(experiment_id: String,
+                               experiment_branch: String,
+                               subgroup: String,
+                               n: Long,
+                               metric_name: String,
+                               metric_type: String,
+                               histogram: CMap[Long, HistogramPoint],
+                               statistic: Option[Seq[Statistic]])
+}

--- a/src/main/scala/com/mozilla/telemetry/utils/package.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/package.scala
@@ -92,4 +92,8 @@ package object utils{
     println(s"Elapsed time: ${(t1 - t0)/1000000000.0} s")
     result
   }
+
+  def yesterdayAsYYYYMMDD: String = {
+    DateTime.now.minusDays(1).toString("yyyyMMdd")
+  }
 }

--- a/src/main/scala/com/mozilla/telemetry/views/ExperimentAnalysisView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/ExperimentAnalysisView.scala
@@ -1,0 +1,90 @@
+package com.mozilla.telemetry.views
+
+import com.mozilla.telemetry.experiments.analyzers.{HistogramAnalysis, HistogramAnalyzer}
+import com.mozilla.telemetry.metrics._
+import org.apache.spark.sql.{Dataset, SparkSession}
+import org.rogach.scallop.ScallopConf
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.functions.col
+
+object ExperimentAnalysisView {
+  def schemaVersion: String = "v1"
+
+  def jobName: String = "experiment_analysis"
+
+  // Configuration for command line arguments
+  private class Conf(args: Array[String]) extends ScallopConf(args) {
+    // TODO: change to s3 bucket/keys
+    val inputLocation = opt[String]("input", descr = "Source for parquet data", required = true)
+    val outputLocation = opt[String]("output", descr = "Destination for parquet data", required = true)
+    val histo = opt[String]("histogram", descr = "Run job on just this histogram", required = false)
+    val experiment = opt[String]("experiment", descr = "Run job on just this experiment", required = false)
+    val date = opt[String]("date", descr = "Run date for this job (defaults to yesterday)", required = false)
+    verify()
+  }
+
+  def main(args: Array[String]) {
+    // Spark/job setup stuff
+    val conf = new Conf(args)
+    val date = conf.date.get match {
+      case Some(d) => d
+      case _ => com.mozilla.telemetry.utils.yesterdayAsYYYYMMDD
+    }
+
+    val spark = SparkSession
+      .builder()
+      .master("local[*]")
+      .appName(jobName)
+      .getOrCreate()
+
+    spark.sparkContext.setLogLevel("ERROR")
+
+    val hadoopConf = spark.sparkContext.hadoopConfiguration
+    hadoopConf.set("parquet.enable.summary-metadata", "false")
+
+    val data = spark.read.parquet(conf.inputLocation())
+
+    val experiments = conf.experiment.get match {
+      case Some(e) => List(e)
+      // if there isn't a specific experiment passed in, run the job for all experiments that had pings on the date
+      // we're running on
+      case _ => data
+        .where(col("submission_date_s3") === date)
+        .select("experiment_id")
+        .distinct()
+        .collect()
+        .toList
+        .map(r => r(0).asInstanceOf[String])
+    }
+
+    val histogramList = conf.histo.get match {
+      case Some(h) => List(h, Histograms.definitions()(h.toUpperCase))
+      case _ => MainSummaryView.filterHistogramDefinitions(Histograms.definitions(), true)
+    }
+
+    import spark.implicits._
+
+    experiments.foreach { e: String =>
+      val experimentData = data.where(col("experiment_id") === e)
+      val experimentResult = histogramList.map {
+        case (name: String, hd: HistogramDefinition) => {
+          val columnName = MainSummaryView.getHistogramName(name.toLowerCase, "parent")
+          val ds = new HistogramAnalyzer(columnName, hd, experimentData).analyze()
+
+          ds match {
+            case Some(d) => d
+            case _ => spark.emptyDataset[HistogramAnalysis]
+          }
+        }
+      }.reduce(_.union(_))
+
+      val outputLocation = s"${conf.outputLocation()}/experiment_id=$e/date=$date"
+      experimentResult.toDF
+        .drop(col("experiment_id"))
+        .repartition(1)
+        .write.mode("overwrite").parquet(outputLocation)
+    }
+
+    spark.stop()
+  }
+}

--- a/src/test/scala/com/mozilla/telemetry/experiments/analyzers/HistogramAnalyzerTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/experiments/analyzers/HistogramAnalyzerTest.scala
@@ -1,0 +1,86 @@
+package com.mozilla.telemetry.experiments.analyzers
+
+import com.holdenkarau.spark.testing.DatasetSuiteBase
+import com.mozilla.telemetry.metrics.EnumeratedHistogram
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.{Map => CMap}
+
+
+case class ExperimentDataset(experiment_id: String,
+                             experiment_branch: String,
+                             histogram: Option[CMap[Int, Int]],
+                             keyed_histogram: Option[CMap[String, CMap[Int, Int]]])
+
+class HistogramAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase {
+  val m1 = CMap(0 -> 1, 1 -> 2, 2 -> 3)
+  val m2 = CMap(0 -> 2, 1 -> 4, 2 -> 6)
+  val m3 = CMap(0 -> 1, 1 -> 2, 2 -> 3, 100 -> 1)
+  val m4 = CMap(0 -> 1, 1 -> 2, 2 -> 3, 5 -> 0)
+
+  def fixture = {
+    import spark.implicits._
+    Seq(
+      ExperimentDataset("experiment1", "control", Some(m1), Some(CMap("key1" -> m1, "key2" -> m2))),
+      ExperimentDataset("experiment1", "control", None, None),
+      ExperimentDataset("experiment1", "control", Some(m2), Some(CMap("hi" -> m2, "there" -> m3))),
+      ExperimentDataset("experiment1", "control", Some(m4), Some(CMap("hi" -> m3, "there" -> m3))),
+      ExperimentDataset("experiment1", "branch1", Some(m1), Some(CMap("key1" -> m1, "key2" -> m2))),
+      ExperimentDataset("experiment1", "branch2", Some(m4), Some(CMap("hi" -> m3, "there" -> m3))),
+      ExperimentDataset("experiment1", "branch2", Some(m4), Some(CMap("hi" -> m3, "there" -> m3))),
+      ExperimentDataset("experiment2", "control", None, Some(CMap("hi" -> m3, "there" -> m3))),
+      ExperimentDataset("experiment3", "control", Some(m4), Some(CMap("hi" -> m3, "there" -> m3))),
+      ExperimentDataset("experiment3", "branch2", Some(m1), Some(CMap("key1" -> m1, "key2" -> m2)))
+    ).toDS().toDF()
+  }
+
+  def partialToPoint(total: Double, label: Option[String])(v: Int): HistogramPoint = {
+    HistogramPoint(v.toDouble/total, v.toLong, label)
+  }
+
+  "Non-keyed Histograms" can "be aggregated" in {
+    val df = fixture
+    val analyzer = new HistogramAnalyzer("histogram",
+      EnumeratedHistogram(false, 150),
+      df.where(df.col("experiment_id") === "experiment1")
+    )
+    val actual = analyzer.analyze().get.collect().toSet
+
+    def toPointControl: (Int => HistogramPoint) = partialToPoint(24.0, None)
+    def toPointBranch1: (Int => HistogramPoint) = partialToPoint(6.0, None)
+    def toPointBranch2: (Int => HistogramPoint) = partialToPoint(12.0, None)
+
+    val expected = Set(
+      HistogramAnalysis("experiment1", "control", "All", 3L, "histogram", "EnumeratedHistogram",
+        CMap(0L -> toPointControl(4), 1L -> toPointControl(8), 2L -> toPointControl(12), 5L -> toPointControl(0)), None),
+      HistogramAnalysis("experiment1", "branch1", "All", 1L, "histogram", "EnumeratedHistogram",
+        CMap(0L -> toPointBranch1(1), 1L -> toPointBranch1(2), 2L -> toPointBranch1(3)), None),
+      HistogramAnalysis("experiment1", "branch2", "All", 2L, "histogram", "EnumeratedHistogram",
+        CMap(0L -> toPointBranch2(2), 1L -> toPointBranch2(4), 2L -> toPointBranch2(6), 5L -> toPointBranch2(0)), None)
+    )
+    assert(actual == expected)
+  }
+
+  "Keyed Histograms" can "be aggregated" in {
+    val df = fixture
+    val analyzer = new HistogramAnalyzer("keyed_histogram",
+      EnumeratedHistogram(true, 150),
+      df.where(df.col("experiment_id") === "experiment1")
+    )
+    val actual = analyzer.analyze().get.collect().toSet
+
+    def toPointControl: (Int => HistogramPoint) = partialToPoint(51.0, None)
+    def toPointBranch1: (Int => HistogramPoint) = partialToPoint(18.0, None)
+    def toPointBranch2: (Int => HistogramPoint) = partialToPoint(28.0, None)
+
+    val expected = Set(
+      HistogramAnalysis("experiment1", "control", "All", 3L, "keyed_histogram", "EnumeratedHistogram",
+        CMap(0L -> toPointControl(8), 1L -> toPointControl(16), 2L -> toPointControl(24), 100L -> toPointControl(3)), None),
+      HistogramAnalysis("experiment1", "branch1", "All", 1L, "keyed_histogram", "EnumeratedHistogram",
+        CMap(0L -> toPointBranch1(3), 1L -> toPointBranch1(6), 2L -> toPointBranch1(9)), None),
+      HistogramAnalysis("experiment1", "branch2", "All", 2L, "keyed_histogram", "EnumeratedHistogram",
+        CMap(0L -> toPointBranch2(4), 1L -> toPointBranch2(8), 2L -> toPointBranch2(12), 100L -> toPointBranch2(4)), None)
+    )
+    assert(actual == expected)
+  }
+}


### PR DESCRIPTION
Much smaller PR than last time: this is the first iteration of the experiment metric aggregation and analysis job based on Main Summary and Datasets.

Currently, this only aggregates the whitelisted histograms in main summary. The next PR will include scalar aggregation, and the one after that probably summary stats.