### PR TITLE
Add partition option to Generic Count view

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/GenericCountView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/GenericCountView.scala
@@ -14,6 +14,7 @@ object GenericCountView {
   val DefaultSubmissionDateCol = "submission_date_s3"
   val DefaultHllBits = 12
   val DefaultOutputFiles = 32
+  val DefaultWriteMode = "overwrite"
 
   class Conf(args: Array[String]) extends ScallopConf(args) {
     val from = opt[String](
@@ -75,6 +76,11 @@ object GenericCountView {
       "output-partition",
       descr = "Partition of the output data",
       required = false)
+    val writeMode = opt[String](
+      "write-mode",
+      descr = "Spark write mode. Defaults to overwrite",
+      required = false,
+      default = Some(DefaultWriteMode))
     requireOne(inputTablename, inputFiles)
     verify()
   }
@@ -155,7 +161,7 @@ object GenericCountView {
     aggregate(sc, conf)
       .repartition(sparkPartitions)
       .write
-      .mode("overwrite")
+      .mode(conf.writeMode())
       .parquet(s"s3://${conf.outputBucket()}/$version$partition")
 
     sc.stop()


### PR DESCRIPTION
Instead of reprocessing all data every week we want to update the Quantum RC, having it partitioned means that I can update it weekly with only the most recent data, assuming the schema doesn't change. Eventually we can do this with the other counts as well.

This shouldn't affect end users as all queries are using `WHERE` and `GROUP BY`, which will still be fine with the partitions, even if two rows in separate partitions have the same values for all dimensions.