### PR TITLE
Make generic count view overwrite

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/GenericCountView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/GenericCountView.scala
@@ -146,6 +146,7 @@ object GenericCountView {
     aggregate(sc, conf)
       .repartition(partitions)
       .write
+      .mode("overwrite")
       .parquet(s"s3://${conf.outputBucket()}/$version")
 
     sc.stop()


### PR DESCRIPTION
Should fix the current problem, but it doesn't explain why Spark is creating the metadata dirs before the actual data starts loading.

This hasn't been tested, can do tomorrow, but is the same as most of our other jobs now.