### PR TITLE
Add the "disabled_addons_ids" field to the TAAR HBase

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/HBaseAddonRecommenderView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/HBaseAddonRecommenderView.scala
@@ -87,7 +87,8 @@ object HBaseAddonRecommenderView {
             $"scalar_parent_browser_engagement_tab_open_event_count",
             $"scalar_parent_browser_engagement_total_uri_count",
             $"scalar_parent_browser_engagement_unique_domains_count",
-            $"active_addons")
+            $"active_addons",
+            $"disabled_addons_ids")
 
         // Join the two tables: only the elements in both dataframes will make it
         // through.

--- a/src/test/scala/com/mozilla/telemetry/views/HBaseAddonRecommenderViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/HBaseAddonRecommenderViewTest.scala
@@ -17,7 +17,8 @@ case class TestMainSummaryPing(client_id: Option[String],
                                scalar_parent_browser_engagement_tab_open_event_count: Option[Long] = None,
                                scalar_parent_browser_engagement_total_uri_count: Option[Long] = None,
                                scalar_parent_browser_engagement_unique_domains_count: Option[Long] = None,
-                               active_addons: Option[String] = None)
+                               active_addons: Option[String] = None,
+                               disabled_addons_ids: Option[String] = None)
 
 class HBaseAddonRecommenderViewTest extends FlatSpec with Matchers with BeforeAndAfterAll {
   val tableName = HBaseAddonRecommenderView.tableName


### PR DESCRIPTION
This fields contains the list of addon ids that were disabled and are not reported in `active_addons`. See
bug 1390814.