### PR TITLE
Confidence intervals

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/experiments/statistics/DescriptiveStatistics.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/statistics/DescriptiveStatistics.scala
@@ -6,31 +6,49 @@ import scala.annotation.tailrec
 import scala.collection.Map
 
 
-sealed abstract class DescriptiveStatistic(h: Map[Long, HistogramPoint]) {
+sealed abstract class DescriptiveStatistic(actual: Map[Long, HistogramPoint],
+                                           resampled: Option[List[Map[Long, HistogramPoint]]] = None) {
+  val Alpha = 0.05
   val name: String
-  lazy val total = h.values.map(_.count).sum
+  lazy val total = actual.values.map(_.count).sum
 
-  def run: Double
+  def run(h: Map[Long, HistogramPoint] = actual): Double
+
+  def confidenceIntervals: Option[(Double, Double)] = {
+    resampled.map {
+      l => val stats = l.map(run(_)).sorted
+        // currently using the super simple percentile version instead of the BCA algorithm
+        val halfAlpha = Alpha / 2
+        val lowIdx = scala.math.floor(stats.length * halfAlpha).toInt
+        val highIdx = scala.math.ceil(stats.length * (1 - halfAlpha)).toInt
+        (stats(lowIdx), stats(highIdx))
+    }
+  }
 
   def asStatistic: Statistic = {
-    Statistic(None, name, run)
+    val c = confidenceIntervals
+    Statistic(None, name, run(), c.map(_._1), c.map(_._2), c.map(_ => Alpha))
   }
 }
 
-case class Mean(h: Map[Long, HistogramPoint]) extends DescriptiveStatistic(h) {
+case class Mean(actual: Map[Long, HistogramPoint], resampled: Option[List[Map[Long, HistogramPoint]]] = None)
+  extends DescriptiveStatistic(actual, resampled) {
   val name = "Mean"
-  def run: Double = {
+  def run(h: Map[Long, HistogramPoint] = actual): Double = {
     h.map { case (bucket, point) => bucket * point.count }.sum / total
   }
 }
 
-case class Percentile(h: Map[Long, HistogramPoint], percentile: Double, name: String)
-  extends DescriptiveStatistic(h) {
+case class Percentile(actual: Map[Long, HistogramPoint],
+                      percentile: Double,
+                      name: String,
+                      resampled: Option[List[Map[Long, HistogramPoint]]] = None)
+  extends DescriptiveStatistic(actual, resampled) {
   protected def percentileIndex: Double = {
     total * percentile
   }
 
-  def run: Double =  {
+  def run(h: Map[Long, HistogramPoint] = actual): Double =  {
     val i = percentileIndex
     val rem = i % 1
 
@@ -39,11 +57,11 @@ case class Percentile(h: Map[Long, HistogramPoint], percentile: Double, name: St
     } else {
       // This scales the percentile steps linearly, which is not quite accurate for exponential histograms, esp
       // for, say, 95th percentile calculations. Fwiw, this behavior is the default in Pandas
-      getNthValue(i.floor.toLong) * (1 - rem) + getNthValue(i.ceil.toLong) * rem
+      getNthValue(i.floor.toLong, h) * (1 - rem) + getNthValue(i.ceil.toLong, h) * rem
     }
   }
 
-  protected def getNthValue(n: Long): Long = {
+  protected def getNthValue(n: Long, h: Map[Long, HistogramPoint] = actual): Long = {
     @tailrec def _getNthValue(n: Long, l: List[(Long, Long)], cumulative: Long): Long = {
       val (bucket, count) = l.head
       if (cumulative + count >= n) bucket else _getNthValue(n, l.tail, cumulative + count)
@@ -53,12 +71,13 @@ case class Percentile(h: Map[Long, HistogramPoint], percentile: Double, name: St
   }
 }
 
-case class DescriptiveStatistics(m: MetricAnalysis) {
+case class DescriptiveStatistics(m: MetricAnalysis, resampled: Option[List[MetricAnalysis]] = None) {
+  lazy val resampledHistograms = resampled.map(_.map(_.histogram))
   lazy val statisticsList = List(
-    Mean(m.histogram).asStatistic,
-    Percentile(m.histogram, 0.5, "Median").asStatistic,
-    Percentile(m.histogram, 0.25, "25th Percentile").asStatistic,
-    Percentile(m.histogram, 0.75, "75th Percentile").asStatistic
+    Mean(m.histogram, resampledHistograms).asStatistic,
+    Percentile(m.histogram, 0.5, "Median", resampledHistograms).asStatistic,
+    Percentile(m.histogram, 0.25, "25th Percentile", resampledHistograms).asStatistic,
+    Percentile(m.histogram, 0.75, "75th Percentile", resampledHistograms).asStatistic
   )
 
   def getStatistics: List[Statistic] = {

--- a/src/main/scala/com/mozilla/telemetry/metrics/Histogram.scala
+++ b/src/main/scala/com/mozilla/telemetry/metrics/Histogram.scala
@@ -13,21 +13,27 @@ sealed abstract class HistogramDefinition extends MetricDefinition {
 }
 case class FlagHistogram(keyed: Boolean, originalName: String, process: Option[String] = None) extends HistogramDefinition {
   def getBuckets: Array[Int] = Array(0, 1)
+  val isCategoricalMetric = true
 }
 case class BooleanHistogram(keyed: Boolean, originalName: String, process: Option[String] = None) extends HistogramDefinition {
   def getBuckets: Array[Int] = Array(0, 1)
+  val isCategoricalMetric = true
 }
 case class CountHistogram(keyed: Boolean, originalName: String, process: Option[String] = None) extends HistogramDefinition {
   def getBuckets: Array[Int] = Array(0, 1)
+  val isCategoricalMetric = false
 }
 case class EnumeratedHistogram(keyed: Boolean, originalName: String, nValues: Int, process: Option[String] = None) extends HistogramDefinition {
   def getBuckets: Array[Int] = (0 to nValues).toArray
+  val isCategoricalMetric = true
 }
 case class LinearHistogram(keyed: Boolean, originalName: String, low: Int, high: Int, nBuckets: Int, process: Option[String] = None) extends HistogramDefinition {
   def getBuckets: Array[Int] = Histograms.linearBuckets(low, high, nBuckets)
+  val isCategoricalMetric = false
 }
 case class ExponentialHistogram(keyed: Boolean, originalName: String, low: Int, high: Int, nBuckets: Int, process: Option[String] = None) extends HistogramDefinition {
   def getBuckets: Array[Int] = Histograms.exponentialBuckets(low, high, nBuckets)
+  val isCategoricalMetric = false
 }
 
 /**
@@ -37,6 +43,7 @@ case class ExponentialHistogram(keyed: Boolean, originalName: String, low: Int, 
 case class CategoricalHistogram(keyed: Boolean, originalName: String, labels: Seq[String], process: Option[String] = None) extends HistogramDefinition {
   def getLabel(i: Int): String = labels.lift(i).getOrElse(CategoricalHistogram.SpillBucketName)
   def getBuckets: Array[Int] = (0 to labels.length).toArray
+  val isCategoricalMetric = true
 }
 object CategoricalHistogram{ val SpillBucketName = "spill" }
 

--- a/src/main/scala/com/mozilla/telemetry/metrics/Metric.scala
+++ b/src/main/scala/com/mozilla/telemetry/metrics/Metric.scala
@@ -6,6 +6,7 @@ trait MetricDefinition {
   val keyed: Boolean
   val process: Option[String]
   val originalName: String
+  val isCategoricalMetric: Boolean
 }
 
 class MetricsClass {

--- a/src/main/scala/com/mozilla/telemetry/metrics/Scalars.scala
+++ b/src/main/scala/com/mozilla/telemetry/metrics/Scalars.scala
@@ -8,9 +8,21 @@ import scala.io.Source
 import com.mozilla.telemetry.utils.MainPing
 
 abstract class ScalarDefinition extends MetricDefinition
-case class UintScalar(keyed: Boolean, originalName: String, process: Option[String] = None) extends ScalarDefinition
-case class BooleanScalar(keyed: Boolean, originalName: String, process: Option[String] = None) extends ScalarDefinition
-case class StringScalar(keyed: Boolean, originalName: String, process: Option[String] = None) extends ScalarDefinition
+
+case class UintScalar(keyed: Boolean, originalName: String, process: Option[String] = None)
+  extends ScalarDefinition {
+  val isCategoricalMetric = false
+}
+
+case class BooleanScalar(keyed: Boolean, originalName: String, process: Option[String] = None)
+  extends ScalarDefinition {
+  val isCategoricalMetric = true
+}
+
+case class StringScalar(keyed: Boolean, originalName: String, process: Option[String] = None)
+  extends ScalarDefinition {
+  val isCategoricalMetric = true
+}
 
 class ScalarsClass extends MetricsClass {
   val ScalarColumnNamePrefix = "scalar"

--- a/src/test/scala/com/mozilla/telemetry/experiments/analyzers/HistogramAnalyzerTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/experiments/analyzers/HistogramAnalyzerTest.scala
@@ -1,7 +1,7 @@
 package com.mozilla.telemetry.experiments.analyzers
 
 import com.holdenkarau.spark.testing.DatasetSuiteBase
-import com.mozilla.telemetry.metrics.EnumeratedHistogram
+import com.mozilla.telemetry.metrics.{EnumeratedHistogram, LinearHistogram}
 import org.apache.spark.sql.DataFrame
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -43,18 +43,42 @@ class HistogramAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase
 
   "Non-keyed Histograms" can "be aggregated" in {
     val df = fixture
-    val analyzer = new HistogramAnalyzer("histogram",
+    val categoricalAnalyzer = new HistogramAnalyzer("histogram",
       EnumeratedHistogram(keyed = false, "name", 150),
       df.where(df.col("experiment_id") === "experiment1")
     )
-    val actual = analyzer.analyze().toSet
+    val actualCategorical = categoricalAnalyzer.analyze().toSet
 
     def toPointControl: (Int => HistogramPoint) = partialToPoint(24.0, None)
     def toPointBranch1: (Int => HistogramPoint) = partialToPoint(6.0, None)
     def toPointBranch2: (Int => HistogramPoint) = partialToPoint(12.0, None)
 
-    val expected = Set(
+    val expectedCategorical = Set(
       MetricAnalysis("experiment1", "control", MetricAnalyzer.topLevelLabel, 3L, "histogram", "EnumeratedHistogram",
+        Map(0L -> toPointControl(4), 1L -> toPointControl(8), 2L -> toPointControl(12), 5L -> toPointControl(0)),
+        Some(List(
+          Statistic(Some("branch1"), "Chi-Square Distance", 0.0),
+          Statistic(Some("branch2"), "Chi-Square Distance", 0.0)))),
+      MetricAnalysis("experiment1", "branch1", MetricAnalyzer.topLevelLabel, 1L, "histogram", "EnumeratedHistogram",
+        Map(0L -> toPointBranch1(1), 1L -> toPointBranch1(2), 2L -> toPointBranch1(3)),
+        Some(List(
+          Statistic(Some("control"), "Chi-Square Distance", 0.0)))),
+      MetricAnalysis("experiment1", "branch2", MetricAnalyzer.topLevelLabel, 2L, "histogram", "EnumeratedHistogram",
+        Map(0L -> toPointBranch2(2), 1L -> toPointBranch2(4), 2L -> toPointBranch2(6), 5L -> toPointBranch2(0)),
+        Some(List(
+          Statistic(Some("control"), "Chi-Square Distance", 0.0)))))
+
+      assert(actualCategorical == expectedCategorical)
+
+    val numericAnalyzer = new HistogramAnalyzer("histogram",
+      LinearHistogram(keyed = false, "name", 0, 149, 150),
+      df.where(df.col("experiment_id") === "experiment1")
+    )
+
+    val actualNumeric = numericAnalyzer.analyze().toSet
+
+    val expectedNumeric = Set(
+      MetricAnalysis("experiment1", "control", MetricAnalyzer.topLevelLabel, 3L, "histogram", "LinearHistogram",
         Map(0L -> toPointControl(4), 1L -> toPointControl(8), 2L -> toPointControl(12), 5L -> toPointControl(0)),
         Some(List(
           Statistic(Some("branch1"), "Chi-Square Distance", 0.0),
@@ -63,7 +87,7 @@ class HistogramAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase
           Statistic(None, "Median", 1.0),
           Statistic(None, "25th Percentile", 1.0),
           Statistic(None, "75th Percentile", 2.0)))),
-      MetricAnalysis("experiment1", "branch1", MetricAnalyzer.topLevelLabel, 1L, "histogram", "EnumeratedHistogram",
+      MetricAnalysis("experiment1", "branch1", MetricAnalyzer.topLevelLabel, 1L, "histogram", "LinearHistogram",
         Map(0L -> toPointBranch1(1), 1L -> toPointBranch1(2), 2L -> toPointBranch1(3)),
         Some(List(
           Statistic(Some("control"), "Chi-Square Distance", 0.0),
@@ -71,7 +95,7 @@ class HistogramAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase
           Statistic(None, "Median", 1.0),
           Statistic(None, "25th Percentile", 0.5),
           Statistic(None, "75th Percentile", 2.0)))),
-      MetricAnalysis("experiment1", "branch2", MetricAnalyzer.topLevelLabel, 2L, "histogram", "EnumeratedHistogram",
+      MetricAnalysis("experiment1", "branch2", MetricAnalyzer.topLevelLabel, 2L, "histogram", "LinearHistogram",
         Map(0L -> toPointBranch2(2), 1L -> toPointBranch2(4), 2L -> toPointBranch2(6), 5L -> toPointBranch2(0)),
         Some(List(
           Statistic(Some("control"), "Chi-Square Distance", 0.0),
@@ -79,7 +103,8 @@ class HistogramAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase
           Statistic(None, "Median", 1.0),
           Statistic(None, "25th Percentile", 1.0),
           Statistic(None, "75th Percentile", 2.0)))))
-    assert(actual == expected)
+
+    assert(actualNumeric == expectedNumeric)
   }
 
   "Keyed Histograms" can "be aggregated" in {
@@ -99,28 +124,15 @@ class HistogramAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase
         Map(0L -> toPointControl(8), 1L -> toPointControl(16), 2L -> toPointControl(24), 100L -> toPointControl(3)),
         Some(List(
           Statistic(Some("branch1"), "Chi-Square Distance", 0.030303030303030304),
-          Statistic(Some("branch2"), "Chi-Square Distance", 0.019470404984423675),
-          Statistic(None, "Mean", 7.137254901960785),
-          Statistic(None, "Median", 2.0),
-          Statistic(None, "25th Percentile", 1.0),
-          Statistic(None, "75th Percentile", 2.0)))),
+          Statistic(Some("branch2"), "Chi-Square Distance", 0.019470404984423675)))),
       MetricAnalysis("experiment1", "branch1", MetricAnalyzer.topLevelLabel, 1L, "keyed_histogram", "EnumeratedHistogram",
         Map(0L -> toPointBranch1(3), 1L -> toPointBranch1(6), 2L -> toPointBranch1(9)),
         Some(List(
-          Statistic(Some("control"), "Chi-Square Distance", 0.030303030303030304),
-          Statistic(None, "Mean", 1.3333333333333333),
-          Statistic(None, "Median", 1.0),
-          Statistic(None, "25th Percentile", 1.0),
-          Statistic(None, "75th Percentile", 2.0)))),
+          Statistic(Some("control"), "Chi-Square Distance", 0.030303030303030304)))),
       MetricAnalysis("experiment1", "branch2", MetricAnalyzer.topLevelLabel, 2L, "keyed_histogram", "EnumeratedHistogram",
         Map(0L -> toPointBranch2(4), 1L -> toPointBranch2(8), 2L -> toPointBranch2(12), 100L -> toPointBranch2(4)),
         Some(List(
-          Statistic(Some("control"), "Chi-Square Distance", 0.019470404984423675),
-          Statistic(None, "Mean", 15.428571428571429),
-          Statistic(None, "Median", 2.0),
-          Statistic(None, "25th Percentile", 1.0),
-          Statistic(None, "75th Percentile", 2.0))))
-    )
+          Statistic(Some("control"), "Chi-Square Distance", 0.019470404984423675)))))
     assert(actual == expected)
   }
 

--- a/src/test/scala/com/mozilla/telemetry/experiments/analyzers/ScalarAnalyzerTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/experiments/analyzers/ScalarAnalyzerTest.scala
@@ -17,6 +17,8 @@ case class ScalarExperimentDataset(experiment_id: String,
                                    string_scalar: Option[String],
                                    keyed_string_scalar: Option[Map[String, String]])
 
+case class ConfidenceIntervalsDataset(experiment_id: String, experiment_branch: String, uint_scalar: Option[Int])
+
 
 class ScalarAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase {
   val keyed_uint = Map("key1" -> 3, "key2" -> 1)
@@ -162,27 +164,15 @@ class ScalarAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase {
         booleansToPoints(1, 2),
         Some(List(
           Statistic(Some("branch1"), "Chi-Square Distance", 0.2),
-          Statistic(Some("branch2"), "Chi-Square Distance", 0.02857142857142857),
-          Statistic(None, "Mean", 0.6666666666666666),
-          Statistic(None, "Median", 0.5),
-          Statistic(None, "25th Percentile", 0.0),
-          Statistic(None, "75th Percentile", 1.0)))),
+          Statistic(Some("branch2"), "Chi-Square Distance", 0.02857142857142857)))),
       MetricAnalysis("experiment1", "branch1", MetricAnalyzer.topLevelLabel, 1L, "boolean_scalar", "BooleanScalar",
         booleansToPoints(0, 1),
         Some(List(
-          Statistic(Some("control"), "Chi-Square Distance", 0.2),
-          Statistic(None, "Mean", 1.0),
-          Statistic(None, "Median", 0.5),
-          Statistic(None, "25th Percentile", 0.25),
-          Statistic(None, "75th Percentile", 0.75)))),
+          Statistic(Some("control"), "Chi-Square Distance", 0.2)))),
       MetricAnalysis("experiment1", "branch2", MetricAnalyzer.topLevelLabel, 2L, "boolean_scalar", "BooleanScalar",
         booleansToPoints(1, 1),
         Some(List(
-          Statistic(Some("control"), "Chi-Square Distance", 0.02857142857142857),
-          Statistic(None, "Mean", 0.5),
-          Statistic(None, "Median", 0.0),
-          Statistic(None, "25th Percentile", 0.0),
-          Statistic(None, "75th Percentile", 0.5)))))
+          Statistic(Some("control"), "Chi-Square Distance", 0.02857142857142857)))))
     assert(actual == expected)
   }
 
@@ -200,27 +190,15 @@ class ScalarAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase {
         booleansToPoints(4, 2),
         Some(List(
           Statistic(Some("branch1"), "Chi-Square Distance", 0.2),
-          Statistic(Some("branch2"), "Chi-Square Distance", 0.008403361344537816),
-          Statistic(None, "Mean", 0.3333333333333333),
-          Statistic(None, "Median", 0.0),
-          Statistic(None, "25th Percentile", 0.0),
-          Statistic(None, "75th Percentile", 0.5)))),
+          Statistic(Some("branch2"), "Chi-Square Distance", 0.008403361344537816)))),
       MetricAnalysis("experiment1", "branch1", MetricAnalyzer.topLevelLabel, 1L, "keyed_boolean_scalar", "BooleanScalar",
         booleansToPoints(2, 0),
         Some(List(
-          Statistic(Some("control"), "Chi-Square Distance", 0.2),
-          Statistic(None, "Mean", 0.0),
-          Statistic(None, "Median", 0.0),
-          Statistic(None, "25th Percentile", 0.0),
-          Statistic(None, "75th Percentile", 0.0)))),
+          Statistic(Some("control"), "Chi-Square Distance", 0.2)))),
       MetricAnalysis("experiment1", "branch2", MetricAnalyzer.topLevelLabel, 2L, "keyed_boolean_scalar", "BooleanScalar",
         booleansToPoints(3, 1),
         Some(List(
-          Statistic(Some("control"), "Chi-Square Distance", 0.008403361344537816),
-          Statistic(None, "Mean", 0.25),
-          Statistic(None, "Median", 0.0),
-          Statistic(None, "25th Percentile", 0.0),
-          Statistic(None, "75th Percentile", 0.0)))))
+          Statistic(Some("control"), "Chi-Square Distance", 0.008403361344537816)))))
     assert(actual == expected)
   }
 
@@ -237,26 +215,14 @@ class ScalarAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase {
         stringsToPoints(List((0, "hello", 2), (2, "world", 1))),
         Some(List(
           Statistic(Some("branch1"), "Chi-Square Distance", 0.2),
-          Statistic(Some("branch2"), "Chi-Square Distance", 1.0),
-          Statistic(None, "Mean", 0.6666666666666666),
-          Statistic(None, "Median", 0.0),
-          Statistic(None, "25th Percentile", 0.0),
-          Statistic(None, "75th Percentile", 0.5)))),
+          Statistic(Some("branch2"), "Chi-Square Distance", 1.0)))),
       MetricAnalysis("experiment1", "branch1", MetricAnalyzer.topLevelLabel, 1L, "string_scalar", "StringScalar",
         stringsToPoints(List((0, "hello", 1))),
         Some(List(
-          Statistic(Some("control"), "Chi-Square Distance", 0.2),
-          Statistic(None, "Mean", 0.0),
-          Statistic(None, "Median", 0.0),
-          Statistic(None, "25th Percentile", 0.0),
-          Statistic(None, "75th Percentile", 0.0)))),
+          Statistic(Some("control"), "Chi-Square Distance", 0.2)))),
       MetricAnalysis("experiment1", "branch2", MetricAnalyzer.topLevelLabel, 2L, "string_scalar", "StringScalar",
         stringsToPoints(List((1, "ohai", 2))), Some(List(
-          Statistic(Some("control"), "Chi-Square Distance", 1.0),
-          Statistic(None, "Mean", 1.0),
-          Statistic(None, "Median", 1.0),
-          Statistic(None, "25th Percentile", 1.0),
-          Statistic(None, "75th Percentile", 1.0)))))
+          Statistic(Some("control"), "Chi-Square Distance", 1.0)))))
     assert(actual == expected)
   }
 
@@ -274,27 +240,15 @@ class ScalarAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase {
         stringsToPoints(List((0, "hello", 3), (1, "world", 3))),
         Some(List(
           Statistic(Some("branch1"), "Chi-Square Distance", 0.0),
-          Statistic(Some("branch2"), "Chi-Square Distance", 0.0),
-          Statistic(None, "Mean", 0.5),
-          Statistic(None, "Median", 0.0),
-          Statistic(None, "25th Percentile", 0.0),
-          Statistic(None, "75th Percentile", 1.0)))),
+          Statistic(Some("branch2"), "Chi-Square Distance", 0.0)))),
       MetricAnalysis("experiment1", "branch1", MetricAnalyzer.topLevelLabel, 1L, "keyed_string_scalar", "StringScalar",
         stringsToPoints(List((0, "hello", 1), (1, "world", 1))),
         Some(List(
-          Statistic(Some("control"), "Chi-Square Distance", 0.0),
-          Statistic(None, "Mean", 0.5),
-          Statistic(None, "Median", 0.0),
-          Statistic(None, "25th Percentile", 0.0),
-          Statistic(None, "75th Percentile", 0.5)))),
+          Statistic(Some("control"), "Chi-Square Distance", 0.0)))),
       MetricAnalysis("experiment1", "branch2", MetricAnalyzer.topLevelLabel, 2L, "keyed_string_scalar", "StringScalar",
         stringsToPoints(List((0, "hello", 2), (1, "world", 2))),
         Some(List(
-          Statistic(Some("control"), "Chi-Square Distance", 0.0),
-          Statistic(None, "Mean", 0.5),
-          Statistic(None, "Median", 0.0),
-          Statistic(None, "25th Percentile", 0.0),
-          Statistic(None, "75th Percentile", 1.0)))))
+          Statistic(Some("control"), "Chi-Square Distance", 0.0)))))
     assert(actual == expected)
   }
 
@@ -311,7 +265,59 @@ class ScalarAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase {
       UintScalar(true, "name"),
       df.where(df.col("experiment_id") === "experiment1")
     )
-    val keyed_actual = analyzer.analyze().filter(_.experiment_branch == "control").head
+    val keyed_actual = keyed_analyzer.analyze().filter(_.experiment_branch == "control").head
     assert(keyed_actual.n == 3L)
+  }
+
+  "Confidence intervals" should "be added" in {
+    import spark.implicits._
+
+    val ciFixture: DataFrame = Seq(
+      ConfidenceIntervalsDataset("experiment1", "control", Some(84)),
+      ConfidenceIntervalsDataset("experiment1", "control", Some(46)),
+      ConfidenceIntervalsDataset("experiment1", "control", Some(7)),
+      ConfidenceIntervalsDataset("experiment1", "control", Some(39)),
+      ConfidenceIntervalsDataset("experiment1", "control", Some(44)),
+      ConfidenceIntervalsDataset("experiment1", "control", Some(92)),
+      ConfidenceIntervalsDataset("experiment1", "control", Some(35)),
+      ConfidenceIntervalsDataset("experiment1", "control", Some(54)),
+      ConfidenceIntervalsDataset("experiment1", "control", Some(58)),
+      ConfidenceIntervalsDataset("experiment1", "control", Some(96)),
+      ConfidenceIntervalsDataset("experiment1", "control", Some(115)),
+      ConfidenceIntervalsDataset("experiment1", "control", Some(94)),
+      ConfidenceIntervalsDataset("experiment1", "control", Some(113)),
+      ConfidenceIntervalsDataset("experiment1", "control", Some(66)),
+      ConfidenceIntervalsDataset("experiment1", "control", Some(68))
+    ).toDS().toDF()
+
+    val analyzer = ScalarAnalyzer.getAnalyzer("uint_scalar", UintScalar(false, "name"), ciFixture, true)
+    val actual = analyzer.analyze()
+
+    val expected = List(MetricAnalysis(
+      "experiment1", "control", MetricAnalyzer.topLevelLabel, 15, "uint_scalar", "UintScalar",
+      Map(
+        115L -> HistogramPoint(0.06666666666666667, 1.0, None),
+        46L -> HistogramPoint(0.06666666666666667, 1.0, None),
+        84L -> HistogramPoint(0.06666666666666667, 1.0, None),
+        92L -> HistogramPoint(0.06666666666666667, 1.0, None),
+        96L -> HistogramPoint(0.06666666666666667, 1.0, None),
+        44L -> HistogramPoint(0.06666666666666667, 1.0, None),
+        54L -> HistogramPoint(0.06666666666666667, 1.0, None),
+        113L -> HistogramPoint(0.06666666666666667, 1.0, None),
+        7L -> HistogramPoint(0.06666666666666667, 1.0, None),
+        39L -> HistogramPoint(0.06666666666666667, 1.0, None),
+        66L -> HistogramPoint(0.06666666666666667, 1.0, None),
+        35L -> HistogramPoint(0.06666666666666667, 1.0, None),
+        58L -> HistogramPoint(0.06666666666666667, 1.0, None),
+        94L -> HistogramPoint(0.06666666666666667, 1.0, None),
+        68L -> HistogramPoint(0.06666666666666667, 1.0, None)),
+      Some(List(
+        // These CIs are in line with the numbers from the scipy.bootstrap implementation
+        Statistic(None, "Mean", 67.4, Some(54.93333333333333), Some(86.46666666666667), Some(0.05), None),
+        Statistic(None, "Median", 62.0, Some(41.5), Some(88.0), Some(0.05), None),
+        Statistic(None, "25th Percentile", 42.75, Some(28.0), Some(58.0), Some(0.05), None),
+        Statistic(None, "75th Percentile", 92.5, Some(58.0), Some(100.25), Some(0.05), None)))))
+
+    assert(actual == expected)
   }
 }

--- a/src/test/scala/com/mozilla/telemetry/views/ExperimentAnalysisViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/ExperimentAnalysisViewTest.scala
@@ -142,36 +142,6 @@ class ExperimentAnalysisViewTest extends FlatSpec with Matchers with BeforeAndAf
     res.size should be (0)
   }
 
-  "Permutations column" can "be added" in {
-    import spark.implicits._
-
-    val data = Seq(
-      PermutationsRow("a"),
-      PermutationsRow("a"),
-      PermutationsRow("b"),
-      PermutationsRow("c"),
-      PermutationsRow("d")
-    )
-    val res = ExperimentAnalysisView
-      .addPermutations(data.toDS.toDF, Map("control" -> 2, "branch1" -> 1, "branch2" -> 2), "test_experiment")
-      .select("permutations")
-      .collect()
-    val counts = res
-      .flatMap(_.getAs[Seq[Byte]](0))
-      .groupBy(identity)
-      .mapValues(_.size)
-
-    // 0 should map to "branch1", first alphabetically
-    counts(0x00) should be (100 +- 15)
-    // 1 should map to "branch2", second alphabetically
-    counts(0x01) should be (200 +- 30)
-    // 2 should map to "control", last alphabetically
-    counts(0x02) should be (200 +- 30)
-
-    // the permutations for client_id "a" should be the same
-    res(0).getAs[Seq[Byte]](0) should be (res(1).getAs[Seq[Byte]](0))
-  }
-
   override def afterAll() {
     spark.stop()
   }


### PR DESCRIPTION
This includes implementations of bootstrapped confidence intervals for both histograms and scalars but only turns them on for scalars in the job since the current histogram implementation is too slow to be pragmatically useful.

Briefly, the metric analyzer is responsible for providing resampled aggregates to the DescriptiveStatistics class, which merely runs the statistic on each aggregate, sorts the results and uses the simple percentile method to return the confidence interval.

The histogram resampler uses the built-in spark sample-with-replacement method, which is effective but slow.

The scalar resampler, on the otherhand, distributes resampling into separate spark tasks for each node and therefore is able to run much faster since we can resample directly from the aggregated histogram. With the histogram CIs turned off and the scalar CIs turned on, it looks like the jobs take ~4x, which is fine since the job now takes ~2 hours to run.

I've added an "isCategorical" attribute to each metric definition for numeric vs categorical data, and am skipping bootstrapping/summary statistics for categorical metric types since those aren't particularly meaningful.

PS I am so tired of looking at this code