### PR TITLE
Add metadata (client and ping count) row to experiment aggregates

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/experiments/analyzers/ExperimentAnalyzer.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/analyzers/ExperimentAnalyzer.scala
@@ -1,0 +1,37 @@
+package com.mozilla.telemetry.experiments.analyzers
+
+import org.apache.spark.sql.{DataFrame, Dataset}
+import org.apache.spark.sql.functions.{col, lit, count, sum, countDistinct}
+
+
+case class ExperimentMetadata(experiment_id: String,
+                              branch: String,
+                              subgroup: String,
+                              client_count: Long,
+                              ping_count: Long)
+
+object ExperimentAnalyzer {
+  def getExperimentMetadata(df: DataFrame): Dataset[MetricAnalysis] = {
+    import df.sparkSession.implicits._
+
+    val counts = df
+      .select(
+        col("experiment_id"),
+        col("experiment_branch").as("branch"),
+        lit("All").as("subgroup"),
+        col("client_id"))
+      .groupBy(col("experiment_id"), col("branch"), col("subgroup"))
+      .agg(countDistinct("client_id").alias("client_count"), count("*").alias("ping_count"))
+      .as[ExperimentMetadata]
+
+    counts.map { r =>
+      MetricAnalysis(r.experiment_id, r.branch, r.subgroup, r.ping_count, "Experiment Metadata", "Metadata",
+        Map.empty[Long, HistogramPoint],
+        Some(Seq(
+          Statistic(None, "Total Pings", r.ping_count.toDouble),
+          Statistic(None, "Total Clients", r.client_count.toDouble)
+        ))
+      )
+    }
+  }
+}

--- a/src/main/scala/com/mozilla/telemetry/experiments/analyzers/MetricAnalyzer.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/analyzers/MetricAnalyzer.scala
@@ -23,10 +23,10 @@ case class HistogramPoint(pdf: Double, count: Double, label: Option[String])
 case class Statistic(comparison_branch: Option[String],
                      name: String,
                      value: Double,
-                     confidence_low: Double,
-                     confidence_high: Double,
-                     confidence_level: Double,
-                     p_value: Double)
+                     confidence_low: Option[Double] = None,
+                     confidence_high: Option[Double] = None,
+                     confidence_level: Option[Double] = None,
+                     p_value: Option[Double] = None)
 
 case class MetricAnalysis(experiment_id: String,
                           experiment_branch: String,

--- a/src/test/scala/com/mozilla/telemetry/experiments/analyzers/ExperimentAnalyzerTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/experiments/analyzers/ExperimentAnalyzerTest.scala
@@ -1,0 +1,45 @@
+package com.mozilla.telemetry.experiments.analyzers
+
+import com.holdenkarau.spark.testing.DatasetSuiteBase
+import org.apache.spark.sql.DataFrame
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.Map
+
+
+case class ExperimentDataset(experiment_id: String, experiment_branch: String, client_id: String)
+
+class ExperimentAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase {
+  def fixture: DataFrame = {
+    import spark.implicits._
+    Seq(
+      ExperimentDataset("experiment1", "control", "a"),
+      ExperimentDataset("experiment1", "control", "b"),
+      ExperimentDataset("experiment1", "control", "a"),
+      ExperimentDataset("experiment1", "control", "c"),
+      ExperimentDataset("experiment1", "branch1", "d"),
+      ExperimentDataset("experiment1", "branch2", "e"),
+      ExperimentDataset("experiment1", "branch2", "d")
+    ).toDS().toDF()
+  }
+
+  "Pings and clients" can "be counted" in {
+    val df = fixture
+    val actual = ExperimentAnalyzer.getExperimentMetadata(df).collect.toSet
+    val expected = Set(
+      MetricAnalysis("experiment1", "control", "All", 4, "Experiment Metadata", "Metadata",
+        Map.empty[Long, HistogramPoint],
+        Some(Seq(Statistic(None, "Total Pings", 4.0), Statistic(None, "Total Clients", 3.0)))
+      ),
+      MetricAnalysis("experiment1", "branch1", "All", 1, "Experiment Metadata", "Metadata",
+        Map.empty[Long, HistogramPoint],
+        Some(Seq(Statistic(None, "Total Pings", 1.0), Statistic(None, "Total Clients", 1.0)))
+      ),
+      MetricAnalysis("experiment1", "branch2", "All", 2, "Experiment Metadata", "Metadata",
+        Map.empty[Long, HistogramPoint],
+        Some(Seq(Statistic(None, "Total Pings", 2.0), Statistic(None, "Total Clients", 2.0)))
+      )
+    )
+    assert(actual == expected)
+  }
+}

--- a/src/test/scala/com/mozilla/telemetry/experiments/analyzers/HistogramAnalyzerTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/experiments/analyzers/HistogramAnalyzerTest.scala
@@ -3,7 +3,6 @@ package com.mozilla.telemetry.experiments.analyzers
 import com.holdenkarau.spark.testing.DatasetSuiteBase
 import com.mozilla.telemetry.metrics.EnumeratedHistogram
 import org.apache.spark.sql.DataFrame
-import com.mozilla.telemetry.utils.MainPing
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.collection.Map

--- a/src/test/scala/com/mozilla/telemetry/views/ExperimentAnalysisViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/ExperimentAnalysisViewTest.scala
@@ -3,11 +3,9 @@ package com.mozilla.telemetry
 import com.mozilla.telemetry.views.ExperimentAnalysisView
 import org.apache.spark.sql.{Row, SparkSession}
 import org.scalatest.{FlatSpec, Matchers, BeforeAndAfterAll}
-import org.json4s.jackson.JsonMethods.parse
-
-import scala.io.Source
 
 case class ExperimentSummaryRow(
+  client_id: String,
   experiment_id: String,
   experiment_branch: String,
   scalar_content_browser_usage_graphite: Int,
@@ -21,11 +19,11 @@ class ExperimentAnalysisViewTest extends FlatSpec with Matchers with BeforeAndAf
     .getOrCreate()
 
   val predata = Seq(
-    ExperimentSummaryRow("id1", "control", 1, Map(1 -> 1)),
-    ExperimentSummaryRow("id2", "branch1", 2, Map(2 -> 1)),
-    ExperimentSummaryRow("id2", "control", 1, Map(2 -> 1)),
-    ExperimentSummaryRow("id2", "branch1", 1, Map(2 -> 1)),
-    ExperimentSummaryRow("id3", "control", 1, Map(2 -> 1))
+    ExperimentSummaryRow("a", "id1", "control", 1, Map(1 -> 1)),
+    ExperimentSummaryRow("b", "id2", "branch1", 2, Map(2 -> 1)),
+    ExperimentSummaryRow("c", "id2", "control", 1, Map(2 -> 1)),
+    ExperimentSummaryRow("d", "id2", "branch1", 1, Map(2 -> 1)),
+    ExperimentSummaryRow("e", "id3", "control", 1, Map(2 -> 1))
   )
 
   "Child Scalars" can "be counted" in {
@@ -38,8 +36,8 @@ class ExperimentAnalysisViewTest extends FlatSpec with Matchers with BeforeAndAf
     val conf = new ExperimentAnalysisView.Conf(args.toArray)
 
     val res = ExperimentAnalysisView.getExperimentMetrics("id1", data, conf).collect()
-    val row = res.filter(_.getAs[String]("metric_name") == "scalar_content_browser_usage_graphite")(0)
-    row.getAs[Map[Int, Row]]("histogram")(1).getDouble(0) should be (1.0)
+    val agg = res.filter(_.metric_name == "scalar_content_browser_usage_graphite").head
+    agg.histogram(1).pdf should be (1.0)
   }
 
   "Child Histograms" can "be counted" in {
@@ -52,8 +50,23 @@ class ExperimentAnalysisViewTest extends FlatSpec with Matchers with BeforeAndAf
     val conf = new ExperimentAnalysisView.Conf(args.toArray)
 
     val res = ExperimentAnalysisView.getExperimentMetrics("id1", data, conf).collect()
-    val row = res.filter(_.getAs[String]("metric_name") == "histogram_content_gc_max_pause_ms")(0)
-    row.getAs[Map[Int, Row]]("histogram")(1).getDouble(0) should be (1.0)
+    val agg = res.filter(_.metric_name == "histogram_content_gc_max_pause_ms").head
+    agg.histogram(1).pdf should be (1.0)
+  }
+
+  "Total client ids and pings" can "be counted" in {
+    import spark.implicits._
+
+    val data = predata.toDS().toDF()
+    val args =
+      "--input" :: "telemetry-mock-bucket" ::
+      "--output" :: "telemetry-mock-bucket" :: Nil
+    val conf = new ExperimentAnalysisView.Conf(args.toArray)
+
+    val res = ExperimentAnalysisView.getExperimentMetrics("id1", data, conf).collect()
+    val metadata = res.filter(_.metric_name == "Experiment Metadata").head.statistics.get
+    metadata.filter(_.name == "Total Pings").head.value should be (1.0)
+    metadata.filter(_.name == "Total Clients").head.value should be (1.0)
   }
 
   override def afterAll() {


### PR DESCRIPTION
This adds a row to the experiment aggregates output which includes ping and client count as "Statistics" objects for each branch/subgroup

Required for mozilla/experiments-viewer#155