### PR TITLE
Bug 1378804 - Add Process Metrics to Experiment Analysis View

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/experiments/analyzers/Aggregators.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/analyzers/Aggregators.scala
@@ -46,6 +46,16 @@ object UintAggregator extends MetricAggregator[Int] {
   def bufferEncoder: Encoder[Map[Int, Long]] = ExpressionEncoder()
 }
 
+object LongAggregator extends MetricAggregator[Long] {
+  def finish(b: Map[Long, Long]): Map[Long, HistogramPoint] = {
+    val sum = b.values.sum.toDouble
+    if (sum == 0) return Map.empty[Long, HistogramPoint]
+    b.map { case (k: Long, v) => k -> HistogramPoint(v.toDouble / sum, v.toDouble, None) }
+  }
+
+  def bufferEncoder: Encoder[Map[Long, Long]] = ExpressionEncoder()
+}
+
 object StringAggregator extends MetricAggregator[String] {
   def finish(b: Map[String, Long]): Map[Long, HistogramPoint] = {
     val sum = b.values.sum.toDouble

--- a/src/main/scala/com/mozilla/telemetry/experiments/analyzers/ScalarAnalyzer.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/analyzers/ScalarAnalyzer.scala
@@ -35,6 +35,10 @@ case class UintScalarRow(experiment_id: String, branch: String, subgroup: String
   extends ScalarRow[Int] with definesToScalarMapRow[UintScalarMapRow] {
   def toScalarMapRow: UintScalarMapRow = UintScalarMapRow(experiment_id, branch, subgroup, scalarMapRowMetric)
 }
+case class LongScalarRow(experiment_id: String, branch: String, subgroup: String, metric: Option[Long])
+  extends ScalarRow[Long] with definesToScalarMapRow[LongScalarMapRow] {
+  def toScalarMapRow: LongScalarMapRow = LongScalarMapRow(experiment_id, branch, subgroup, scalarMapRowMetric)
+}
 case class StringScalarRow(experiment_id: String, branch: String, subgroup: String, metric: Option[String])
   extends ScalarRow[String] with definesToScalarMapRow[StringScalarMapRow] {
   def toScalarMapRow: StringScalarMapRow = StringScalarMapRow(experiment_id, branch, subgroup, scalarMapRowMetric)
@@ -66,6 +70,11 @@ case class KeyedUintScalarRow(experiment_id: String, branch: String, subgroup: S
   extends KeyedScalarRow[Int] with definesToScalarMapRow[UintScalarMapRow] {
   def toScalarMapRow: UintScalarMapRow = UintScalarMapRow(experiment_id, branch, subgroup, collapsedMetric)
 }
+case class KeyedLongScalarRow(experiment_id: String, branch: String, subgroup: String,
+                              metric: Option[Map[String, Long]])
+  extends KeyedScalarRow[Long] with definesToScalarMapRow[LongScalarMapRow] {
+  def toScalarMapRow: LongScalarMapRow = LongScalarMapRow(experiment_id, branch, subgroup, collapsedMetric)
+}
 case class KeyedStringScalarRow(experiment_id: String, branch: String, subgroup: String,
                                 metric: Option[Map[String, String]])
   extends KeyedScalarRow[String] with definesToScalarMapRow[StringScalarMapRow] {
@@ -76,6 +85,8 @@ case class BooleanScalarMapRow(experiment_id: String, branch: String, subgroup: 
                                metric: Option[Map[Boolean, Long]]) extends PreAggregateRow[Boolean]
 case class UintScalarMapRow(experiment_id: String, branch: String, subgroup: String,
                             metric: Option[Map[Int, Long]]) extends PreAggregateRow[Int]
+case class LongScalarMapRow(experiment_id: String, branch: String, subgroup: String,
+                            metric: Option[Map[Long, Long]]) extends PreAggregateRow[Long]
 case class StringScalarMapRow(experiment_id: String, branch: String, subgroup: String,
                               metric: Option[Map[String, Long]]) extends PreAggregateRow[String]
 
@@ -100,6 +111,18 @@ class UintScalarAnalyzer(name: String, md: ScalarDefinition, df: DataFrame)
   def collapseKeys(formatted: DataFrame): Dataset[UintScalarMapRow] = {
     import df.sparkSession.implicits._
     val s = if (md.keyed) formatted.as[KeyedUintScalarRow] else formatted.as[UintScalarRow]
+    s.map(_.toScalarMapRow)
+  }
+}
+
+class LongScalarAnalyzer(name: String, md: ScalarDefinition, df: DataFrame)
+  extends MetricAnalyzer[Long](name, md, df) {
+  override type PreAggregateRowType = LongScalarMapRow
+  val aggregator = LongAggregator
+
+  def collapseKeys(formatted: DataFrame): Dataset[LongScalarMapRow] = {
+    import df.sparkSession.implicits._
+    val s = if (md.keyed) formatted.as[KeyedLongScalarRow] else formatted.as[LongScalarRow]
     s.map(_.toScalarMapRow)
   }
 }

--- a/src/main/scala/com/mozilla/telemetry/metrics/Metric.scala
+++ b/src/main/scala/com/mozilla/telemetry/metrics/Metric.scala
@@ -4,7 +4,8 @@ import com.mozilla.telemetry.utils.MainPing
 
 trait MetricDefinition {
   val keyed: Boolean
-  val processes: List[String]
+  val process: Option[String]
+  val originalName: String
 }
 
 class MetricsClass {

--- a/src/main/scala/com/mozilla/telemetry/metrics/Scalars.scala
+++ b/src/main/scala/com/mozilla/telemetry/metrics/Scalars.scala
@@ -7,7 +7,7 @@ import collection.JavaConversions._
 import scala.io.Source
 import com.mozilla.telemetry.utils.MainPing
 
-sealed abstract class ScalarDefinition extends MetricDefinition
+abstract class ScalarDefinition extends MetricDefinition
 case class UintScalar(keyed: Boolean, processes: List[String]) extends ScalarDefinition
 case class BooleanScalar(keyed: Boolean, processes: List[String]) extends ScalarDefinition
 case class StringScalar(keyed: Boolean, processes: List[String]) extends ScalarDefinition

--- a/src/test/scala/com/mozilla/telemetry/experiments/analyzers/HistogramAnalyzerTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/experiments/analyzers/HistogramAnalyzerTest.scala
@@ -43,7 +43,7 @@ class HistogramAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase
   "Non-keyed Histograms" can "be aggregated" in {
     val df = fixture
     val analyzer = new HistogramAnalyzer("histogram",
-      EnumeratedHistogram(keyed = false, 150, MainPing.ProcessTypes),
+      EnumeratedHistogram(keyed = false, "name", 150),
       df.where(df.col("experiment_id") === "experiment1")
     )
     val actual = analyzer.analyze().collect().toSet
@@ -66,7 +66,7 @@ class HistogramAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase
   "Keyed Histograms" can "be aggregated" in {
     val df = fixture
     val analyzer = new HistogramAnalyzer("keyed_histogram",
-      EnumeratedHistogram(keyed = true, 150, MainPing.ProcessTypes),
+      EnumeratedHistogram(keyed = true, "name", 150),
       df.where(df.col("experiment_id") === "experiment1")
     )
     val actual = analyzer.analyze().collect().toSet
@@ -89,7 +89,7 @@ class HistogramAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase
   "Unknown histogram" should "return an empty dataset" in {
     val df = fixture
     val analyzer = new HistogramAnalyzer("unknown_histogram",
-      EnumeratedHistogram(keyed = true, 150, MainPing.ProcessTypes),
+      EnumeratedHistogram(keyed = true, "name", 150),
       df.where(df.col("experiment_id") === "experiment1")
     )
     val actual = analyzer.analyze()

--- a/src/test/scala/com/mozilla/telemetry/experiments/analyzers/ScalarAnalyzerTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/experiments/analyzers/ScalarAnalyzerTest.scala
@@ -69,7 +69,7 @@ class ScalarAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase {
   "Uint Scalars" can "be aggregated" in {
     val df = fixture
     val analyzer = ScalarAnalyzer.getAnalyzer("uint_scalar",
-      UintScalar(false, MainPing.ProcessTypes),
+      UintScalar(false, "name"),
       df.where(df.col("experiment_id") === "experiment1")
     )
     val actual = analyzer.analyze().collect().toSet
@@ -92,7 +92,7 @@ class ScalarAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase {
   "Keyed Uint Scalars" can "be aggregated" in {
     val df = fixture
     val analyzer = ScalarAnalyzer.getAnalyzer("keyed_uint_scalar",
-      UintScalar(true, MainPing.ProcessTypes),
+      UintScalar(true, "name"),
       df.where(df.col("experiment_id") === "experiment1")
     )
     val actual = analyzer.analyze().collect().toSet
@@ -116,7 +116,7 @@ class ScalarAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase {
   "Boolean Scalars" can "be aggregated" in {
     val df = fixture
     val analyzer = ScalarAnalyzer.getAnalyzer("boolean_scalar",
-      BooleanScalar(false, MainPing.ProcessTypes),
+      BooleanScalar(false, "name"),
       df.where(df.col("experiment_id") === "experiment1")
     )
     val actual = analyzer.analyze().collect().toSet
@@ -136,7 +136,7 @@ class ScalarAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase {
   "Keyed Boolean Scalars" can "be aggregated" in {
     val df = fixture
     val analyzer = ScalarAnalyzer.getAnalyzer("keyed_boolean_scalar",
-      BooleanScalar(true, MainPing.ProcessTypes),
+      BooleanScalar(true, "name"),
       df.where(df.col("experiment_id") === "experiment1")
     )
     val actual = analyzer.analyze().collect().toSet
@@ -155,7 +155,7 @@ class ScalarAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase {
   "String Scalars" can "be aggregated" in {
     val df = fixture
     val analyzer = ScalarAnalyzer.getAnalyzer("string_scalar",
-      StringScalar(false, MainPing.ProcessTypes),
+      StringScalar(false, "name"),
       df.where(df.col("experiment_id") === "experiment1")
     )
     val actual = analyzer.analyze().collect().toSet
@@ -175,7 +175,7 @@ class ScalarAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase {
   "Keyed String Scalars" can "be aggregated" in {
     val df = fixture
     val analyzer = ScalarAnalyzer.getAnalyzer("keyed_string_scalar",
-      StringScalar(true, MainPing.ProcessTypes),
+      StringScalar(true, "name"),
       df.where(df.col("experiment_id") === "experiment1")
     )
     val actual = analyzer.analyze().collect().toSet

--- a/src/test/scala/com/mozilla/telemetry/metrics/HistogramsTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/metrics/HistogramsTest.scala
@@ -23,7 +23,9 @@ class HistogramsTest extends FlatSpec with Matchers {
       } toMap
 
       val definitions = optStatuses map {
-        optStatus => optStatus -> histograms.definitions(optStatus)
+        optStatus => optStatus -> histograms.definitions(optStatus).map{
+          case (k, value) => (k.toLowerCase, value)
+        }
       } toMap
     }
   }
@@ -45,11 +47,27 @@ class HistogramsTest extends FlatSpec with Matchers {
 
   "Histograms" must "have processes specified" in {
     val histograms = fixture.definitions(true)
-    assert(histograms("MOCK_KEYED_EXPONENTIAL").processes == MainPing.ProcessTypes)
+    assert(histograms.contains("mock_keyed_exponential"))
+    assert(histograms.contains("mock_keyed_exponential_content"))
+    assert(histograms.contains("mock_keyed_exponential_gpu"))
   }
 
   "Histograms all_child process" must "have child processes specified" in {
     val histograms = fixture.definitions(true)
-    assert(histograms("CHILD_PROCESSES_ONLY").processes == MainPing.ProcessTypes.filter(_ != "parent"))
+    assert(!histograms.contains("child_processes_only"))
+    assert(histograms.contains("child_processes_only_gpu"))
+    assert(histograms.contains("child_processes_only_content"))
+  }
+
+  "Histograms process" must "match name" in {
+    val histograms = fixture.definitions(true)
+    assert(histograms("mock_keyed_exponential").process.get == "parent")
+    assert(histograms("mock_keyed_exponential_content").process.get == "content")
+    assert(histograms("mock_keyed_exponential_gpu").process.get == "gpu")
+  }
+
+  "Histograms originalName" must "be correct" in {
+    val histograms = fixture.definitions(true)
+    assert(histograms("mock_keyed_exponential").originalName == "MOCK_KEYED_EXPONENTIAL")
   }
 }

--- a/src/test/scala/com/mozilla/telemetry/metrics/ScalarsTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/metrics/ScalarsTest.scala
@@ -30,31 +30,47 @@ class ScalarsTest extends FlatSpec with Matchers {
 
   "Optout scalars" must "be included when optout only" in {
     val scalars = fixture.names(false)
-    assert(scalars.exists(_ == "mock.uint.optout"))
+    assert(scalars.exists(_ == "scalar_parent_mock_uint_optout"))
   }
 
   "Optin scalars" must "not be included when optout only" in {
     val scalars = fixture.names(false)
-    assert(!scalars.exists(_ == "mock.uint.optin"))
+    assert(!scalars.exists(_ == "scalar_praent_mock_uint_optin"))
   }
 
   "Optout scalars" must "be included when optin and optout" in {
     val scalars = fixture.names(true)
-    assert(scalars.exists(_ == "mock.uint.optout"))
+    assert(scalars.exists(_ == "scalar_parent_mock_uint_optout"))
   }
 
   "Optin scalars" must "be included when optin and optout" in {
     val scalars = fixture.names(true)
-    assert(scalars.exists(_ == "mock.uint.optin"))
+    assert(scalars.exists(_ == "scalar_parent_mock_uint_optin"))
   }
 
   "Scalars" must "have processes specified" in {
     val scalars = fixture.definitions(true)
-    assert(scalars("mock.uint.optin").processes == MainPing.ProcessTypes)
+    assert(scalars.contains("scalar_parent_mock_uint_optin"))
+    assert(scalars.contains("scalar_gpu_mock_uint_optin"))
+    assert(scalars.contains("scalar_content_mock_uint_optin"))
   }
 
   "Scalars all_child process" must "have child processes specified" in {
     val scalars = fixture.definitions(true)
-    assert(scalars("mock.all.children").processes == MainPing.ProcessTypes.filter(_ != "parent"))
+    assert(!scalars.contains("scalar_parent_mock_all_children"))
+    assert(scalars.contains("scalar_gpu_mock_all_children"))
+    assert(scalars.contains("scalar_content_mock_all_children"))
+  }
+
+  "Scalars process" must "match name" in {
+    val scalars = fixture.definitions(true)
+    assert(scalars("scalar_parent_mock_uint_optin").process.get == "parent")
+    assert(scalars("scalar_gpu_mock_uint_optin").process.get == "gpu")
+    assert(scalars("scalar_content_mock_uint_optin").process.get == "content")
+  }
+
+  "Scalars originalName" must "be correct" in {
+    val scalars = fixture.definitions(true)
+    assert(scalars("scalar_parent_mock_uint_optin").originalName == "mock.uint.optin")
   }
 }

--- a/src/test/scala/com/mozilla/telemetry/views/ExperimentAnalysisViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/ExperimentAnalysisViewTest.scala
@@ -1,0 +1,45 @@
+package com.mozilla.telemetry
+
+import com.mozilla.telemetry.views.ExperimentAnalysisView
+import org.apache.spark.sql.{Row, SparkSession}
+import org.scalatest.{FlatSpec, Matchers, BeforeAndAfter}
+import org.json4s.jackson.JsonMethods.parse
+
+import scala.io.Source
+
+case class ExperimentSummaryRow(
+  experiment_id: String,
+  experiment_branch: String,
+  scalar_parent_browser_engagement_max_concurrent_tab_count: Int)
+
+class ExperimentAnalysisViewTest extends FlatSpec with Matchers with BeforeAndAfter {
+  val spark: SparkSession =
+    SparkSession.builder()
+    .appName("Experiment Aggregate Test")
+    .master("local[*]")
+    .getOrCreate()
+
+  "Scalars" can "be counted" in {
+    import spark.implicits._
+
+    val data = Seq(
+      ExperimentSummaryRow("id1", "control", 1),
+      ExperimentSummaryRow("id1", "branch1", 2),
+      ExperimentSummaryRow("id2", "control", 1),
+      ExperimentSummaryRow("id2", "branch1", 1),
+      ExperimentSummaryRow("id3", "control", 1)
+    ).toDS().toDF()
+
+    val args =
+      "--input" :: "telemetry-mock-bucket" ::
+      "--output" :: "telemetry-mock-bucket" :: Nil
+    val conf = new ExperimentAnalysisView.Conf(args.toArray)
+
+    val res = ExperimentAnalysisView.getExperimentMetrics("id1", data, conf).collect()
+    res(0).getAs[String]("metric_name") should be ("scalar_parent_browser_engagement_max_concurrent_tab_count")
+  }
+
+  after {
+    spark.stop()
+  }
+}

--- a/src/test/scala/com/mozilla/telemetry/views/ExperimentAnalysisViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/ExperimentAnalysisViewTest.scala
@@ -2,7 +2,7 @@ package com.mozilla.telemetry
 
 import com.mozilla.telemetry.views.ExperimentAnalysisView
 import org.apache.spark.sql.{Row, SparkSession}
-import org.scalatest.{FlatSpec, Matchers, BeforeAndAfter}
+import org.scalatest.{FlatSpec, Matchers, BeforeAndAfterAll}
 import org.json4s.jackson.JsonMethods.parse
 
 import scala.io.Source
@@ -10,36 +10,53 @@ import scala.io.Source
 case class ExperimentSummaryRow(
   experiment_id: String,
   experiment_branch: String,
-  scalar_parent_browser_engagement_max_concurrent_tab_count: Int)
+  scalar_content_browser_usage_graphite: Int,
+  histogram_content_gc_max_pause_ms: Map[Int, Int])
 
-class ExperimentAnalysisViewTest extends FlatSpec with Matchers with BeforeAndAfter {
+class ExperimentAnalysisViewTest extends FlatSpec with Matchers with BeforeAndAfterAll {
   val spark: SparkSession =
     SparkSession.builder()
     .appName("Experiment Aggregate Test")
     .master("local[*]")
     .getOrCreate()
 
-  "Scalars" can "be counted" in {
+  val predata = Seq(
+    ExperimentSummaryRow("id1", "control", 1, Map(1 -> 1)),
+    ExperimentSummaryRow("id2", "branch1", 2, Map(2 -> 1)),
+    ExperimentSummaryRow("id2", "control", 1, Map(2 -> 1)),
+    ExperimentSummaryRow("id2", "branch1", 1, Map(2 -> 1)),
+    ExperimentSummaryRow("id3", "control", 1, Map(2 -> 1))
+  )
+
+  "Child Scalars" can "be counted" in {
     import spark.implicits._
 
-    val data = Seq(
-      ExperimentSummaryRow("id1", "control", 1),
-      ExperimentSummaryRow("id1", "branch1", 2),
-      ExperimentSummaryRow("id2", "control", 1),
-      ExperimentSummaryRow("id2", "branch1", 1),
-      ExperimentSummaryRow("id3", "control", 1)
-    ).toDS().toDF()
-
+    val data = predata.toDS().toDF()
     val args =
       "--input" :: "telemetry-mock-bucket" ::
       "--output" :: "telemetry-mock-bucket" :: Nil
     val conf = new ExperimentAnalysisView.Conf(args.toArray)
 
     val res = ExperimentAnalysisView.getExperimentMetrics("id1", data, conf).collect()
-    res(0).getAs[String]("metric_name") should be ("scalar_parent_browser_engagement_max_concurrent_tab_count")
+    val row = res.filter(_.getAs[String]("metric_name") == "scalar_content_browser_usage_graphite")(0)
+    row.getAs[Map[Int, Row]]("histogram")(1).getDouble(0) should be (1.0)
   }
 
-  after {
+  "Child Histograms" can "be counted" in {
+    import spark.implicits._
+
+    val data = predata.toDS().toDF()
+    val args =
+      "--input" :: "telemetry-mock-bucket" ::
+      "--output" :: "telemetry-mock-bucket" :: Nil
+    val conf = new ExperimentAnalysisView.Conf(args.toArray)
+
+    val res = ExperimentAnalysisView.getExperimentMetrics("id1", data, conf).collect()
+    val row = res.filter(_.getAs[String]("metric_name") == "histogram_content_gc_max_pause_ms")(0)
+    row.getAs[Map[Int, Row]]("histogram")(1).getDouble(0) should be (1.0)
+  }
+
+  override def afterAll() {
     spark.stop()
   }
 }

--- a/src/test/scala/com/mozilla/telemetry/views/LongitudinalViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/LongitudinalViewTest.scala
@@ -250,8 +250,8 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
       private val sqlContext = new SQLContext(sc)
 
       // Opt-out only schema
-      private val optoutHistogramDefs = histograms.definitions(includeOptin = false)
-      private val optoutScalarDefs = scalars.definitions(includeOptin = false)
+      val optoutHistogramDefs = histograms.definitions(includeOptin = false)
+      val optoutScalarDefs = scalars.definitions(includeOptin = false)
 
       private val optoutSchema = LongitudinalView invokePrivate buildSchema(optoutHistogramDefs, optoutScalarDefs)
       private val optoutRecord = (LongitudinalView  invokePrivate buildRecord(payloads ++ dupes, optoutSchema, optoutHistogramDefs, optoutScalarDefs)).get


### PR DESCRIPTION
I included a bit of the reverted code, since I needed it for testing. I stripped out everything to do with the derived scalars, which we can talk about re-adding down the line (with some changes).

Look at the commit for a summary of changes. Kept Histograms.definitions backwards compatible with LongitudinalView.