### PR TITLE
Fix the docType filter

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -150,7 +150,7 @@ object MainSummaryView {
         }.where("sourceVersion") {
           case "4" => true
         }.where("docType") {
-          case filterDocType => true
+          case dt => dt == filterDocType
         }.where("appName") {
           case "Firefox" => true
         }.where("submissionDate") {


### PR DESCRIPTION
Subtle bug with the new docType filtering where the `case` variable was shadowing and causing all docTypes to match.