### PR TITLE
Validate experiments data before aggregating

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/experiments/analyzers/ScalarAnalyzer.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/analyzers/ScalarAnalyzer.scala
@@ -96,6 +96,8 @@ class BooleanScalarAnalyzer(name: String, md: ScalarDefinition, df: DataFrame)
   override type PreAggregateRowType = BooleanScalarMapRow
   val aggregator = BooleanAggregator
 
+  override def validateRow(row: BooleanScalarMapRow): Boolean = row.metric.isDefined
+
   def collapseKeys(formatted: DataFrame): Dataset[BooleanScalarMapRow] = {
     import df.sparkSession.implicits._
     val s = if (md.keyed) formatted.as[KeyedBooleanScalarRow] else formatted.as[BooleanScalarRow]
@@ -107,6 +109,10 @@ class UintScalarAnalyzer(name: String, md: ScalarDefinition, df: DataFrame)
   extends MetricAnalyzer[Int](name, md, df) {
   override type PreAggregateRowType = UintScalarMapRow
   val aggregator = UintAggregator
+  override def validateRow(row: UintScalarMapRow): Boolean = row.metric match {
+    case Some(m) => m.keys.forall(_ >= 0)
+    case None => false
+  }
 
   def collapseKeys(formatted: DataFrame): Dataset[UintScalarMapRow] = {
     import df.sparkSession.implicits._
@@ -120,6 +126,11 @@ class LongScalarAnalyzer(name: String, md: ScalarDefinition, df: DataFrame)
   override type PreAggregateRowType = LongScalarMapRow
   val aggregator = LongAggregator
 
+  override def validateRow(row: LongScalarMapRow): Boolean = row.metric match {
+    case Some(m) => m.keys.forall(_ >= 0L)
+    case None => false
+  }
+
   def collapseKeys(formatted: DataFrame): Dataset[LongScalarMapRow] = {
     import df.sparkSession.implicits._
     val s = if (md.keyed) formatted.as[KeyedLongScalarRow] else formatted.as[LongScalarRow]
@@ -131,6 +142,8 @@ class StringScalarAnalyzer(name: String, md: ScalarDefinition, df: DataFrame)
   extends MetricAnalyzer[String](name, md, df) {
   override type PreAggregateRowType = StringScalarMapRow
   val aggregator = StringAggregator
+
+  override def validateRow(row: StringScalarMapRow): Boolean = row.metric.isDefined
 
   def collapseKeys(formatted: DataFrame): Dataset[StringScalarMapRow] = {
     import df.sparkSession.implicits._

--- a/src/test/scala/com/mozilla/telemetry/experiments/analyzers/ScalarAnalyzerTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/experiments/analyzers/ScalarAnalyzerTest.scala
@@ -35,6 +35,7 @@ class ScalarAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase {
         Some(false), Some(keyed_boolean2), Some("world"), Some(keyed_string)),
       ScalarExperimentDataset("experiment1", "control", Some(5), Some(keyed_uint),
         Some(true), Some(keyed_boolean2), Some("hello"), Some(keyed_string)),
+      ScalarExperimentDataset("experiment1", "control", Some(-1), Some(Map("test" -> -1)), None, None, None, None),
       ScalarExperimentDataset("experiment1", "branch1", Some(1), Some(keyed_uint),
         Some(true), Some(keyed_boolean1), Some("hello"), Some(keyed_string)),
       ScalarExperimentDataset("experiment1", "branch2", Some(1), Some(keyed_uint),
@@ -189,5 +190,22 @@ class ScalarAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase {
         stringsToPoints(List((0, "hello", 2), (1, "world", 2))), None)
     )
     assert(actual == expected)
+  }
+
+  "Invalid scalars" should "be filtered out" in {
+    val df = fixture
+    val analyzer = ScalarAnalyzer.getAnalyzer("uint_scalar",
+      UintScalar(false, "name"),
+      df.where(df.col("experiment_id") === "experiment1")
+    )
+    val actual = analyzer.analyze().collect().filter(_.experiment_branch == "control").head
+    assert(actual.n == 3L)
+
+    val keyed_analyzer = ScalarAnalyzer.getAnalyzer("keyed_uint_scalar",
+      UintScalar(true, "name"),
+      df.where(df.col("experiment_id") === "experiment1")
+    )
+    val keyed_actual = analyzer.analyze().collect().filter(_.experiment_branch == "control").head
+    assert(keyed_actual.n == 3L)
   }
 }


### PR DESCRIPTION
- Adds a method to histogram definitions returning its valid bucket values
- Validates experiments data before aggregation to filter out negative values and validate incoming buckets

Closes mozilla/experiments-viewer#225 and mozilla/experiments-viewer#260