### PR TITLE
Bug 1432282 - Add fields from sync-ping/payload/os to the sync event telemetry table

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/utils/SyncPingConversion.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/SyncPingConversion.scala
@@ -380,7 +380,7 @@ object SyncPingConversion {
     case _ => null
   }
 
-  private def extractOSData(ping: JValue, payload: JValue): (String, String, String) = {
+  def extractOSData(ping: JValue, payload: JValue): (String, String, String) = {
     val os = payload \ "os" match {
       case obj @ JObject(_) => obj
       // Android stores it at the top level, unfortunately


### PR DESCRIPTION
[Relevant bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1432282). We plan on adding event telemetry for additional platforms soon, and so we're getting this done in advance.

I don't know if I need to bump `SyncEventView.schemaVersion` to `"v2"` for this, please let me know either way.

Thanks.