### PR TITLE
Add a .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.idea
+docs
+lib_managed
+target


### PR DESCRIPTION
If there's a bunch of stuff in your working directory, it all gets
sent to Docker when building the image, which causes it to take a
long time (particularly if you've built the assembly jar).