### PR TITLE
Use Dataset API instead of DataFrame.

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/HeavyUsersView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/HeavyUsersView.scala
@@ -245,9 +245,7 @@ object HeavyUsersView {
   def senseExistingData(existingData: Dataset[HeavyUsersRow], date: String, firstRun: Boolean): Unit = {
     if(!firstRun) {
       val yesterday = fmt.print(fmt.parseDateTime(date) - 1.days)
-      val ydayRow = existingData.select(col("submission_date_s3"))
-                                .filter(r => r(0) == yesterday)
-                                .limit(1).collect()
+      val ydayRow = existingData.filter(_.submission_date_s3 == yesterday).take(1)
       if(ydayRow.isEmpty) {
         throw new java.lang.IllegalStateException(
           s"Missing previous day's heavy_users data: '$date' depends on '$yesterday'")


### PR DESCRIPTION
Use Dataset operations to check the existence of data for "yesterday".

This is an attempt to work around the following error raised from [here](https://github.com/mozilla/telemetry-batch-view/blob/7d2d7a9176e87a625298fb8fe6a1b77729e5f9d0/src/main/scala/com/mozilla/telemetry/views/HeavyUsersView.scala#L250):
```
Exception in thread "main" java.lang.UnsupportedOperationException: Only code-generated evaluation is supported.
	at org.apache.spark.sql.catalyst.expressions.objects.Invoke.eval(objects.scala:118)
	at org.apache.spark.sql.catalyst.expressions.InterpretedPredicate$$anonfun$create$2.apply(predicates.scala:38)
	at org.apache.spark.sql.catalyst.expressions.InterpretedPredicate$$anonfun$create$2.apply(predicates.scala:38)
	at org.apache.spark.sql.execution.datasources.PartitioningAwareFileCatalog$$anonfun$9.apply(PartitioningAwareFileCatalog.scala:161)
	at org.apache.spark.sql.execution.datasources.PartitioningAwareFileCatalog$$anonfun$9.apply(PartitioningAwareFileCatalog.scala:160)
	at scala.collection.TraversableLike$$anonfun$filterImpl$1.apply(TraversableLike.scala:248)
	at scala.collection.mutable.ResizableArray$class.foreach(ResizableArray.scala:59)
<snip>
	at org.apache.spark.sql.Dataset.collect(Dataset.scala:2173)
	at com.mozilla.telemetry.views.HeavyUsersView$.senseExistingData(HeavyUsersView.scala:250)
	at com.mozilla.telemetry.views.HeavyUsersView$.main(HeavyUsersView.scala:309)
	at com.mozilla.telemetry.views.HeavyUsersView.main(HeavyUsersView.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.spark.deploy.SparkSubmit$.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:736)
	at org.apache.spark.deploy.SparkSubmit$.doRunMain$1(SparkSubmit.scala:185)
	at org.apache.spark.deploy.SparkSubmit$.submit(SparkSubmit.scala:210)
	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:124)
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
```