### PR TITLE
Fix experiment metadata output

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/ExperimentAnalysisView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/ExperimentAnalysisView.scala
@@ -108,7 +108,7 @@ object ExperimentAnalysisView {
           case _ => throw new UnsupportedOperationException("Unsupported metric definition type")
         }
     }
-    val metadata = ExperimentAnalyzer.getExperimentMetadata(data)
+    val metadata = ExperimentAnalyzer.getExperimentMetadata(experimentData)
     (metadata :: metrics).reduce(_.union(_))
   }
 }

--- a/src/test/scala/com/mozilla/telemetry/views/ExperimentAnalysisViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/ExperimentAnalysisViewTest.scala
@@ -64,9 +64,12 @@ class ExperimentAnalysisViewTest extends FlatSpec with Matchers with BeforeAndAf
     val conf = new ExperimentAnalysisView.Conf(args.toArray)
 
     val res = ExperimentAnalysisView.getExperimentMetrics("id1", data, conf).collect()
-    val metadata = res.filter(_.metric_name == "Experiment Metadata").head.statistics.get
-    metadata.filter(_.name == "Total Pings").head.value should be (1.0)
-    metadata.filter(_.name == "Total Clients").head.value should be (1.0)
+    val metadata = res.filter(_.metric_name == "Experiment Metadata")
+    metadata.length should be (1)
+
+    val first = metadata.head.statistics.get
+    first.filter(_.name == "Total Pings").head.value should be (1.0)
+    first.filter(_.name == "Total Clients").head.value should be (1.0)
   }
 
   override def afterAll() {


### PR DESCRIPTION
The metadata output had a bug where each experiment was outputting metadata *every* experiment, not just its own, because I passed in the unfiltered dataset. Whoops.

cc @robhudson 