### PR TITLE
Activeticks fallback

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/utils/MainPing.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/MainPing.scala
@@ -311,8 +311,20 @@ object MainPing{
       Some(keys)
   }
 
-  def scalarsToRow(scalars: Map[String, JValue], definitions: List[(String, ScalarDefinition)]): Row = {
-    val values = definitions.map{
+  def getScalarByName(scalars: Map[String, JValue], definitions: List[(String, ScalarDefinition)],
+                      scalarName: String): Any = {
+    val filteredDefs = definitions.filter(_._1 == scalarName)
+    val filtered = scalarsToList(scalars, filteredDefs)
+
+    filtered.length match {
+      case 1 => filtered.head
+      case 0 => throw new IllegalArgumentException("A scalar by that name does not exist.")
+      case _ => throw new IllegalArgumentException("Multiple scalars by that name were found.")
+    }
+  }
+
+  def scalarsToList(scalars: Map[String, JValue], definitions: List[(String, ScalarDefinition)]): List[Any] = {
+    definitions.map{
       case (name, definition) =>
         definition match {
           case _: UintScalar => (name, definition, asInt _)
@@ -332,8 +344,10 @@ object MainPing{
           case _ => null
         }
     }
+  }
 
-    Row.fromSeq(values)
+  def scalarsToRow(scalars: Map[String, JValue], definitions: List[(String, ScalarDefinition)]): Row = {
+    Row.fromSeq(scalarsToList(scalars, definitions))
   }
 
   // Check if a json value contains a number greater than zero.

--- a/src/test/resources/ScalarsActiveTicks.yaml
+++ b/src/test/resources/ScalarsActiveTicks.yaml
@@ -1,0 +1,20 @@
+# This file contains a definition of the scalar probes that are recorded in Telemetry.
+# They are submitted with the "main" pings and can be inspected in about:telemetry.
+
+# The following section contains the browser engagement scalars.
+browser.engagement:
+  active_ticks:
+    bug_numbers:
+      - 1376942
+    description: >
+      The count of the number of five-second intervals ('ticks') the user
+      was considered 'active' in a subsession. Session activity involves keyboard or mouse
+      interaction with the application. It does not take into account whether or not the window
+      has focus or is in the foreground, only if it is receiving these interaction events.
+    expires: never
+    kind: uint
+    notification_emails:
+      - bcolloran@mozilla.com
+    release_channel_collection: opt-out
+    record_in_processes:
+      - 'main'


### PR DESCRIPTION
Bug 1382002 - Added and used MainPing.getScalarByName to access a scalar value from the payload, which if available, is supplemented for the original measurement. Currently being used for active_ticks. Includes tests.

@sunahsuh please review! :)