### PR TITLE
Bug 1375353 - Add OS info to the Sync summary view

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/SyncView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/SyncView.scala
@@ -212,7 +212,10 @@ object SyncPingConverter {
     StructField("app_name", StringType, nullable = true), // application/name
     StructField("app_version", StringType, nullable = true), // application/version
     StructField("app_channel", StringType, nullable = true), // application/channel
-    // XXX - how do we record the "platform"?
+
+    StructField("os", StringType, nullable = true), // os/name
+    StructField("os_version", StringType, nullable = true), // os/version
+    StructField("os_locale", StringType, nullable = true), // os/locale
 
     // These fields are unique to the sync pings.
     StructField("uid", StringType, nullable = false),
@@ -466,6 +469,19 @@ object SyncPingConverter {
       application \ "channel" match {
         case JString(x) => x
         case _ => return None // a required field.
+      },
+
+      payload \ "os" \ "name" match {
+        case JString(x) => x
+        case _ => null
+      },
+      payload \ "os" \ "version" match {
+        case JString(x) => x
+        case _ => null
+      },
+      payload \ "os" \ "locale" match {
+        case JString(x) => x
+        case _ => null
       },
 
       // Info about the sync.

--- a/src/test/scala/com/mozilla/telemetry/views/SyncViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/SyncViewTest.scala
@@ -182,6 +182,10 @@ class SyncViewTest extends FlatSpec with Matchers{
     firstSync.getAs[String]("app_version") should be ((ping \ "application" \ "version").extract[String])
     firstSync.getAs[String]("app_channel") should be ((ping \ "application" \ "channel").extract[String])
 
+    firstSync.getAs[String]("os") should be ((ping \ "payload" \ "os" \ "name").extract[String])
+    firstSync.getAs[String]("os_version") should be ((ping \ "payload" \ "os" \ "version").extract[String])
+    firstSync.getAs[String]("os_locale") should be ((ping \ "payload" \ "os" \ "locale").extract[String])
+
     val firstPing = (ping \ "payload" \ "syncs")(0)
     firstSync.getAs[Long]("when") should be ((firstPing \ "when").extract[Long])
     firstSync.getAs[String]("uid") should be ((firstPing \ "uid").extract[String])
@@ -201,6 +205,10 @@ class SyncViewTest extends FlatSpec with Matchers{
     secondSync.getAs[String]("app_name") should be ((ping \ "application" \ "name").extract[String])
     secondSync.getAs[String]("app_version") should be ((ping \ "application" \ "version").extract[String])
     secondSync.getAs[String]("app_channel") should be ((ping \ "application" \ "channel").extract[String])
+
+    secondSync.getAs[String]("os") should be ((ping \ "payload" \ "os" \ "name").extract[String])
+    secondSync.getAs[String]("os_version") should be ((ping \ "payload" \ "os" \ "version").extract[String])
+    secondSync.getAs[String]("os_locale") should be ((ping \ "payload" \ "os" \ "locale").extract[String])
 
     val secondPing = (ping \ "payload" \ "syncs")(1)
 
@@ -228,6 +236,10 @@ class SyncViewTest extends FlatSpec with Matchers{
     sync.getAs[String]("app_display_version") should be ((ping \ "application" \ "displayVersion").extract[String])
     sync.getAs[String]("app_name") should be ((ping \ "application" \ "name").extract[String])
     sync.getAs[String]("app_version") should be ((ping \ "application" \ "version").extract[String])
+
+    sync.getAs[String]("os") should be ((ping \ "payload" \ "os" \ "name").extract[String])
+    sync.getAs[String]("os_version") should be ((ping \ "payload" \ "os" \ "version").extract[String])
+    sync.getAs[String]("os_locale") should be ((ping \ "payload" \ "os" \ "locale").extract[String])
 
     val pingPayload = (ping \ "payload" \ "syncs")(0)
     sync.getAs[Long]("when") should be ((pingPayload \ "when").extract[Long])

--- a/src/test/scala/com/mozilla/telemetry/views/SyncViewTestPayloads.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/SyncViewTestPayloads.scala
@@ -104,6 +104,11 @@ object SyncViewTestPayloads {
     |    "channel": "nightly"
     |  },
     |  "payload": {
+    |    "os": {
+    |      "name": "Darwin",
+    |      "version": "15.6.0",
+    |      "locale": "en-US"
+    |    },
     |    "why": "schedule",
     |    "version": 1,
     |    "syncs": [
@@ -218,6 +223,11 @@ object SyncViewTestPayloads {
       |    "channel": "nightly"
       |  },
       |  "payload": {
+      |    "os": {
+      |      "name": "Darwin",
+      |      "version": "15.6.0",
+      |      "locale": "en-US"
+      |    },
       |    "why": "schedule",
       |    "version": 1,
       |    "syncs": [
@@ -300,6 +310,11 @@ object SyncViewTestPayloads {
       |    "channel": "nightly"
       |  },
       |  "payload": {
+      |    "os": {
+      |      "name": "Darwin",
+      |      "version": "15.6.0",
+      |      "locale": "en-US"
+      |    },
       |    "why": "schedule",
       |    "version": 1,
       |    "uid": "12345678912345678912345678912345",


### PR DESCRIPTION
Hi! We added OS data to the Sync ping in https://bugzilla.mozilla.org/show_bug.cgi?id=1373093, but I don't think it's in the `sync_summary` table yet. This adds the base fields from [`TelemetryEnvironment#_getOSData`](http://searchfox.org/mozilla-central/rev/31311070d9860b24fe4a7a36976c14b328c16208/toolkit/components/telemetry/TelemetryEnvironment.jsm#1463-1467) as columns to `sync_summary`.