### PR TITLE
Add select only used columns, add permutations column and persist res…

### DIFF
--- a/src/test/scala/com/mozilla/telemetry/views/ExperimentAnalysisViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/ExperimentAnalysisViewTest.scala
@@ -162,11 +162,11 @@ class ExperimentAnalysisViewTest extends FlatSpec with Matchers with BeforeAndAf
       .mapValues(_.size)
 
     // 0 should map to "branch1", first alphabetically
-    counts(0x00) should be (5000 +- 100)
+    counts(0x00) should be (100 +- 15)
     // 1 should map to "branch2", second alphabetically
-    counts(0x01) should be (10000 +- 100)
+    counts(0x01) should be (200 +- 30)
     // 2 should map to "control", last alphabetically
-    counts(0x02) should be (10000 +- 100)
+    counts(0x02) should be (200 +- 30)
 
     // the permutations for client_id "a" should be the same
     res(0).getAs[Seq[Byte]](0) should be (res(1).getAs[Seq[Byte]](0))


### PR DESCRIPTION
…ulting dataset

I ran a couple different trials to tune this and using a 10-node cluster this dropped the job's runtime significantly.

One note: I reduced the number of permutations drastically -- just *generating* 5000 increased the job time drastically (largely because of storage, I think, and not computation) and we probably only need 100 to get a decent confidence interval for the p-value in most cases. If we need more for specific metrics, we can generate them on the fly, but I think we can probably start with 100 and work our way up if we need to.