### PR TITLE
Don't run bootstrapped CIs on scalars by default

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/ExperimentAnalysisView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/ExperimentAnalysisView.scala
@@ -48,7 +48,7 @@ object ExperimentAnalysisView {
     val bootstrapScalars = toggle(
       "bootstrapScalars",
       descrYes = "Run bootstrapped confidence intervals on scalars",
-      default = Some(true))
+      default = Some(false))
     val bootstrapHistograms = toggle(
       "bootstrapHistograms",
       descrYes = "Run bootstrapped confidence intervals on histograms (very slow)",


### PR DESCRIPTION
The job is unfortunately timing out (on one particular experiment, it looks like -- the experiments before that are running pretty quickly) so I'm turning off bootstrapped CIs for now