### PR TITLE
Bug 1381840 - Add 1 day Firefox retention view using HLL

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/RetentionView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/RetentionView.scala
@@ -1,0 +1,89 @@
+package com.mozilla.telemetry.views
+
+
+import com.mozilla.telemetry.utils.UDFs._
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.functions._
+import org.rogach.scallop._
+
+
+object RetentionView {
+  class Conf(args: Array[String]) extends ScallopConf(args) {
+    val date = opt[String]("date", descr = "Run date for this job", required = true)
+    val input = opt[String]("input", descr = "Source for parquet data", required = true)
+    val bucket = opt[String]("bucket", descr = "output bucket", required = true)
+    val prefix = opt[String]("prefix",
+      descr = "output prefix",
+      required = false,
+      default = Some("retention/v1")
+    )
+    val hllBits = opt[Int](
+      "hll-bits",
+      descr = "Number of bits to use for hll. 13 bits is 8192 bytes with an error of 0.0115. Defaults to 13.",
+      required = false,
+      default = Some(13)
+    )
+    verify()
+  }
+
+  val dimensions: List[String] = List(
+    "subsession_start",
+    "profile_creation",
+    "days_since_creation",
+    "channel",
+    "app_version",
+    "geo",
+    "distribution_id",
+    "is_funnelcake",
+    "source",
+    "medium",
+    "content",
+    "sync_usage",
+    "is_active"
+  )
+
+  val metrics: List[String] = List(
+    "usage_hours",
+    "sum_squared_usage_hours",
+    "total_uri_count",
+    "unique_domains_count"
+  )
+
+
+  def transform(dataframe: DataFrame, hllBits: Int): DataFrame = {
+    val expr = List(s"hll_create(client_id, $hllBits) as hll") ++ dimensions ++ metrics
+
+    dataframe.selectExpr(expr:_*)
+      .groupBy(dimensions.head, dimensions.tail:_*)
+      .agg(
+        HllMerge(col("hll")).as("hll"),
+        sum("usage_hours").as("usage_hours"),
+        sum("sum_squared_usage_hours").as("sum_squared_usage_hours"),
+        sum("total_uri_count").as("total_uri_count"),
+        avg("unique_domains_count").as("unique_domains_count")
+      )
+  }
+
+  def main(args: Array[String]) {
+    val conf = new Conf(args)
+
+    val spark = SparkSession
+      .builder()
+      .appName(s"Retention")
+      .getOrCreate()
+
+    spark.registerUDFs
+
+    val date = conf.date()
+    val df = spark.read.parquet(conf.input())
+
+    val result = transform(df, conf.hllBits())
+
+    result
+      .write
+      .mode("overwrite")
+      .parquet(s"s3://${conf.bucket()}/${conf.prefix()}/start_date=${conf.date()}")
+
+    spark.stop()
+  }
+}

--- a/src/test/scala/com/mozilla/telemetry/views/RetentionViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/RetentionViewTest.scala
@@ -1,0 +1,105 @@
+package com.mozilla.telemetry
+
+import com.mozilla.telemetry.views.RetentionView
+import com.mozilla.telemetry.utils.UDFs._
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.functions.{col, expr}
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+
+case class ProcessedRetentionRow(
+                                  client_id: String,
+                                  subsession_start: String,
+                                  profile_creation: String,
+                                  days_since_creation: Long,
+                                  channel: String,
+                                  app_version: String,
+                                  geo: String,
+                                  distribution_id: String,
+                                  is_funnelcake: Boolean,
+                                  source: String,
+                                  medium: String,
+                                  campaign: String,
+                                  content: String,
+                                  sync_usage: String,
+                                  is_active: Boolean,
+                                  usage_hours: Double,
+                                  sum_squared_usage_hours: Double,
+                                  total_uri_count: Long,
+                                  unique_domains_count: Long
+                                )
+
+
+class RetentionViewTest extends FlatSpec with Matchers with BeforeAndAfterAll {
+  val spark: SparkSession =
+    SparkSession.builder()
+      .appName("Retention Aggregate Test")
+      .master("local[*]")
+      .getOrCreate()
+  spark.registerUDFs
+
+  val sample = ProcessedRetentionRow(
+    client_id = "1",
+    subsession_start = "2017-01-15",
+    profile_creation = "2017-01-12",
+    days_since_creation = 3,
+    channel = "release",
+    app_version = "57.0.0",
+    geo = "US",
+    distribution_id = "mozilla57",
+    is_funnelcake = true,
+    source = "source-value",
+    medium = "medium-value",
+    campaign = "campaign-value",
+    content = "content-value",
+    sync_usage = "multiple",
+    is_active = true,
+    usage_hours = 1.0,
+    sum_squared_usage_hours = 1.0,
+    total_uri_count = 20,
+    unique_domains_count = 3
+  )
+
+  val predata = Seq(
+    sample.copy(client_id = "1_dup", channel = "release"),
+    sample.copy(client_id = "1_dup", channel = "release", unique_domains_count = 0),
+    sample.copy(client_id = "2", channel = "release"),
+    sample.copy(client_id = "3", channel = "release"),
+    sample.copy(client_id = "4", channel = "beta"),
+    sample.copy(client_id = "5_dup", channel = "beta"),
+    sample.copy(client_id = "5_dup", channel = "beta"),
+    sample.copy(client_id = "5_dup", channel = "beta"),
+    sample.copy(client_id = "5_dup", channel = "beta")
+  )
+
+  // Fix the value of the number of HLL bits for this test
+  val test_transform: (DataFrame) =>  DataFrame = RetentionView.transform(_: DataFrame, 13)
+
+  "unique_domains_count" can "be counted" in {
+    import spark.implicits._
+
+    val data = predata.toDS().toDF()
+    val res = test_transform(data).where(col("channel") === "release")
+    // (3 pings each with with 3 unique domains) / 4 pings
+    // The average is on a per-session basis as opposed to per-client
+    res.head.getAs[Double]("unique_domains_count") should be(2.25)
+  }
+
+  "Client aggregates" can "be counted without duplicates" in {
+    import spark.implicits._
+
+    val data = predata.toDS().toDF()
+
+    val grouped =
+      test_transform(data)
+        .groupBy("channel")
+        .agg(HllMerge(col("hll")).alias("hll"))
+        .select(expr(s"$HllCardinality(hll)"))
+
+    grouped.where(col("channel") === "release").head.getLong(0) should be(3)
+    grouped.where(col("channel") === "beta").head.getLong(0) should be(2)
+  }
+
+  override def afterAll() {
+    spark.stop()
+  }
+}


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1381840)

This PR is used in conjunction with [mozilla/python_mozetl #133](https://github.com/mozilla/python_mozetl/pull/133) to generate a 1 day Firefox retention dataset.

The mozetl script will preprocess the data in the following stages:
1. Convert `new_profile_ping_parquet` to a subset of `main_summary_v4`
2. Join `new_profile` with `main_summary` and select the subset for the retention period
3. Build a select expression for cleaning and derived columns and apply the transformation
4. Write the cleaned intermediate data into HDFS

This job will carry out the aggregation of the final data, and store the data to the final output location.

As opposed to previous versions of `retention_dev` which use the `GenericCountView`, `retention_dev_v3` uses the HLL UDFs directly. The GenericCountView was immensely useful for creating the first two revisions of this dataset, but deciding on a good generic API for passing in aggregate functions via the command line is hard.

It would be nice to have access to the `spark-hyperloglog` library via `py4j`, but there are [problems with calling `hll_cardinality`](https://bugzilla.mozilla.org/show_bug.cgi?id=1305087) that I have verified for myself. Now that pyspark can be installed via pip, it would be attractive to extend `spark-hyperloglog` with a pyspark binding. 

Finally, the entire job wasn't written directly as a scala view because the cleaning subroutines and structure of the `daily_retention` job is heavily influenced by the third revision of the `churn` code. The testing harness used in `churn` can be reused to validate pre-aggregate transformations of the intermediate data. 