### PR TITLE
Bug 1381641 - Implement a sync view that flattens sync engine data

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/utils/SyncPingConversion.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/SyncPingConversion.scala
@@ -1,0 +1,593 @@
+package com.mozilla.telemetry.utils
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+import org.joda.time.DateTime
+import org.json4s.{DefaultFormats, JValue}
+import org.json4s.JsonAST.{JArray, JInt, JObject, JString}
+import java.util.UUID
+
+// Common conversion code for SyncView and SyncFlatView. Schema for sync pings described here:
+// https://dxr.mozilla.org/mozilla-central/source/services/sync/tests/unit/sync_ping_schema.json
+object SyncPingConversion {
+  /*
+   * The type definitions for the rows we create.
+   */
+  private val failureType = StructType(List(
+    // failures are probably *too* flexible in the schema, but all current errors have a "name" and a second field
+    // that is a string or an int. To keep things simple and small here, we just define a string "value" field and
+    // convert ints to the string.
+    StructField("name", StringType, nullable = false),
+    StructField("value", StringType, nullable = true)
+  ))
+
+  // The record of incoming sync-records.
+  private val incomingType = StructType(List(
+    StructField("applied", LongType, nullable = false),
+    StructField("failed", LongType, nullable = false),
+    StructField("new_failed", LongType, nullable = false),
+    StructField("reconciled", LongType, nullable = false)
+  ))
+
+  // Outgoing records.
+  private val outgoingType = StructType(List(
+    StructField("sent", LongType, nullable = false),
+    StructField("failed", LongType, nullable = false)
+  ))
+
+  // Entries in devices array
+  private val deviceType = StructType(List(
+    StructField("id", StringType, nullable = false),
+    StructField("version", StringType, nullable = false),
+    StructField("os", StringType, nullable = false)
+  ))
+
+  // Data about a single validation problem found
+  private val validationProblemType = StructType(List(
+    StructField("name", StringType, nullable = false),
+    StructField("count", LongType, nullable = false)
+  ))
+
+  // Data about a validation run on an engine
+  private val validationType = StructType(List(
+    // Validator version, optional per spec, but we fill in 0 where it was missing.
+    StructField("version", LongType, nullable = false),
+    StructField("checked", LongType, nullable = false), // # records checked
+    StructField("took", LongType, nullable = false), // milliseconds
+    StructField("problems", ArrayType(validationProblemType, containsNull = false), nullable = true),
+    // present if the validator failed for some reason.
+    StructField("failure_reason", failureType, nullable = true)
+  ))
+
+  // The schema for an engine.
+  private val engineType = StructType(List(
+    StructField("name", StringType, nullable = false),
+    StructField("took", LongType, nullable = false),
+    StructField("status", StringType, nullable = true),
+    StructField("failure_reason", failureType, nullable = true),
+    StructField("incoming", incomingType, nullable = true),
+    StructField("outgoing", ArrayType(outgoingType, containsNull = false), nullable = true),
+    StructField("validation", validationType, nullable = true)
+  ))
+
+  // The status for the Sync itself (ie, not the status for an engine - that's just a string)
+  private val statusType = StructType(List(
+    StructField("sync", StringType, nullable = true),
+    StructField("service", StringType, nullable = true)
+  ))
+
+  // The record of a single sync event.
+  def nestedSyncType = StructType(List(
+    // These field names are the same as used by MainSummaryView
+    StructField("app_build_id", StringType, nullable = true), // application/buildId
+    StructField("app_display_version", StringType, nullable = true), // application/displayVersion
+    StructField("app_name", StringType, nullable = true), // application/name
+    StructField("app_version", StringType, nullable = true), // application/version
+    StructField("app_channel", StringType, nullable = true), // application/channel
+
+    StructField("os", StringType, nullable = true), // os/name
+    StructField("os_version", StringType, nullable = true), // os/version
+    StructField("os_locale", StringType, nullable = true), // os/locale
+
+    // These fields are unique to the sync pings.
+    StructField("uid", StringType, nullable = false),
+    StructField("device_id", StringType, nullable = true), // should always exists, but old pings didn't record it.
+    StructField("when", LongType, nullable = false),
+    StructField("took", LongType, nullable = false),
+    StructField("failure_reason", failureType, nullable = true),
+    StructField("status", statusType, nullable = true),
+    // "why" is defined in the client-side schema but currently never populated.
+    StructField("why", StringType, nullable = true),
+    StructField("engines", ArrayType(engineType, containsNull = false), nullable = true),
+    StructField("devices", ArrayType(deviceType, containsNull = false), nullable = true)
+  ))
+
+  def singleEngineFlatSyncType = StructType(List(
+    // These field names are the same as used by MainSummaryView
+    StructField("app_build_id", StringType, nullable = true), // application/buildId
+    StructField("app_display_version", StringType, nullable = true), // application/displayVersion
+    StructField("app_name", StringType, nullable = true), // application/name
+    StructField("app_version", StringType, nullable = true), // application/version
+    StructField("app_channel", StringType, nullable = true), // application/channel
+
+    StructField("os", StringType, nullable = true), // os/name
+    StructField("os_version", StringType, nullable = true), // os/version
+    StructField("os_locale", StringType, nullable = true), // os/locale
+
+    // These fields are unique to the sync pings.
+    StructField("uid", StringType, nullable = false),
+    StructField("device_id", StringType, nullable = true), // should always exists, but old pings didn't record it.
+    StructField("when", LongType, nullable = false),
+    StructField("took", LongType, nullable = false),
+    StructField("failure_reason", failureType, nullable = true),
+    StructField("status", statusType, nullable = true),
+    // "why" is defined in the client-side schema but currently never populated.
+    StructField("why", StringType, nullable = true),
+    StructField("devices", ArrayType(deviceType, containsNull = false), nullable = true),
+
+    StructField("sync_id", StringType, nullable = false),
+    StructField("sync_day", StringType, nullable = false), // `when` formatted as "yyyyMMdd".
+
+    StructField("engine_name", StringType, nullable = false),
+    StructField("engine_took", LongType, nullable = false),
+    StructField("engine_status", StringType, nullable = true),
+    StructField("engine_failure_reason", failureType, nullable = true),
+
+    StructField("engine_incoming_applied", LongType, nullable = false),
+    StructField("engine_incoming_failed", LongType, nullable = false),
+    StructField("engine_incoming_new_failed", LongType, nullable = false),
+    StructField("engine_incoming_reconciled", LongType, nullable = false),
+
+    StructField("engine_outgoing_batch_count", LongType, nullable = false),
+    StructField("engine_outgoing_batch_total_sent", LongType, nullable = false),
+    StructField("engine_outgoing_batch_total_failed", LongType, nullable = false)
+  ))
+
+ /*
+ * Convert the JSON payload to rows matching the above types.
+ */
+  // XXX - this looks dodgy - I'm sure there's a more scala-ish way to write this...
+  private def failureReasonToRow(failure: JValue): Row = failure match {
+    case JObject(x) =>
+      implicit val formats: DefaultFormats.type = DefaultFormats
+      Row(
+        (failure \ "name").extract[String],
+        (failure \ "name").extract[String] match {
+          case "httperror" => (failure \ "code").extract[String]
+          case "nserror" => (failure \ "code").extract[String]
+          case "shutdownerror" => null
+          case "autherror" => (failure \ "from").extract[String]
+          case "othererror" => (failure \ "error").extract[String]
+          case "unexpectederror" => (failure \ "error").extract[String]
+          case "sqlerror" => (failure \ "code").extract[String]
+          case _ => null
+        }
+      )
+    case _ =>
+      null
+  }
+
+  private def deviceToRow(device: JValue): Option[Row] = device match {
+    case JObject(d) =>
+      Some(Row(
+        device \ "id" match {
+          case JString(x) => x
+          case _ => return None
+        },
+        device \ "version" match {
+          case JString(x) => x
+          case _ => return None
+        },
+        device \ "os" match {
+          case JString(x) => x
+          case _ => return None
+        }
+      ))
+    case _ => None
+  }
+
+  private def toDeviceRows(devices: JValue): List[Row] = devices match {
+    case JArray(x) =>
+      val rows = x.flatMap(d => deviceToRow(d))
+      if (rows.isEmpty) null
+      else rows
+    case _ => null
+  }
+
+  private def incomingSummary(incoming: JValue): (Long, Long, Long, Long) = incoming match {
+    case JObject(_) =>
+      (
+        incoming \ "applied" match {
+          case JInt(x) => x.toLong
+          case _ => 0L
+        },
+        incoming \ "failed" match {
+          case JInt(x) => x.toLong
+          case _ => 0L
+        },
+        incoming \ "newFailed" match {
+          case JInt(x) => x.toLong
+          case _ => 0L
+        },
+        incoming \ "reconciled" match {
+          case JInt(x) => x.toLong
+          case _ => 0L
+        }
+      )
+    case _ => (0L, 0L, 0L, 0L)
+  }
+
+  // Create a row representing incomingType
+  private def incomingToRow(incoming: JValue): Row = incoming match {
+    case JObject(_) =>
+      val (applied, failed, newFailed, reconciled) = incomingSummary(incoming)
+      Row(applied, failed, newFailed, reconciled)
+    case _ => null
+  }
+
+  private def parseSingleOutgoing(outgoingEntry: JValue): (Long, Long) = {
+    val sent = outgoingEntry \ "sent" match {
+      case JInt(n) => n.toLong
+      case _ => 0L
+    }
+    val failed = outgoingEntry \ "failed" match {
+      case JInt(n) => n.toLong
+      case _ => 0L
+    }
+    (sent, failed)
+  }
+
+  private def outgoingSummary(outgoing: JValue): (Long, Long, Long) = outgoing match {
+    case JArray(x) =>
+      val (totalSent, totalFailed) = x.foldLeft((0L, 0L))((acc, entry) => {
+        val (entrySent, entryFailed) = parseSingleOutgoing(entry)
+        (acc._1 + entrySent, acc._2 + entryFailed)
+      })
+      (x.size.toLong, totalSent, totalFailed)
+
+    case JObject(_) =>
+      val (entrySent, entryFailed) = parseSingleOutgoing(outgoing)
+      (1L, entrySent, entryFailed)
+
+    case _ =>
+      (0L, 0L, 0L)
+  }
+
+  private def outgoingToRow(outgoing: JValue): List[Row] = outgoing match {
+    case JArray(x) if x.nonEmpty =>
+      x.map(o => {
+        val (sent, failed) = parseSingleOutgoing(o)
+        Row(sent, failed)
+      })
+    case JObject(_) =>
+      val (sent, failed) = parseSingleOutgoing(outgoing)
+      List(Row(sent, failed))
+    case _ =>
+      null
+  }
+
+  private def validationToRow(validation: JValue): Row = validation match {
+    case JObject(_) =>
+      Row(
+        validation \ "version" match {
+          case JInt(x) => x.toLong
+          case _ => 0L
+        },
+        validation \ "checked" match {
+          case JInt(x) => x.toLong
+          case _ => 0L
+        },
+        validation \ "took" match {
+          case JInt(x) => x.toLong
+          case _ => 0L
+        },
+        validation \ "problems" match {
+          case JArray(problems) =>
+            problems.flatMap(validationProblemToRow)
+          case _ => null
+        },
+        failureReasonToRow(validation \ "failureReason")
+      )
+    case _ => null
+  }
+
+  private def validationProblemToRow(problem: JValue): Option[Row] = problem match {
+    case JObject(_) =>
+      Some(Row(
+        problem \ "name" match {
+          case JString(x) => x
+          case _ => return None
+        },
+        problem \ "count" match {
+          case JInt(x) => x.toLong
+          case _ => return None
+        }
+      ))
+    case _ => None
+  }
+
+  // Parse an element of "engines" elt in a sync object
+  private def engineToRow(engine: JValue): Row = {
+    Row(
+      engine \ "name" match {
+        case JString(x) => x
+        case _ => return null // engines must have a name!
+      },
+      engine \ "took" match {
+        case JInt(x) => x.toLong
+        case _ => 0L
+      },
+      engine \ "status" match {
+        case JString(x) => x
+        case _ => null
+      },
+      failureReasonToRow(engine \ "failureReason"),
+      incomingToRow(engine \ "incoming"),
+      outgoingToRow(engine \ "outgoing"),
+      validationToRow(engine \ "validation")
+    )
+  }
+
+  private def toEnginesRows(engines: JValue): List[Row] = engines match {
+    case JArray(x) =>
+      val buf = scala.collection.mutable.ListBuffer.empty[Row]
+      // Need simple array iteration??
+      for (e <- x) {
+        buf.append(engineToRow(e))
+      }
+      if (buf.isEmpty) null
+      else buf.toList
+    case _ => null
+  }
+
+  private def statusToRow(status: JValue): Row = status match {
+    case JObject(_) =>
+      Row(
+        status \ "sync" match {
+          case JString(x) => x
+          case _ => null
+        },
+        status \ "service" match {
+          case JString(x) => x
+          case _ => null
+        }
+      )
+    case _ => null
+  }
+
+  // Convert a "new style v1" ping that records multiple Syncs to a number of (nested) rows.
+  private def multiSyncPayloadToNestedRow(ping: JValue, syncs: List[JValue]): List[Row] = {
+    syncs.flatMap(sync => singleSyncPayloadToNestedRow(ping, sync))
+  }
+
+  // Convert an "old style" ping that records a single Sync to a (nested) row
+  private def singleSyncPayloadToNestedRow(ping: JValue, sync: JValue): Option[Row] = {
+    val application = ping \ "application"
+    val payload = ping \ "payload"
+
+    def stringFromSyncOrPayload(s: String): String = {
+      sync \ s match {
+        case JString(x) => x
+        case _ =>
+          payload \ s match {
+            case JString(x) => x
+            case _ => null
+          }
+      }
+    }
+
+    val row = Row(
+      // The metadata...
+      application \ "buildId" match {
+        case JString(x) => x
+        case _ => return None // a required field.
+      },
+      application \ "displayVersion" match {
+        case JString(x) => x
+        case _ => return None // a required field.
+      },
+      application \ "name" match {
+        case JString(x) => x
+        case _ => return None // a required field.
+      },
+      application \ "version" match {
+        case JString(x) => x
+        case _ => return None // a required field.
+      },
+      application \ "channel" match {
+        case JString(x) => x
+        case _ => return None // a required field.
+      },
+
+      payload \ "os" \ "name" match {
+        case JString(x) => x
+        case _ => null
+      },
+      payload \ "os" \ "version" match {
+        case JString(x) => x
+        case _ => null
+      },
+      payload \ "os" \ "locale" match {
+        case JString(x) => x
+        case _ => null
+      },
+
+      // Info about the sync.
+      stringFromSyncOrPayload("uid") match {
+        case null => return None // a required field.
+        case x => x
+      },
+
+      stringFromSyncOrPayload("deviceID"),
+
+      sync \ "when" match {
+        case JInt(x) => x.toLong
+        case _ => return None
+      },
+      sync \ "took" match {
+        case JInt(x) => x.toLong
+        case _ => return None
+      },
+      failureReasonToRow(sync \ "failureReason"),
+      statusToRow(sync \ "status"),
+      sync \ "why" match {
+        case JString(x) => x
+        case _ => null
+      },
+      toEnginesRows(sync \ "engines"),
+      sync \ "devices" match {
+        case devices @ JArray(_) => toDeviceRows(devices)
+        case _ => null
+      }
+    )
+
+    Some(row)
+  }
+
+  // Same as singleSyncPayloadToNestedRow, but creates a flat row.
+  private def singleSyncPayloadToFlatRows(ping: JValue, sync: JValue): List[Row] = {
+    val application = ping \ "application"
+    val payload = ping \ "payload"
+
+    def stringFromSyncOrPayload(s: String): String = {
+      sync \ s match {
+        case JString(x) => x
+        case _ =>
+          payload \ s match {
+            case JString(x) => x
+            case _ => null
+          }
+      }
+    }
+    val when = sync \ "when" match {
+      case JInt(x) => x.toLong
+      case _ => return List.empty
+    }
+
+    val syncDay = new DateTime(when).toDateTime.toString("yyyyMMdd")
+
+    val rowRepeatedPart = List(
+      // The metadata...
+      application \ "buildId" match {
+        case JString(x) => x
+        case _ => return List.empty // a required field.
+      },
+      application \ "displayVersion" match {
+        case JString(x) => x
+        case _ => return List.empty // a required field.
+      },
+      application \ "name" match {
+        case JString(x) => x
+        case _ => return List.empty // a required field.
+      },
+      application \ "version" match {
+        case JString(x) => x
+        case _ => return List.empty // a required field.
+      },
+      application \ "channel" match {
+        case JString(x) => x
+        case _ => return List.empty // a required field.
+      },
+
+      payload \ "os" \ "name" match {
+        case JString(x) => x
+        case _ => null
+      },
+      payload \ "os" \ "version" match {
+        case JString(x) => x
+        case _ => null
+      },
+      payload \ "os" \ "locale" match {
+        case JString(x) => x
+        case _ => null
+      },
+
+      // Info about the sync.
+      stringFromSyncOrPayload("uid") match {
+        case null => return List.empty // a required field.
+        case x => x
+      },
+
+      stringFromSyncOrPayload("deviceID"),
+      when,
+      sync \ "took" match {
+        case JInt(x) => x.toLong
+        case _ => return List.empty
+      },
+      failureReasonToRow(sync \ "failureReason"),
+      statusToRow(sync \ "status"),
+      sync \ "why" match {
+        case JString(x) => x
+        case _ => null
+      },
+      sync \ "devices" match {
+        case devices @ JArray(_) => toDeviceRows(devices)
+        case _ => null
+      },
+      sync \ "sync_id" match {
+        case JString(s) => s
+        case _ => UUID.randomUUID.toString
+      },
+      syncDay
+    )
+
+    val engineParts = sync \ "engines" match {
+      case JArray(a) =>
+        a.map(engine => {
+          val (batchesOut, sentOut, failedOut) = outgoingSummary(engine \ "outgoing")
+          val (appliedIn, failedIn, newFailedIn, reconciledIn) = incomingSummary(engine \ "incoming")
+          List(
+            engine \ "name" match {
+              case JString(x) => x
+              case _ => return null // engines must have a name!
+            },
+            engine \ "took" match {
+              case JInt(x) => x.toLong
+              case _ => 0L
+            },
+            engine \ "status" match {
+              case JString(x) => x
+              case _ => null
+            },
+            failureReasonToRow(engine \ "failureReason"),
+
+            appliedIn, failedIn, newFailedIn, reconciledIn,
+            batchesOut,
+            sentOut,
+            failedOut
+          )
+        })
+      case _ => return List.empty
+    }
+
+    engineParts.map(engineData =>
+      Row.fromSeq(rowRepeatedPart ++ engineData))
+  }
+
+  // Same as multiSyncPayloadToNestedRow, but creates flat rows.
+  private def multiSyncPayloadToFlatRows(ping: JValue, syncs: List[JValue]): List[Row] = {
+    syncs.flatMap(sync => singleSyncPayloadToFlatRows(ping, sync))
+  }
+
+  // Take an entire ping and return a list of rows with "nestedSyncType" as a schema.
+  def pingToNestedRows(ping: JValue): List[Row] = {
+    ping \ "payload" \ "syncs" match {
+      case JArray(x) => multiSyncPayloadToNestedRow(ping, x)
+      case _ =>
+        val row = singleSyncPayloadToNestedRow(ping, ping \ "payload")
+        row match {
+          case Some(x) => List(x)
+          case None => List()
+        }
+    }
+  }
+
+  // Take an entire ping and return a list of rows with "singleEngineFlatSyncType" as a schema.
+  def pingToFlatRows(ping: JValue): List[Row] = {
+    ping \ "payload" \ "syncs" match {
+      case JArray(x) => multiSyncPayloadToFlatRows(ping, x)
+      case _ => singleSyncPayloadToFlatRows(ping, ping \ "payload")
+    }
+  }
+
+}

--- a/src/test/scala/com/mozilla/telemetry/views/SyncFlatViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/SyncFlatViewTest.scala
@@ -1,0 +1,144 @@
+package com.mozilla.telemetry
+
+import com.mozilla.telemetry.utils.SyncPingConversion
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
+import org.apache.spark.sql.{Row, SQLContext, SparkSession}
+import org.apache.spark.{SparkConf, SparkContext}
+import org.joda.time.DateTime
+import org.json4s.JsonAST.{JArray, JNothing, JObject}
+import org.json4s.{DefaultFormats, JValue}
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.mutable
+
+class SyncFlatViewTest extends FlatSpec with Matchers {
+
+  "New Style SyncPing payload" can "be flattened" in {
+    val sparkConf = new SparkConf().setAppName("SyncPing")
+    sparkConf.setMaster(sparkConf.get("spark.master", "local[1]"))
+    val sc = new SparkContext(sparkConf)
+    sc.setLogLevel("WARN")
+    try {
+      val row = SyncPingConversion.pingToFlatRows(SyncViewTestPayloads.multiSyncPing)
+      val sqlContext = new SQLContext(sc)
+      val rdd = sc.parallelize(row.toSeq)
+      val dataframe = sqlContext.createDataFrame(rdd, SyncPingConversion.singleEngineFlatSyncType)
+
+      // verify the contents
+      validateSyncPing(dataframe.collect(), SyncViewTestPayloads.multiSyncPing)
+    } finally {
+      sc.stop()
+    }
+  }
+
+  "SyncPing records" can "be round-tripped to parquet as flat data" in {
+    val sparkConf = new SparkConf().setAppName("SyncPing")
+    sparkConf.setMaster(sparkConf.get("spark.master", "local[1]"))
+    val sc = new SparkContext(sparkConf)
+    sc.setLogLevel("WARN")
+    try {
+      val row = SyncPingConversion.pingToFlatRows(SyncViewTestPayloads.multiSyncPing)
+      // Write a parquet file with the rows.
+      val sqlContext = SparkSession.builder.appName("TestSyncPing").getOrCreate();
+      val rdd = sc.parallelize(row.toSeq)
+      val dataframe = sqlContext.createDataFrame(rdd, SyncPingConversion.singleEngineFlatSyncType)
+      val tempFile = com.mozilla.telemetry.utils.temporaryFileName()
+      dataframe.write.parquet(tempFile.toString)
+      // read it back in and verify it.
+      val localDataset = sqlContext.read.load(tempFile.toString)
+      localDataset.createOrReplaceTempView("sync")
+      val localDataframe = sqlContext.sql("SELECT * FROM sync")
+      validateSyncPing(localDataframe.collect(), SyncViewTestPayloads.multiSyncPing)
+    } finally {
+      sc.stop()
+    }
+  }
+
+  private def validateSyncPing(rows: Array[Row], ping: JValue) {
+    implicit val formats = DefaultFormats
+    val syncs = rows.groupBy(_.getAs[String]("sync_id"))
+    syncs.size should be (2)
+    val JArray(pingSyncs) = ping \ "payload" \ "syncs";
+    for ((_, syncRows) <- syncs) {
+      val Some(pingSync) = pingSyncs.find(p => (p \ "when").extract[Long] == syncRows(0).getAs[Long]("when"))
+      val JArray(pingEngines) = pingSync \ "engines"
+
+      val seen = mutable.Set.empty[String]
+
+      syncRows.size should be (6)
+
+      for (sync <- syncRows) {
+        // check common data
+        sync.getAs[String]("app_build_id") should be((ping \ "application" \ "buildId").extract[String])
+        sync.getAs[String]("app_display_version") should be((ping \ "application" \ "displayVersion").extract[String])
+        sync.getAs[String]("app_name") should be((ping \ "application" \ "name").extract[String])
+        sync.getAs[String]("app_version") should be((ping \ "application" \ "version").extract[String])
+        sync.getAs[String]("app_channel") should be((ping \ "application" \ "channel").extract[String])
+
+        sync.getAs[String]("os") should be((ping \ "payload" \ "os" \ "name").extract[String])
+        sync.getAs[String]("os_version") should be((ping \ "payload" \ "os" \ "version").extract[String])
+        sync.getAs[String]("os_locale") should be((ping \ "payload" \ "os" \ "locale").extract[String])
+
+        sync.getAs[String]("uid") should be((pingSync \ "uid").extract[String])
+        sync.getAs[String]("device_id") should be((pingSync \ "deviceID").extract[String])
+        sync.getAs[Long]("took") should be((pingSync \ "took").extract[Long])
+        sync.getAs[GenericRowWithSchema]("status") should be(null)
+        sync.getAs[String]("sync_day") should be (new DateTime((pingSync \ "when").extract[Long]).toDateTime.toString("yyyyMMdd"))
+
+        // engine specific data
+        val engineName = sync.getAs[String]("engine_name")
+        seen.contains(engineName) should be(false)
+        seen.add(engineName)
+        val Some(pingEngine) = pingEngines.find(e => (e \ "name").extract[String] == engineName)
+
+        sync.getAs[Long]("engine_took") should be ((pingEngine \ "took").extractOrElse[Long](0))
+        sync.getAs[String]("engine_status") should be ((pingEngine \ "status").extractOrElse[String](null))
+
+        // check failure
+        sync.getAs[GenericRowWithSchema]("engine_failure_reason") match {
+          case null =>
+            (pingEngine \ "failureReason") should be (JNothing)
+          case reason =>
+            reason.getAs[String]("name") should be ((pingEngine \ "failureReason" \ "name").extract[String])
+            reason.getAs[String]("value") should be ((pingEngine \ "failureReason" \ "code").extract[String])
+        }
+        // check incoming
+        val (expectedApplied, expectedFailed, expectedNewFailed, expectedReconciled) = pingEngine \ "incoming" match {
+          case JObject(_) => (
+            (pingEngine \ "incoming" \ "applied").extractOrElse[Long](0),
+            (pingEngine \ "incoming" \ "failed").extractOrElse[Long](0),
+            (pingEngine \ "incoming" \ "newFailed").extractOrElse[Long](0),
+            (pingEngine \ "incoming" \ "reconciled").extractOrElse[Long](0)
+          )
+          case _ =>
+            (0L, 0L, 0L, 0L)
+        }
+        sync.getAs[Long]("engine_incoming_applied") should be(expectedApplied)
+        sync.getAs[Long]("engine_incoming_failed") should be(expectedFailed)
+        sync.getAs[Long]("engine_incoming_new_failed") should be(expectedNewFailed)
+        sync.getAs[Long]("engine_incoming_reconciled") should be(expectedReconciled)
+
+        // Check outgoing
+        val (expectedOutCount, expectedOutSent, expectedOutFailed) = pingEngine \ "outgoing" match {
+          case JArray(l) => (
+            l.size.toLong,
+            l.map(x => (x \ "sent").extractOrElse[Long](0)).sum,
+            l.map(x => (x \ "failed").extractOrElse[Long](0)).sum
+          )
+          case JObject(_) => (
+            1L,
+            (pingEngine \ "outgoing" \ "sent").extractOrElse[Long](0),
+            (pingEngine \ "outgoing" \ "sent").extractOrElse[Long](0)
+          )
+          case _ =>
+            (0L, 0L, 0L)
+        }
+        sync.getAs[Long]("engine_outgoing_batch_count") should be(expectedOutCount)
+        sync.getAs[Long]("engine_outgoing_batch_total_sent") should be(expectedOutSent)
+        sync.getAs[Long]("engine_outgoing_batch_total_failed") should be(expectedOutFailed)
+      }
+    }
+  }
+
+
+}

--- a/src/test/scala/com/mozilla/telemetry/views/SyncViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/SyncViewTest.scala
@@ -1,6 +1,6 @@
 package com.mozilla.telemetry
 
-import com.mozilla.telemetry.views.SyncPingConverter
+import com.mozilla.telemetry.utils.SyncPingConversion
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.{Row, SQLContext}
 import org.apache.spark.{SparkConf, SparkContext}
@@ -19,11 +19,11 @@ class SyncViewTest extends FlatSpec with Matchers{
     implicit val formats = DefaultFormats
     sc.setLogLevel("WARN")
     try {
-      val row = SyncPingConverter.pingToRows(SyncViewTestPayloads.singleSyncPing)
+      val row = SyncPingConversion.pingToNestedRows(SyncViewTestPayloads.singleSyncPing)
       val sqlContext = new SQLContext(sc)
       val rdd = sc.parallelize(row.toSeq)
 
-      val dataframe = sqlContext.createDataFrame(rdd, SyncPingConverter.syncType)
+      val dataframe = sqlContext.createDataFrame(rdd, SyncPingConversion.nestedSyncType)
 
       // verify the contents.
       dataframe.count() should be (1)
@@ -57,10 +57,10 @@ class SyncViewTest extends FlatSpec with Matchers{
     val sc = new SparkContext(sparkConf)
     sc.setLogLevel("WARN")
     try {
-      val row = SyncPingConverter.pingToRows(SyncViewTestPayloads.multiSyncPing)
+      val row = SyncPingConversion.pingToNestedRows(SyncViewTestPayloads.multiSyncPing)
       val sqlContext = new SQLContext(sc)
       val rdd = sc.parallelize(row.toSeq)
-      val dataframe = sqlContext.createDataFrame(rdd, SyncPingConverter.syncType)
+      val dataframe = sqlContext.createDataFrame(rdd, SyncPingConversion.nestedSyncType)
 
       // verify the contents
       validateMultiSyncPing(dataframe.collect(), SyncViewTestPayloads.multiSyncPing)
@@ -75,11 +75,11 @@ class SyncViewTest extends FlatSpec with Matchers{
     val sc = new SparkContext(sparkConf)
     sc.setLogLevel("WARN")
     try {
-      val row = SyncPingConverter.pingToRows(SyncViewTestPayloads.multiSyncPing)
+      val row = SyncPingConversion.pingToNestedRows(SyncViewTestPayloads.multiSyncPing)
       // Write a parquet file with the rows.
       val sqlContext = new SQLContext(sc)
       val rdd = sc.parallelize(row.toSeq)
-      val dataframe = sqlContext.createDataFrame(rdd, SyncPingConverter.syncType)
+      val dataframe = sqlContext.createDataFrame(rdd, SyncPingConversion.nestedSyncType)
       val tempFile = com.mozilla.telemetry.utils.temporaryFileName()
       dataframe.write.parquet(tempFile.toString)
       // read it back in and verify it.
@@ -98,11 +98,11 @@ class SyncViewTest extends FlatSpec with Matchers{
     val sc = new SparkContext(sparkConf)
     sc.setLogLevel("WARN")
     try {
-      val row = SyncPingConverter.pingToRows(SyncViewTestPayloads.complexSyncPing)
+      val row = SyncPingConversion.pingToNestedRows(SyncViewTestPayloads.complexSyncPing)
       // Write a parquet file with the rows.
       val sqlContext = new SQLContext(sc)
       val rdd = sc.parallelize(row.toSeq)
-      val dataframe = sqlContext.createDataFrame(rdd, SyncPingConverter.syncType)
+      val dataframe = sqlContext.createDataFrame(rdd, SyncPingConversion.nestedSyncType)
       val tempFile = com.mozilla.telemetry.utils.temporaryFileName()
       dataframe.write.parquet(tempFile.toString)
       // read it back in and verify it.
@@ -121,11 +121,11 @@ class SyncViewTest extends FlatSpec with Matchers{
     val sc = new SparkContext(sparkConf)
     sc.setLogLevel("WARN")
     try {
-      val row = SyncPingConverter.pingToRows(SyncViewTestPayloads.multiSyncPingWithTopLevelIds)
+      val row = SyncPingConversion.pingToNestedRows(SyncViewTestPayloads.multiSyncPingWithTopLevelIds)
       // Write a parquet file with the rows.
       val sqlContext = new SQLContext(sc)
       val rdd = sc.parallelize(row.toSeq)
-      val dataframe = sqlContext.createDataFrame(rdd, SyncPingConverter.syncType)
+      val dataframe = sqlContext.createDataFrame(rdd, SyncPingConversion.nestedSyncType)
       // Note: We intentionally validate with a *different* json object from the one we parsed.
       validateMultiSyncPing(dataframe.collect(), SyncViewTestPayloads.multiSyncPing)
     } finally {


### PR DESCRIPTION
Ideally I'd like for my patch for [Bug 1390320](https://bugzilla.mozilla.org/show_bug.cgi?id=1390320) to land first, but I'm getting it up without waiting, since it is not a small change (although I think the github diff viewer is making it look bigger than it is) and it wouldn't really surprise me that much if it were a little controversial. Once that's available, I'll probably change SyncFlatView's loop body around a bit to take advantage of it.

Since the github diff doesn't seem to capture this well, most of the code in SyncPingConversion.scala previously lived in SyncView.scala.

This also addresses a very small issue ([Bug 1389233](https://bugzilla.mozilla.org/show_bug.cgi?id=1389233)), where android and iOS will write outgoing arrays as an object. This is a bug in them that is being addressed, but we'd like the (historical) data. I did it here since this code changes the outgoing handling anyway, so it is easy to do as part of this patch.

Somewhat rambling issue summary and background:

`sync_summary` has a good amount of data and has been useful for ad-hoc analysis, but has essentially been unqueryable in redash. Every query times out or exausts its available resources in one way or another. This is, essentially, because of a `cross join unnest` required since we store the engine sync data as an `engines` array in the sync row. That's more or less what this view addresses, by flattening that array out.

Additionally, frequently the parquet files written out by SyncView, are unreadable, due to, AFAICT, [this bug in parquet](https://issues.apache.org/jira/browse/PARQUET-511) (although I'm not 100% confident that's the bug, the error log is almost identical, but it seems... surprising, that we'd hit the limit). Regardless of the cause, reading a parquet file written by the SyncView seems to have a decent chance of failing in practice.

Anyway, I initially wanted to write this as a python rollup view. Due to performance issues around UDFs implemented in python (Even a trivial one caused a single day of data to take several hours), we wouldn't have as rich of data as this code provides. But even ignoring that, the headaches associated with the busted parquet files (as well as just the extremely large size of the data) made this really painful. After struggling with this for a while, I ended up asking @acmiyaguchi if he thought I could just land it as another sync view, and he gave me some indication along the lines of "well, if that's the best place for it..." (although I'm aware in an ideal world it probably is not).

So I prototyped this in a zeppelin notebook based on a modified version of the SyncView code, ran it across a little over three months, and ended up with something in redash that we can actually query. Even better, most of the queries complete very quickly.

Regarding replacing the current SyncView code vs adding a new sync view: We do have code that depends on the current view (not much), and the data the code I'm landing generates is a bit more annoying to work with. It also doesn't include everything we want in every situation, just the stuff we want to be able to directly query in redash. That said, if having two views into the sync ping data in this repo is completely abhorrent, we could probably include more data here, and change some other stuff on our end to make this doable.