### PR TITLE
Fix null pointer exception from specific client

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/experiments/analyzers/HistogramAnalyzer.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/analyzers/HistogramAnalyzer.scala
@@ -17,7 +17,11 @@ case class KeyedHistogramRow(experiment_id: String, branch: String, subgroup: St
                              metric: Option[Map[String, Map[Int, Int]]]) {
   def toPreAggregateRow: PreAggHistogramRow = {
     import HistogramAnalyzer._
-    PreAggHistogramRow(experiment_id, branch, subgroup, metric.collapse.toLongValues)
+    try {
+      PreAggHistogramRow(experiment_id, branch, subgroup, metric.collapse.toLongValues)
+    } catch {
+      case _: java.lang.NullPointerException => PreAggHistogramRow(experiment_id, branch, subgroup, None)
+    }
   }
 }
 

--- a/src/test/scala/com/mozilla/telemetry/experiments/analyzers/HistogramAnalyzerTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/experiments/analyzers/HistogramAnalyzerTest.scala
@@ -159,4 +159,17 @@ class HistogramAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase
     val actual = analyzer.analyze().filter(_.experiment_branch == "control").head
     assert(actual.n == 3L)
   }
+
+  "Keyed histogram with null value" should "be discarded" in {
+    import spark.implicits._
+    val df = Seq(
+      HistogramExperimentDataset("experiment1", "control", Some(m1), Some(Map("key1" -> null, "key2" -> m2)))
+    ).toDS().toDF()
+    val analyzer = new HistogramAnalyzer("keyed_histogram",
+      EnumeratedHistogram(keyed = true, "name", 150), df
+    )
+    val actual = analyzer.analyze()
+    val expected = List()
+    assert(expected == actual)
+  }
 }


### PR DESCRIPTION
This fixes the ExperimentAnalysisView failures over the weekend -- basically, we have a ping or two where the inner map in a keyed histogram is null, for whatever reason, which was an unhandled issue. I've only been able to find two instances of this underlying issue in the main_summary in the column that was throwing this error (`histogram_parent_fx_urlbar_selected_result_index_by_type`) since 11/24 (when the job started failing with this error.) Since the incidence is small, I decided to just discard those pings.