### PR TITLE
Bug 1344259: Support for content and addon events

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/utils/Events.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/Events.scala
@@ -70,14 +70,16 @@ object Event {
       case _ => None
     }
   }
+
+  def fromList(event: List[Any], process: String): Option[Event] = {
+    fromList(event).map(e => e.copy(
+      mapValues = Some(Map("telemetry_process" -> process) ++ e.mapValues.getOrElse(Map()))))
+  }
 }
 
 object Events {
-  def getEvents(events: JValue): Option[List[Row]] = {
-    extractEvents(events).flatMap(eventToRow) match {
-      case Nil => None
-      case x => Some(x)
-    }
+  def getEvents(events: JValue, process: String): List[Row] = {
+    extractEvents(events).flatMap(e => eventToRow(e, process))
   }
 
   def extractEvents(events: JValue): List[List[Any]] = {
@@ -88,8 +90,8 @@ object Events {
     }
   }
 
-  def eventToRow(event: List[Any]): Option[Row] = {
-    Event.fromList(event) match {
+  def eventToRow(event: List[Any], process: String): Option[Row] = {
+    Event.fromList(event, process) match {
       case Some(e) => Some(e.toRow)
       case _ => None
     }

--- a/src/main/scala/com/mozilla/telemetry/views/MainEventsView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainEventsView.scala
@@ -93,7 +93,7 @@ object MainEventsView {
       .select("document_id", "client_id", "normalized_channel", "country", "locale", "app_name", "app_version", "os",
         "os_version", "e10s_enabled", "e10s_cohort", "subsession_start_date", "subsession_length", "sync_configured",
         "sync_count_desktop", "sync_count_mobile", "timestamp", "sample_id", "active_experiment_id",
-        "active_experiment_branch", "events")
+        "active_experiment_branch", "experiments", "events")
       .where("client_id is not null")
       .where("events is not null")
 
@@ -108,7 +108,7 @@ object MainEventsView {
     exploded.selectExpr("document_id", "client_id", "normalized_channel", "country", "locale", "app_name",
       "app_version", "os", "os_version", "e10s_enabled", "e10s_cohort", "subsession_start_date", "subsession_length",
       "sync_configured", "sync_count_desktop", "sync_count_mobile", "timestamp", "sample_id", "active_experiment_id",
-      "active_experiment_branch",
+      "active_experiment_branch", "experiments",
       // Flatten nested event fields.
       "events.timestamp as event_timestamp",
       "events.category as event_category",

--- a/src/main/scala/com/mozilla/telemetry/views/MainEventsView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainEventsView.scala
@@ -115,6 +115,7 @@ object MainEventsView {
       "events.method as event_method",
       "events.object as event_object",
       "events.string_value as event_string_value",
-      "events.map_values as event_map_values")
+      "events.map_values as event_map_values",
+      "events.map_values['telemetry_process'] as event_process")
   }
 }

--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -427,7 +427,11 @@ object MainSummaryView {
       lazy val weaveConfigured = MainPing.booleanHistogramToBoolean(histograms("parent") \ "WEAVE_CONFIGURED")
       lazy val weaveDesktop = MainPing.enumHistogramToCount(histograms("parent") \ "WEAVE_DEVICE_COUNT_DESKTOP")
       lazy val weaveMobile = MainPing.enumHistogramToCount(histograms("parent") \ "WEAVE_DEVICE_COUNT_MOBILE")
-      lazy val parentEvents = payload \ "payload" \ "processes" \ "parent" \ "events"
+
+      lazy val events = ("dynamic" :: MainPing.ProcessTypes).map {
+        p => p -> payload \ "payload" \ "processes" \ p \ "events"
+      }
+
       lazy val experiments = parse(fields.getOrElse("environment.experiments", "{}").asInstanceOf[String])
 
       val sslHandshakeResultKeys = (0 to 671).map(_.toString)
@@ -690,7 +694,8 @@ object MainSummaryView {
           case _ => null
         },
         getOldUserPrefs(settings \ "userPrefs").orNull,
-        Events.getEvents(parentEvents).orNull,
+
+        Option(events.flatMap {case (p, e) => Events.getEvents(e, p)}).filter(!_.isEmpty).orNull,
 
         // bug 1339655
         MainPing.enumHistogramBucketCount(histograms("parent") \ "SSL_HANDSHAKE_RESULT", sslHandshakeResultKeys.head).orNull,

--- a/src/test/scala/com/mozilla/telemetry/views/MainEventsViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/MainEventsViewTest.scala
@@ -32,6 +32,7 @@ case class TestMainSummary(document_id: String,
                            sample_id: Long,
                            active_experiment_id: String,
                            active_experiment_branch: String,
+                           experiments: Map[String, String],
                            events: Option[Seq[Event]])
 
 
@@ -54,7 +55,7 @@ class MainEventsViewTest extends FlatSpec with Matchers{
       val m = TestMainSummary("6609b4d8-94d4-4e87-9f6f-80183079ff1b",
         "25a00eb7-2fd8-47fd-8d3f-223af3e5c68f", "release", "US", "en-US", "Firefox", "50.1.0", "Windows_NT", "10.0",
         true, "test", "2017-01-23T20:54:10.123Z", 1000, false, 0, 0, 1485205018000000000L, 42, "test_experiment",
-        "test_branch", Some(Seq(e)))
+        "test_branch", Map("experiment1" -> "branch1"), Some(Seq(e)))
 
       val pings : DataFrame = Seq(
         m,


### PR DESCRIPTION
- Adds event extraction from content and dynamic processes in main summary (note: we're sticking the process name into the map_values field due to the schema evolution bug for nested objects)
- Moves the process name into a top-level field in the events table
- Not related to the bug, but since I was looking at it: adds the "experiments" block to the events table