### PR TITLE
Revert "Try using approxCountDistinct to reduce processing time"

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/experiments/analyzers/ExperimentAnalyzer.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/analyzers/ExperimentAnalyzer.scala
@@ -1,7 +1,7 @@
 package com.mozilla.telemetry.experiments.analyzers
 
 import org.apache.spark.sql.{DataFrame, Dataset}
-import org.apache.spark.sql.functions.{col, lit, count, approxCountDistinct}
+import org.apache.spark.sql.functions.{col, lit, count, countDistinct}
 
 
 case class ExperimentMetadata(experiment_id: String,
@@ -21,7 +21,7 @@ object ExperimentAnalyzer {
         lit("All").as("subgroup"),
         col("client_id"))
       .groupBy(col("experiment_id"), col("branch"), col("subgroup"))
-      .agg(approxCountDistinct("client_id", 0.01).alias("client_count"), count("*").alias("ping_count"))
+      .agg(countDistinct("client_id").alias("client_count"), count("*").alias("ping_count"))
       .as[ExperimentMetadata]
 
     counts.map { r =>


### PR DESCRIPTION
This reverts commit 07a5a6795efe0476fef1db499b11f854571f367e.

Might as well go back to real counts now. Note this isn't an *exact* revert since there was an unused import that I deleted in the original commit (`org.apache.spark.sql.functions.sum`)