### PR TITLE
Bug 1375560 - Dedupe experiments view

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/ExperimentSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/ExperimentSummaryView.scala
@@ -99,7 +99,10 @@ object ExperimentSummaryView {
 
   def writeExperiments(input: String, output: String, date: String, experiments: List[String], spark: SparkSession): Unit = {
     val mainSummary = spark.read.parquet(input)
+
     mainSummary
+      .where("experiments IS NOT NULL AND size(experiments) > 0")
+      .dropDuplicates("document_id")
       .select(col("*"), explode(col("experiments")).as(Array("experiment_id", "experiment_branch")))
       .where(col("experiment_id").isin(experiments:_*))
       .withColumn("submission_date_s3", lit(date))

--- a/src/test/scala/com/mozilla/telemetry/ExperimentSummaryViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/ExperimentSummaryViewTest.scala
@@ -28,12 +28,17 @@ class ExperimentSummaryViewTest extends FlatSpec with Matchers{
 
       val pings : DataFrame = Seq(
         m,
+        m,
         m.copy(
           document_id = "22539231-c1c6-4b9a-bed6-2a8d2e4e5e8c",
           experiments = Some(Map())),
         m.copy(
           document_id = "547b5406-8717-4696-b12b-b6c796bdbf8b",
           experiments = None),
+        m.copy(
+          client_id = "baedfe78-676e-440e-98b4-a4066657ded1",
+          document_id = "72062950-3daf-450e-adfd-58eda3151a97",
+          experiments = Some(Map("experiment1" -> "branch2"))),
         m.copy(
           client_id = "baedfe78-676e-440e-98b4-a4066657ded1",
           document_id = "72062950-3daf-450e-adfd-58eda3151a97",


### PR DESCRIPTION
This also includes a generic `dedupe()` function available for
all DataFrames, so we can easily call: `df.dedupe()` to remove
any duplicates.