### PR TITLE
Fix the MainSummaryView to correctly find addonDetails

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -366,6 +366,7 @@ object MainSummaryView {
       // Don't compute the expensive stuff until we need it. We may skip a record
       // due to missing required fields.
       lazy val addons = parse(fields.getOrElse("environment.addons", "{}").asInstanceOf[String])
+      lazy val addonDetails = parse(fields.getOrElse("payload.addonDetails", "{}").asInstanceOf[String])
       lazy val payload = parse(message.payload.getOrElse(fields.getOrElse("submission", "{}")).asInstanceOf[String])
       lazy val application = payload \ "application"
       lazy val build = parse(fields.getOrElse("environment.build", "{}").asInstanceOf[String])
@@ -645,7 +646,7 @@ object MainSummaryView {
         MainPing.getSearchCounts(keyedHistograms("parent") \ "SEARCH_COUNTS").orNull,
 
         getActiveAddons(addons \ "activeAddons").orNull,
-        getDisabledAddons(addons \ "activeAddons", payload \ "payload" \ "addonDetails" \ "XPI").orNull,
+        getDisabledAddons(addons \ "activeAddons", addonDetails \ "XPI").orNull,
         getTheme(addons \ "theme").orNull,
         settings \ "blocklistEnabled" match {
           case JBool(x) => x

--- a/src/test/scala/com/mozilla/telemetry/views/MainSummaryViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/MainSummaryViewTest.scala
@@ -171,18 +171,14 @@ class MainSummaryViewTest extends FlatSpec with Matchers{
       Map(
         "documentId" -> "foo",
         "submissionDate" -> "1234",
-        "submission" -> """{
-          "payload": {
-            "addonDetails": {
-              "XPI": {
-                "some-disabled-addon-id": {
-                  "dont-care": "about-this-data",
-                  "we-discard-this": 11
-                },
-                "active-addon-id": {
-                  "dont-care": 12
-                }
-              }
+        "payload.addonDetails" -> """{
+          "XPI": {
+            "some-disabled-addon-id": {
+              "dont-care": "about-this-data",
+              "we-discard-this": 11
+            },
+            "active-addon-id": {
+              "dont-care": 12
             }
           }
         }""",


### PR DESCRIPTION
Turns out I was looking up the field in the wrong data structure: `payload` is not the ping payload, but rather the message payload. I've changed this accordingly and I'm re-generating the dataset in a test bucket.