### PR TITLE
Use consistent interface for unwrapping nullable JValues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ lazy val root = (project in file(".")).
     // Hack to get releases to not fail to upload when the same jar name already exists. Later we will need auto versioning
     isSnapshot := true,
     ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) },
-    libraryDependencies += "com.mozilla.telemetry" %% "moztelemetry" % "1.0-SNAPSHOT",
+    libraryDependencies += "com.mozilla.telemetry" %% "moztelemetry" % "1.1-SNAPSHOT",
     libraryDependencies += "com.mozilla.telemetry" %% "spark-hyperloglog" % "2.0.0-SNAPSHOT",
     libraryDependencies += "org.apache.avro" % "avro" % "1.7.7",
     libraryDependencies += "org.apache.parquet" % "parquet-avro" % "1.7.0",

--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -412,42 +412,49 @@ object MainSummaryView {
   // to a map containing just the fields we're interested in.
   def messageToRow(message: Message, scalarDefinitions: List[(String, ScalarDefinition)], histogramDefinitions: List[(String, HistogramDefinition)], userPrefs: List[UserPref] = userPrefsList): Option[Row] = {
     try {
-      val fields = message.fieldsAsMap
+      val doc = message.toJValue match {
+        case Some(doc) => doc
+        case None => return None
+      }
+
+      val environment = doc \ "environment"
+      val payload = doc \ "payload"
+      val meta = doc \ "meta"
 
       // Don't compute the expensive stuff until we need it. We may skip a record
       // due to missing required fields.
-      lazy val addons = parse(fields.getOrElse("environment.addons", "{}").asInstanceOf[String])
-      lazy val addonDetails = parse(fields.getOrElse("payload.addonDetails", "{}").asInstanceOf[String])
-      lazy val payload = parse(message.payload.getOrElse(fields.getOrElse("submission", "{}")).asInstanceOf[String])
-      lazy val application = payload \ "application"
-      lazy val build = parse(fields.getOrElse("environment.build", "{}").asInstanceOf[String])
-      lazy val profile = parse(fields.getOrElse("environment.profile", "{}").asInstanceOf[String])
-      lazy val partner = parse(fields.getOrElse("environment.partner", "{}").asInstanceOf[String])
-      lazy val settings = parse(fields.getOrElse("environment.settings", "{}").asInstanceOf[String])
-      lazy val system = parse(fields.getOrElse("environment.system", "{}").asInstanceOf[String])
-      lazy val info = parse(fields.getOrElse("payload.info", "{}").asInstanceOf[String])
-      lazy val simpleMeasures = parse(fields.getOrElse("payload.simpleMeasurements", "{}").asInstanceOf[String])
+      lazy val addons = environment \ "addons"
+      lazy val addonDetails = payload \ "addonDetails"
+      lazy val application = doc \ "application"
+      lazy val build = environment \ "build"
+      lazy val experiments = environment \ "experiments"
+      lazy val profile = environment \ "profile"
+      lazy val partner = environment \ "partner"
+      lazy val settings = environment \ "settings"
+      lazy val system = environment \ "system"
+      lazy val info = payload \ "info"
+      lazy val simpleMeasures = payload \ "simpleMeasurements"
 
       lazy val histograms = MainPing.ProcessTypes.map{
         _ match {
-          case "parent" => "parent" -> parse(fields.getOrElse("payload.histograms", "{}").asInstanceOf[String])
-          case p => p -> payload \ "payload" \ "processes" \ p \ "histograms"
+          case "parent" => "parent" -> payload \ "histograms"
+          case p => p -> payload \ "processes" \ p \ "histograms"
         }
       }.toMap
 
       lazy val keyedHistograms = MainPing.ProcessTypes.map{
         _ match {
-          case "parent" => "parent" -> parse(fields.getOrElse("payload.keyedHistograms", "{}").asInstanceOf[String])
-          case p => p -> payload \ "payload" \ "processes" \ p \ "keyedHistograms"
+          case "parent" => "parent" -> payload \ "keyedHistograms"
+          case p => p -> payload \ "processes" \ p \ "keyedHistograms"
         }
       }.toMap
 
       lazy val scalars = MainPing.ProcessTypes.map{
-        p => p -> payload \ "payload" \ "processes" \ p \ "scalars"
+        p => p -> payload \ "processes" \ p \ "scalars"
       }.toMap
 
       lazy val keyedScalars = MainPing.ProcessTypes.map{
-        p => p -> payload \ "payload" \ "processes" \ p \ "keyedScalars"
+        p => p -> payload \ "processes" \ p \ "keyedScalars"
       }.toMap
 
       lazy val weaveConfigured = MainPing.booleanHistogramToBoolean(histograms("parent") \ "WEAVE_CONFIGURED")
@@ -455,10 +462,8 @@ object MainSummaryView {
       lazy val weaveMobile = MainPing.enumHistogramToCount(histograms("parent") \ "WEAVE_DEVICE_COUNT_MOBILE")
 
       lazy val events = ("dynamic" :: MainPing.ProcessTypes).map {
-        p => p -> payload \ "payload" \ "processes" \ p \ "events"
+        p => p -> payload \ "processes" \ p \ "events"
       }
-
-      lazy val experiments = parse(fields.getOrElse("environment.experiments", "{}").asInstanceOf[String])
 
       val sslHandshakeResultKeys = (0 to 671).map(_.toString)
 
@@ -474,37 +479,16 @@ object MainSummaryView {
 
       val row = Row(
         // Row fields must match the structure in 'buildSchema'
-        fields.getOrElse("documentId", None) match {
-          case x: String => x
-          // documentId is required, and must be a string. If either
-          // condition is not satisfied, we skip this record.
-          case _ => return None
+        (meta \ "documentId").toNullableString match {
+          case null => return None  // required, skip this record
+          case x => x
         },
-        fields.getOrElse("clientId", None) match {
-          case x: String => x
-          case _ => null
-        },
-        fields.getOrElse("sampleId", None) match {
-          case x: Long => x
-          case x: Double => x.toLong
-          case _ => null
-        },
-        fields.getOrElse("appUpdateChannel", None) match {
-          case x: String => x
-          case _ => ""
-        },
-        fields.getOrElse("normalizedChannel", None) match {
-          case x: String => x
-          case _ => ""
-        },
-        fields.getOrElse("geoCountry", None) match {
-          case x: String => x
-          case _ => ""
-        },
-        fields.getOrElse("geoCity", None) match {
-          case x: String => x
-          case _ => ""
-        },
+        (meta \ "clientId").toNullableString,
+        (meta \ "sampleId").toNullableLong,
+        (meta \ "appUpdateChannel").toNullableString,
+        (meta \ "normalizedChannel").toNullableString,
+        (meta \ "geoCountry").toNullableString,
+        (meta \ "geoCity").toNullableString,
         (system \ "os" \ "name").toNullableString,
         (system \ "os" \ "version").toNullableString,
         (system \ "os" \ "servicePackMajor").toNullableLong,
@@ -524,11 +508,11 @@ object MainSummaryView {
         (info \ "subsessionLength").toNullableLong,
         (info \ "subsessionCounter").toNullableInt,
         (info \ "profileSubsessionCounter").toNullableInt,
-        (payload \ "creationDate").toNullableString,
+        (doc \ "creationDate").toNullableString,
         (partner \ "distributionId").toNullableString,
-        fields.getOrElse("submissionDate", None) match {
-          case x: String => x
-          case _ => return None // required
+        (meta \ "submissionDate").toNullableString match {
+          case null => return None  // required
+          case x => x
         },
         weaveConfigured.orNull,
         weaveDesktop.orNull,
@@ -573,10 +557,7 @@ object MainSummaryView {
         (settings \ "defaultSearchEngineData" \ "submissionURL").toNullableString,
         (settings \ "defaultSearchEngine").toNullableString,
         hsum(histograms("parent") \ "DEVTOOLS_TOOLBOX_OPENED_COUNT"),
-        fields.getOrElse("Date", None) match {
-          case x: String => x
-          case _ => null
-        },
+        (meta \ "Date").toNullableString,
         MainPing.histogramToMean(histograms("parent") \ "PLACES_BOOKMARKS_COUNT").orNull,
         MainPing.histogramToMean(histograms("parent") \ "PLACES_PAGES_COUNT").orNull,
         hsum(histograms("parent") \ "PUSH_API_NOTIFY"),

--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -4,9 +4,8 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.Row
 import org.joda.time.{DateTime, Days, format}
 import org.json4s.JsonAST._
-import org.json4s.jackson.JsonMethods.parse
 import org.rogach.scallop._
-import com.mozilla.telemetry.heka.{Dataset, Message}
+import com.mozilla.telemetry.heka.Dataset
 import com.mozilla.telemetry.utils.{Addon, Attribution, Events,
   Experiment, getOrCreateSparkSession, MainPing, S3Store}
 import com.mozilla.telemetry.utils.{BooleanUserPref, IntegerUserPref, StringUserPref, UserPref}
@@ -165,11 +164,12 @@ object MainSummaryView {
 
       if(!messages.isEmpty()){
         val rowRDD = messages.flatMap(m => {
-          messageToRow(m, scalarDefinitions, histogramDefinitions) match {
+          val row = m.toJValue.map(doc => messageToRow(doc, scalarDefinitions, histogramDefinitions))
+          row match {
             case None =>
               ignoredCount += 1
               None
-            case x =>
+            case Some(x) =>
               processedCount += 1
               x
           }
@@ -385,14 +385,9 @@ object MainSummaryView {
 
   // Convert the given Heka message containing a "main" ping
   // to a map containing just the fields we're interested in.
-  def messageToRow(message: Message, scalarDefinitions: List[(String, ScalarDefinition)], histogramDefinitions: List[(String, HistogramDefinition)], userPrefs: List[UserPref] = userPrefsList): Option[Row] = {
+  def messageToRow(doc: JValue, scalarDefinitions: List[(String, ScalarDefinition)], histogramDefinitions: List[(String, HistogramDefinition)], userPrefs: List[UserPref] = userPrefsList): Option[Row] = {
     try {
       implicit val formats = DefaultFormats
-
-      val doc = message.toJValue match {
-        case Some(doc) => doc
-        case None => return None
-      }
 
       val environment = doc \ "environment"
       val payload = doc \ "payload"
@@ -490,7 +485,7 @@ object MainSummaryView {
         (application \ "displayVersion").extractOpt[String],
         (application \ "name").extractOpt[String],
         (application \ "version").extractOpt[String],
-        message.timestamp, // required
+        (meta \ "Timestamp").extractOpt[Long], // required
         (build \ "buildId").extractOpt[String],
         (build \ "version").extractOpt[String],
         (build \ "architecture").extractOpt[String],

--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -397,252 +397,250 @@ object MainSummaryView {
       val documentId = (meta \ "documentId").extractOpt[String]
       val submissionDate = (meta \ "submissionDate").extractOpt[String]
 
-      if (documentId.isDefined && submissionDate.isDefined) {
+      if (documentId.isEmpty || submissionDate.isEmpty) {
+        return None
+      }
 
-        val addons = environment \ "addons"
-        val addonDetails = payload \ "addonDetails"
-        val application = doc \ "application"
-        val build = environment \ "build"
-        val experiments = environment \ "experiments"
-        val profile = environment \ "profile"
-        val partner = environment \ "partner"
-        val settings = environment \ "settings"
-        val system = environment \ "system"
-        val info = payload \ "info"
-        val simpleMeasures = payload \ "simpleMeasurements"
+      val addons = environment \ "addons"
+      val addonDetails = payload \ "addonDetails"
+      val application = doc \ "application"
+      val build = environment \ "build"
+      val experiments = environment \ "experiments"
+      val profile = environment \ "profile"
+      val partner = environment \ "partner"
+      val settings = environment \ "settings"
+      val system = environment \ "system"
+      val info = payload \ "info"
+      val simpleMeasures = payload \ "simpleMeasurements"
 
-        val histograms = MainPing.ProcessTypes.map {
-          _ match {
-            case "parent" => "parent" -> payload \ "histograms"
-            case p => p -> payload \ "processes" \ p \ "histograms"
-          }
-        }.toMap
-
-        val keyedHistograms = MainPing.ProcessTypes.map {
-          _ match {
-            case "parent" => "parent" -> payload \ "keyedHistograms"
-            case p => p -> payload \ "processes" \ p \ "keyedHistograms"
-          }
-        }.toMap
-
-        val scalars = MainPing.ProcessTypes.map {
-          p => p -> payload \ "processes" \ p \ "scalars"
-        }.toMap
-
-        val keyedScalars = MainPing.ProcessTypes.map {
-          p => p -> payload \ "processes" \ p \ "keyedScalars"
-        }.toMap
-
-        val weaveConfigured = MainPing.booleanHistogramToBoolean(histograms("parent") \ "WEAVE_CONFIGURED")
-        val weaveDesktop = MainPing.enumHistogramToCount(histograms("parent") \ "WEAVE_DEVICE_COUNT_DESKTOP")
-        val weaveMobile = MainPing.enumHistogramToCount(histograms("parent") \ "WEAVE_DEVICE_COUNT_MOBILE")
-
-        val events = ("dynamic" :: MainPing.ProcessTypes).map {
-          p => p -> payload \ "processes" \ p \ "events"
+      val histograms = MainPing.ProcessTypes.map {
+        _ match {
+          case "parent" => "parent" -> payload \ "histograms"
+          case p => p -> payload \ "processes" \ p \ "histograms"
         }
+      }.toMap
 
-        val sslHandshakeResultKeys = (0 to 671).map(_.toString)
+      val keyedHistograms = MainPing.ProcessTypes.map {
+        _ match {
+          case "parent" => "parent" -> payload \ "keyedHistograms"
+          case p => p -> payload \ "processes" \ p \ "keyedHistograms"
+        }
+      }.toMap
 
-        // Messy list of known enum values for POPUP_NOTIFICATION_STATS.
-        val popupNotificationStatsKeys = (0 to 8).union(10 to 11).union(20 to 28).union(30 to 31).map(_.toString)
+      val scalars = MainPing.ProcessTypes.map {
+        p => p -> payload \ "processes" \ p \ "scalars"
+      }.toMap
 
-        val pluginNotificationUserActionKeys = (0 to 2).map(_.toString)
+      val keyedScalars = MainPing.ProcessTypes.map {
+        p => p -> payload \ "processes" \ p \ "keyedScalars"
+      }.toMap
 
-        // Get the "sum" field from histogram h as an Int. Consider a
-        // wonky histogram (one for which the "sum" field is not a
-        // valid number) as null.
-        @inline def hsum(h: JValue): Any = (h \ "sum").extractOpt[Int]
+      val weaveConfigured = MainPing.booleanHistogramToBoolean(histograms("parent") \ "WEAVE_CONFIGURED")
+      val weaveDesktop = MainPing.enumHistogramToCount(histograms("parent") \ "WEAVE_DEVICE_COUNT_DESKTOP")
+      val weaveMobile = MainPing.enumHistogramToCount(histograms("parent") \ "WEAVE_DEVICE_COUNT_MOBILE")
 
-        val row = Row.fromSeq(Seq(
-          // Row fields must match the structure in 'buildSchema'
-          documentId,
-          (meta \ "clientId").extractOpt[String],
-          (meta \ "sampleId").extractOpt[Long],
-          (meta \ "appUpdateChannel").extractOpt[String],
-          (meta \ "normalizedChannel").extractOpt[String],
-          (meta \ "geoCountry").extractOpt[String],
-          (meta \ "geoCity").extractOpt[String],
-          (system \ "os" \ "name").extractOpt[String],
-          (system \ "os" \ "version").extractOpt[String],
-          (system \ "os" \ "servicePackMajor").extractOpt[Long],
-          (system \ "os" \ "servicePackMinor").extractOpt[Long],
-          (system \ "os" \ "windowsBuildNumber").extractOpt[Long],
-          (system \ "os" \ "windowsUBR").extractOpt[Long],
-          (system \ "os" \ "installYear").extractOpt[Long],
-          (system \ "isWow64").extractOpt[Boolean],
-          (system \ "memoryMB").extractOpt[Int],
-          (system \ "appleModelId").extractOpt[String],
-          (system \ "sec" \ "antivirus").extract[Option[Seq[String]]],
-          (system \ "sec" \ "antispyware").extract[Option[Seq[String]]],
-          (system \ "sec" \ "firewall").extract[Option[Seq[String]]],
-          (profile \ "creationDate").extractOpt[Long],
-          (profile \ "resetDate").extractOpt[Long],
-          (info \ "subsessionStartDate").extractOpt[String],
-          (info \ "subsessionLength").extractOpt[Long],
-          (info \ "subsessionCounter").extractOpt[Int],
-          (info \ "profileSubsessionCounter").extractOpt[Int],
-          (doc \ "creationDate").extractOpt[String],
-          (partner \ "distributionId").extractOpt[String],
-          submissionDate,
-          weaveConfigured,
-          weaveDesktop,
-          weaveMobile,
-          (application \ "buildId").extractOpt[String],
-          (application \ "displayVersion").extractOpt[String],
-          (application \ "name").extractOpt[String],
-          (application \ "version").extractOpt[String],
-          (meta \ "Timestamp").extractOpt[Long], // required
-          (build \ "buildId").extractOpt[String],
-          (build \ "version").extractOpt[String],
-          (build \ "architecture").extractOpt[String],
-          (settings \ "e10sEnabled").extractOpt[Boolean],
-          (settings \ "e10sMultiProcesses").extractOpt[Long],
-          (settings \ "locale").extractOpt[String],
-          getAttribution(settings \ "attribution"),
-          (addons \ "activeExperiment" \ "id").extractOpt[String],
-          (addons \ "activeExperiment" \ "branch").extractOpt[String],
-          (info \ "reason").extractOpt[String],
-          (info \ "timezoneOffset").extractOpt[Int],
-          hsum(keyedHistograms("parent") \ "SUBPROCESS_CRASHES_WITH_DUMP" \ "pluginhang"),
-          hsum(keyedHistograms("parent") \ "SUBPROCESS_ABNORMAL_ABORT" \ "plugin"),
-          hsum(keyedHistograms("parent") \ "SUBPROCESS_ABNORMAL_ABORT" \ "content"),
-          hsum(keyedHistograms("parent") \ "SUBPROCESS_ABNORMAL_ABORT" \ "gmplugin"),
-          hsum(keyedHistograms("parent") \ "SUBPROCESS_CRASHES_WITH_DUMP" \ "plugin"),
-          hsum(keyedHistograms("parent") \ "SUBPROCESS_CRASHES_WITH_DUMP" \ "content"),
-          hsum(keyedHistograms("parent") \ "SUBPROCESS_CRASHES_WITH_DUMP" \ "gmplugin"),
-          hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_ATTEMPT" \ "main-crash"),
-          hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_ATTEMPT" \ "content-crash"),
-          hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_ATTEMPT" \ "plugin-crash"),
-          hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_SUCCESS" \ "main-crash"),
-          hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_SUCCESS" \ "content-crash"),
-          hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_SUCCESS" \ "plugin-crash"),
-          hsum(keyedHistograms("parent") \ "SUBPROCESS_KILL_HARD" \ "ShutDownKill"),
-          MainPing.countKeys(addons \ "activeAddons"),
-          MainPing.getFlashVersion(addons),
-          (application \ "vendor").extractOpt[String],
-          (settings \ "isDefaultBrowser").extractOpt[Boolean],
-          (settings \ "defaultSearchEngineData" \ "name").extractOpt[String],
-          (settings \ "defaultSearchEngineData" \ "loadPath").extractOpt[String],
-          (settings \ "defaultSearchEngineData" \ "origin").extractOpt[String],
-          (settings \ "defaultSearchEngineData" \ "submissionURL").extractOpt[String],
-          (settings \ "defaultSearchEngine").extractOpt[String],
-          hsum(histograms("parent") \ "DEVTOOLS_TOOLBOX_OPENED_COUNT"),
-          (meta \ "Date").extractOpt[String],
-          MainPing.histogramToMean(histograms("parent") \ "PLACES_BOOKMARKS_COUNT"),
-          MainPing.histogramToMean(histograms("parent") \ "PLACES_PAGES_COUNT"),
-          hsum(histograms("parent") \ "PUSH_API_NOTIFY"),
-          hsum(histograms("parent") \ "WEB_NOTIFICATION_SHOWN"),
-
-          MainPing.keyedEnumHistogramToMap(keyedHistograms("parent") \ "POPUP_NOTIFICATION_STATS",
-            popupNotificationStatsKeys),
-
-          MainPing.getSearchCounts(keyedHistograms("parent") \ "SEARCH_COUNTS"),
-
-          getActiveAddons(addons \ "activeAddons"),
-          getDisabledAddons(addons \ "activeAddons", addonDetails \ "XPI"),
-          getTheme(addons \ "theme"),
-          (settings \ "blocklistEnabled").extractOpt[Boolean],
-          (settings \ "addonCompatibilityCheckEnabled").extractOpt[Boolean],
-          (settings \ "telemetryEnabled").extractOpt[Boolean],
-          getOldUserPrefs(settings \ "userPrefs"),
-
-          Option(events.flatMap { case (p, e) => Events.getEvents(e, p) }).filter(!_.isEmpty),
-
-          // bug 1339655
-          MainPing.enumHistogramBucketCount(histograms("parent") \ "SSL_HANDSHAKE_RESULT", sslHandshakeResultKeys.head),
-          MainPing.enumHistogramSumCounts(histograms("parent") \ "SSL_HANDSHAKE_RESULT", sslHandshakeResultKeys.tail),
-          MainPing.enumHistogramToMap(histograms("parent") \ "SSL_HANDSHAKE_RESULT", sslHandshakeResultKeys),
-
-          // bug 1382002 - use scalar version when available.
-          Try(MainPing.getScalarByName(scalars, scalarDefinitions, "scalar_parent_browser_engagement_active_ticks")) match {
-            case Success(x: Integer) => x
-            case _ => (simpleMeasures \ "activeTicks").extractOpt[Int]
-          },
-
-          // bug 1353114 - payload.simpleMeasurements.*
-          (simpleMeasures \ "main").extractOpt[Int],
-
-          // Use scalar version when available.
-          Try(MainPing.getScalarByName(scalars, scalarDefinitions, "scalar_parent_timestamps_first_paint")) match {
-            case Success(x: Integer) => x
-            case _ => (simpleMeasures \ "firstPaint").extractOpt[Int]
-          },
-
-          // bug 1353114 - payload.simpleMeasurements.*
-          (simpleMeasures \ "sessionRestored").extractOpt[Int],
-          (simpleMeasures \ "totalTime").extractOpt[Int],
-
-          // bug 1362520 - plugin notifications
-          hsum(histograms("parent") \ "PLUGINS_NOTIFICATION_SHOWN"),
-          MainPing.enumHistogramToRow(histograms("parent") \ "PLUGINS_NOTIFICATION_USER_ACTION", pluginNotificationUserActionKeys),
-          hsum(histograms("parent") \ "PLUGINS_INFOBAR_SHOWN"),
-          hsum(histograms("parent") \ "PLUGINS_INFOBAR_BLOCK"),
-          hsum(histograms("parent") \ "PLUGINS_INFOBAR_ALLOW"),
-          hsum(histograms("parent") \ "PLUGINS_INFOBAR_DISMISSED"),
-
-          // bug 1366253 - active experiments
-          getExperiments(experiments),
-
-          (settings \ "searchCohort").extractOpt[String],
-
-          // bug 1366838 - Quantum Release Criteria
-          (system \ "gfx" \ "features" \ "compositor").extractOpt[String],
-
-          getQuantumReady(
-            settings \ "e10sEnabled",
-            addons \ "activeAddons",
-            addons \ "theme"
-          ),
-
-          MainPing.histogramToThresholdCount(histograms("parent") \ "GC_MAX_PAUSE_MS_2", 150),
-          MainPing.histogramToThresholdCount(histograms("parent") \ "GC_MAX_PAUSE_MS_2", 250),
-          MainPing.histogramToThresholdCount(histograms("parent") \ "GC_MAX_PAUSE_MS_2", 2500),
-
-          MainPing.histogramToThresholdCount(histograms("content") \ "GC_MAX_PAUSE_MS_2", 150),
-          MainPing.histogramToThresholdCount(histograms("content") \ "GC_MAX_PAUSE_MS_2", 250),
-          MainPing.histogramToThresholdCount(histograms("content") \ "GC_MAX_PAUSE_MS_2", 2500),
-
-          MainPing.histogramToThresholdCount(histograms("parent") \ "CYCLE_COLLECTOR_MAX_PAUSE", 150),
-          MainPing.histogramToThresholdCount(histograms("parent") \ "CYCLE_COLLECTOR_MAX_PAUSE", 250),
-          MainPing.histogramToThresholdCount(histograms("parent") \ "CYCLE_COLLECTOR_MAX_PAUSE", 2500),
-
-          MainPing.histogramToThresholdCount(histograms("content") \ "CYCLE_COLLECTOR_MAX_PAUSE", 150),
-          MainPing.histogramToThresholdCount(histograms("content") \ "CYCLE_COLLECTOR_MAX_PAUSE", 250),
-          MainPing.histogramToThresholdCount(histograms("content") \ "CYCLE_COLLECTOR_MAX_PAUSE", 2500),
-
-          MainPing.histogramToThresholdCount(histograms("parent") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 150),
-          MainPing.histogramToThresholdCount(histograms("parent") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 250),
-          MainPing.histogramToThresholdCount(histograms("parent") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 2500),
-
-          MainPing.histogramToThresholdCount(histograms("content") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 150),
-          MainPing.histogramToThresholdCount(histograms("content") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 250),
-          MainPing.histogramToThresholdCount(histograms("content") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 2500),
-
-          MainPing.histogramToThresholdCount(histograms("parent") \ "GHOST_WINDOWS", 1),
-          MainPing.histogramToThresholdCount(histograms("content") \ "GHOST_WINDOWS", 1)
-        ).map {
-          _ match {
-            case e: Option[Any] => e.orNull
-            case o => o
-          }
-        })
-
-        val userPrefsRow = getUserPrefs(settings \ "userPrefs", userPrefs)
-
-        val scalarRow = MainPing.scalarsToRow(
-          MainPing.ProcessTypes.map { p => p -> (scalars(p) merge keyedScalars(p)) }.toMap,
-          scalarDefinitions
-        )
-        val histogramRow = MainPing.histogramsToRow(
-          MainPing.ProcessTypes.map { p => p -> (histograms(p) merge keyedHistograms(p)) }.toMap,
-          histogramDefinitions
-        )
-
-        Some(Row.merge(row, userPrefsRow, scalarRow, histogramRow))
+      val events = ("dynamic" :: MainPing.ProcessTypes).map {
+        p => p -> payload \ "processes" \ p \ "events"
       }
-      else {
-        None
-      }
+
+      val sslHandshakeResultKeys = (0 to 671).map(_.toString)
+
+      // Messy list of known enum values for POPUP_NOTIFICATION_STATS.
+      val popupNotificationStatsKeys = (0 to 8).union(10 to 11).union(20 to 28).union(30 to 31).map(_.toString)
+
+      val pluginNotificationUserActionKeys = (0 to 2).map(_.toString)
+
+      // Get the "sum" field from histogram h as an Int. Consider a
+      // wonky histogram (one for which the "sum" field is not a
+      // valid number) as null.
+      @inline def hsum(h: JValue): Any = (h \ "sum").extractOpt[Int]
+
+      val row = Row.fromSeq(Seq(
+        // Row fields must match the structure in 'buildSchema'
+        documentId,
+        (meta \ "clientId").extractOpt[String],
+        (meta \ "sampleId").extractOpt[Long],
+        (meta \ "appUpdateChannel").extractOpt[String],
+        (meta \ "normalizedChannel").extractOpt[String],
+        (meta \ "geoCountry").extractOpt[String],
+        (meta \ "geoCity").extractOpt[String],
+        (system \ "os" \ "name").extractOpt[String],
+        (system \ "os" \ "version").extractOpt[String],
+        (system \ "os" \ "servicePackMajor").extractOpt[Long],
+        (system \ "os" \ "servicePackMinor").extractOpt[Long],
+        (system \ "os" \ "windowsBuildNumber").extractOpt[Long],
+        (system \ "os" \ "windowsUBR").extractOpt[Long],
+        (system \ "os" \ "installYear").extractOpt[Long],
+        (system \ "isWow64").extractOpt[Boolean],
+        (system \ "memoryMB").extractOpt[Int],
+        (system \ "appleModelId").extractOpt[String],
+        (system \ "sec" \ "antivirus").extract[Option[Seq[String]]],
+        (system \ "sec" \ "antispyware").extract[Option[Seq[String]]],
+        (system \ "sec" \ "firewall").extract[Option[Seq[String]]],
+        (profile \ "creationDate").extractOpt[Long],
+        (profile \ "resetDate").extractOpt[Long],
+        (info \ "subsessionStartDate").extractOpt[String],
+        (info \ "subsessionLength").extractOpt[Long],
+        (info \ "subsessionCounter").extractOpt[Int],
+        (info \ "profileSubsessionCounter").extractOpt[Int],
+        (doc \ "creationDate").extractOpt[String],
+        (partner \ "distributionId").extractOpt[String],
+        submissionDate,
+        weaveConfigured,
+        weaveDesktop,
+        weaveMobile,
+        (application \ "buildId").extractOpt[String],
+        (application \ "displayVersion").extractOpt[String],
+        (application \ "name").extractOpt[String],
+        (application \ "version").extractOpt[String],
+        (meta \ "Timestamp").extractOpt[Long], // required
+        (build \ "buildId").extractOpt[String],
+        (build \ "version").extractOpt[String],
+        (build \ "architecture").extractOpt[String],
+        (settings \ "e10sEnabled").extractOpt[Boolean],
+        (settings \ "e10sMultiProcesses").extractOpt[Long],
+        (settings \ "locale").extractOpt[String],
+        getAttribution(settings \ "attribution"),
+        (addons \ "activeExperiment" \ "id").extractOpt[String],
+        (addons \ "activeExperiment" \ "branch").extractOpt[String],
+        (info \ "reason").extractOpt[String],
+        (info \ "timezoneOffset").extractOpt[Int],
+        hsum(keyedHistograms("parent") \ "SUBPROCESS_CRASHES_WITH_DUMP" \ "pluginhang"),
+        hsum(keyedHistograms("parent") \ "SUBPROCESS_ABNORMAL_ABORT" \ "plugin"),
+        hsum(keyedHistograms("parent") \ "SUBPROCESS_ABNORMAL_ABORT" \ "content"),
+        hsum(keyedHistograms("parent") \ "SUBPROCESS_ABNORMAL_ABORT" \ "gmplugin"),
+        hsum(keyedHistograms("parent") \ "SUBPROCESS_CRASHES_WITH_DUMP" \ "plugin"),
+        hsum(keyedHistograms("parent") \ "SUBPROCESS_CRASHES_WITH_DUMP" \ "content"),
+        hsum(keyedHistograms("parent") \ "SUBPROCESS_CRASHES_WITH_DUMP" \ "gmplugin"),
+        hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_ATTEMPT" \ "main-crash"),
+        hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_ATTEMPT" \ "content-crash"),
+        hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_ATTEMPT" \ "plugin-crash"),
+        hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_SUCCESS" \ "main-crash"),
+        hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_SUCCESS" \ "content-crash"),
+        hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_SUCCESS" \ "plugin-crash"),
+        hsum(keyedHistograms("parent") \ "SUBPROCESS_KILL_HARD" \ "ShutDownKill"),
+        MainPing.countKeys(addons \ "activeAddons"),
+        MainPing.getFlashVersion(addons),
+        (application \ "vendor").extractOpt[String],
+        (settings \ "isDefaultBrowser").extractOpt[Boolean],
+        (settings \ "defaultSearchEngineData" \ "name").extractOpt[String],
+        (settings \ "defaultSearchEngineData" \ "loadPath").extractOpt[String],
+        (settings \ "defaultSearchEngineData" \ "origin").extractOpt[String],
+        (settings \ "defaultSearchEngineData" \ "submissionURL").extractOpt[String],
+        (settings \ "defaultSearchEngine").extractOpt[String],
+        hsum(histograms("parent") \ "DEVTOOLS_TOOLBOX_OPENED_COUNT"),
+        (meta \ "Date").extractOpt[String],
+        MainPing.histogramToMean(histograms("parent") \ "PLACES_BOOKMARKS_COUNT"),
+        MainPing.histogramToMean(histograms("parent") \ "PLACES_PAGES_COUNT"),
+        hsum(histograms("parent") \ "PUSH_API_NOTIFY"),
+        hsum(histograms("parent") \ "WEB_NOTIFICATION_SHOWN"),
+
+        MainPing.keyedEnumHistogramToMap(keyedHistograms("parent") \ "POPUP_NOTIFICATION_STATS",
+          popupNotificationStatsKeys),
+
+        MainPing.getSearchCounts(keyedHistograms("parent") \ "SEARCH_COUNTS"),
+
+        getActiveAddons(addons \ "activeAddons"),
+        getDisabledAddons(addons \ "activeAddons", addonDetails \ "XPI"),
+        getTheme(addons \ "theme"),
+        (settings \ "blocklistEnabled").extractOpt[Boolean],
+        (settings \ "addonCompatibilityCheckEnabled").extractOpt[Boolean],
+        (settings \ "telemetryEnabled").extractOpt[Boolean],
+        getOldUserPrefs(settings \ "userPrefs"),
+
+        Option(events.flatMap { case (p, e) => Events.getEvents(e, p) }).filter(!_.isEmpty),
+
+        // bug 1339655
+        MainPing.enumHistogramBucketCount(histograms("parent") \ "SSL_HANDSHAKE_RESULT", sslHandshakeResultKeys.head),
+        MainPing.enumHistogramSumCounts(histograms("parent") \ "SSL_HANDSHAKE_RESULT", sslHandshakeResultKeys.tail),
+        MainPing.enumHistogramToMap(histograms("parent") \ "SSL_HANDSHAKE_RESULT", sslHandshakeResultKeys),
+
+        // bug 1382002 - use scalar version when available.
+        Try(MainPing.getScalarByName(scalars, scalarDefinitions, "scalar_parent_browser_engagement_active_ticks")) match {
+          case Success(x: Integer) => x
+          case _ => (simpleMeasures \ "activeTicks").extractOpt[Int]
+        },
+
+        // bug 1353114 - payload.simpleMeasurements.*
+        (simpleMeasures \ "main").extractOpt[Int],
+
+        // Use scalar version when available.
+        Try(MainPing.getScalarByName(scalars, scalarDefinitions, "scalar_parent_timestamps_first_paint")) match {
+          case Success(x: Integer) => x
+          case _ => (simpleMeasures \ "firstPaint").extractOpt[Int]
+        },
+
+        // bug 1353114 - payload.simpleMeasurements.*
+        (simpleMeasures \ "sessionRestored").extractOpt[Int],
+        (simpleMeasures \ "totalTime").extractOpt[Int],
+
+        // bug 1362520 - plugin notifications
+        hsum(histograms("parent") \ "PLUGINS_NOTIFICATION_SHOWN"),
+        MainPing.enumHistogramToRow(histograms("parent") \ "PLUGINS_NOTIFICATION_USER_ACTION", pluginNotificationUserActionKeys),
+        hsum(histograms("parent") \ "PLUGINS_INFOBAR_SHOWN"),
+        hsum(histograms("parent") \ "PLUGINS_INFOBAR_BLOCK"),
+        hsum(histograms("parent") \ "PLUGINS_INFOBAR_ALLOW"),
+        hsum(histograms("parent") \ "PLUGINS_INFOBAR_DISMISSED"),
+
+        // bug 1366253 - active experiments
+        getExperiments(experiments),
+
+        (settings \ "searchCohort").extractOpt[String],
+
+        // bug 1366838 - Quantum Release Criteria
+        (system \ "gfx" \ "features" \ "compositor").extractOpt[String],
+
+        getQuantumReady(
+          settings \ "e10sEnabled",
+          addons \ "activeAddons",
+          addons \ "theme"
+        ),
+
+        MainPing.histogramToThresholdCount(histograms("parent") \ "GC_MAX_PAUSE_MS_2", 150),
+        MainPing.histogramToThresholdCount(histograms("parent") \ "GC_MAX_PAUSE_MS_2", 250),
+        MainPing.histogramToThresholdCount(histograms("parent") \ "GC_MAX_PAUSE_MS_2", 2500),
+
+        MainPing.histogramToThresholdCount(histograms("content") \ "GC_MAX_PAUSE_MS_2", 150),
+        MainPing.histogramToThresholdCount(histograms("content") \ "GC_MAX_PAUSE_MS_2", 250),
+        MainPing.histogramToThresholdCount(histograms("content") \ "GC_MAX_PAUSE_MS_2", 2500),
+
+        MainPing.histogramToThresholdCount(histograms("parent") \ "CYCLE_COLLECTOR_MAX_PAUSE", 150),
+        MainPing.histogramToThresholdCount(histograms("parent") \ "CYCLE_COLLECTOR_MAX_PAUSE", 250),
+        MainPing.histogramToThresholdCount(histograms("parent") \ "CYCLE_COLLECTOR_MAX_PAUSE", 2500),
+
+        MainPing.histogramToThresholdCount(histograms("content") \ "CYCLE_COLLECTOR_MAX_PAUSE", 150),
+        MainPing.histogramToThresholdCount(histograms("content") \ "CYCLE_COLLECTOR_MAX_PAUSE", 250),
+        MainPing.histogramToThresholdCount(histograms("content") \ "CYCLE_COLLECTOR_MAX_PAUSE", 2500),
+
+        MainPing.histogramToThresholdCount(histograms("parent") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 150),
+        MainPing.histogramToThresholdCount(histograms("parent") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 250),
+        MainPing.histogramToThresholdCount(histograms("parent") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 2500),
+
+        MainPing.histogramToThresholdCount(histograms("content") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 150),
+        MainPing.histogramToThresholdCount(histograms("content") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 250),
+        MainPing.histogramToThresholdCount(histograms("content") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 2500),
+
+        MainPing.histogramToThresholdCount(histograms("parent") \ "GHOST_WINDOWS", 1),
+        MainPing.histogramToThresholdCount(histograms("content") \ "GHOST_WINDOWS", 1)
+      ).map {
+        _ match {
+          case e: Option[Any] => e.orNull
+          case o => o
+        }
+      })
+
+      val userPrefsRow = getUserPrefs(settings \ "userPrefs", userPrefs)
+
+      val scalarRow = MainPing.scalarsToRow(
+        MainPing.ProcessTypes.map { p => p -> (scalars(p) merge keyedScalars(p)) }.toMap,
+        scalarDefinitions
+      )
+      val histogramRow = MainPing.histogramsToRow(
+        MainPing.ProcessTypes.map { p => p -> (histograms(p) merge keyedHistograms(p)) }.toMap,
+        histogramDefinitions
+      )
+
+      Some(Row.merge(row, userPrefsRow, scalarRow, histogramRow))
     } catch {
       case e: Exception =>
         None

--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -383,35 +383,12 @@ object MainSummaryView {
     }
   }
 
-  implicit val formats = DefaultFormats
-
-  // A note on json4s JValue extraction:
-  //
-  // JValue provides an `.extract[T]` interface for deconstructing values to
-  // native types. However, fields in the schema are mostly nullable. One
-  // way to extract the value is to use a boxed type e.g. `scala.Long` or
-  // `java.lang.Long`. These are wrappers around the primitive types and
-  // support nullable values. This can increase the the latency of the
-  // program by introducing extra overhead. [1].
-  //
-  // Here, we choose to extract the value into an Option and unwrap into a primitive Any.
-  // `JValue.extract[Option[T]].orNull -> Any`. A general short hand that works for most primitive
-  // types is to use `JValue.extractOpt[T]`. Exceptions should be noted.
-  //
-  // [1]: https://blog.scalac.io/2017/05/25/scala-specialization.html
-  //
-  implicit class RichJValue(val self: JValue) extends AnyVal {
-    @inline def toNullableInt: Any = self.extractOpt[Int].orNull
-    @inline def toNullableLong: Any = self.extractOpt[Long].orNull
-    @inline def toNullableBool: Any = self.extractOpt[Boolean].orNull
-    @inline def toNullableString: Any = self.extractOpt[String].orNull
-    @inline def toNullableSeqString: Any = self.extract[Option[Seq[String]]].orNull
-  }
-
   // Convert the given Heka message containing a "main" ping
   // to a map containing just the fields we're interested in.
   def messageToRow(message: Message, scalarDefinitions: List[(String, ScalarDefinition)], histogramDefinitions: List[(String, HistogramDefinition)], userPrefs: List[UserPref] = userPrefsList): Option[Row] = {
     try {
+      implicit val formats = DefaultFormats
+
       val doc = message.toJValue match {
         case Some(doc) => doc
         case None => return None
@@ -473,64 +450,58 @@ object MainSummaryView {
       // Get the "sum" field from histogram h as an Int. Consider a
       // wonky histogram (one for which the "sum" field is not a
       // valid number) as null.
-      @inline def hsum(h: JValue): Any = (h \ "sum").extractOpt[Int].orNull
+      @inline def hsum(h: JValue): Any = (h \ "sum").extractOpt[Int]
 
-      val row = Row(
+      val row = Row.fromSeq(Seq(
         // Row fields must match the structure in 'buildSchema'
-        (meta \ "documentId").toNullableString match {
-          case null => return None  // required, skip this record
-          case x => x
-        },
-        (meta \ "clientId").toNullableString,
-        (meta \ "sampleId").toNullableLong,
-        (meta \ "appUpdateChannel").toNullableString,
-        (meta \ "normalizedChannel").toNullableString,
-        (meta \ "geoCountry").toNullableString,
-        (meta \ "geoCity").toNullableString,
-        (system \ "os" \ "name").toNullableString,
-        (system \ "os" \ "version").toNullableString,
-        (system \ "os" \ "servicePackMajor").toNullableLong,
-        (system \ "os" \ "servicePackMinor").toNullableLong,
-        (system \ "os" \ "windowsBuildNumber").toNullableLong,
-        (system \ "os" \ "windowsUBR").toNullableLong,
-        (system \ "os" \ "installYear").toNullableLong,
-        (system \ "isWow64").toNullableBool,
-        (system \ "memoryMB").toNullableInt,
-        (system \ "appleModelId").toNullableString,
-        (system \ "sec" \ "antivirus").toNullableSeqString,
-        (system \ "sec" \ "antispyware").toNullableSeqString,
-        (system \ "sec" \ "firewall").toNullableSeqString,
-        (profile \ "creationDate").toNullableLong,
-        (profile \ "resetDate").toNullableLong,
-        (info \ "subsessionStartDate").toNullableString,
-        (info \ "subsessionLength").toNullableLong,
-        (info \ "subsessionCounter").toNullableInt,
-        (info \ "profileSubsessionCounter").toNullableInt,
-        (doc \ "creationDate").toNullableString,
-        (partner \ "distributionId").toNullableString,
-        (meta \ "submissionDate").toNullableString match {
-          case null => return None  // required
-          case x => x
-        },
-        weaveConfigured.orNull,
-        weaveDesktop.orNull,
-        weaveMobile.orNull,
-        (application \ "buildId").toNullableString,
-        (application \ "displayVersion").toNullableString,
-        (application \ "name").toNullableString,
-        (application \ "version").toNullableString,
+        (meta \ "documentId").extractOpt[String],
+        (meta \ "clientId").extractOpt[String],
+        (meta \ "sampleId").extractOpt[Long],
+        (meta \ "appUpdateChannel").extractOpt[String],
+        (meta \ "normalizedChannel").extractOpt[String],
+        (meta \ "geoCountry").extractOpt[String],
+        (meta \ "geoCity").extractOpt[String],
+        (system \ "os" \ "name").extractOpt[String],
+        (system \ "os" \ "version").extractOpt[String],
+        (system \ "os" \ "servicePackMajor").extractOpt[Long],
+        (system \ "os" \ "servicePackMinor").extractOpt[Long],
+        (system \ "os" \ "windowsBuildNumber").extractOpt[Long],
+        (system \ "os" \ "windowsUBR").extractOpt[Long],
+        (system \ "os" \ "installYear").extractOpt[Long],
+        (system \ "isWow64").extractOpt[Boolean],
+        (system \ "memoryMB").extractOpt[Int],
+        (system \ "appleModelId").extractOpt[String],
+        (system \ "sec" \ "antivirus").extract[Option[Seq[String]]],
+        (system \ "sec" \ "antispyware").extract[Option[Seq[String]]],
+        (system \ "sec" \ "firewall").extract[Option[Seq[String]]],
+        (profile \ "creationDate").extractOpt[Long],
+        (profile \ "resetDate").extractOpt[Long],
+        (info \ "subsessionStartDate").extractOpt[String],
+        (info \ "subsessionLength").extractOpt[Long],
+        (info \ "subsessionCounter").extractOpt[Int],
+        (info \ "profileSubsessionCounter").extractOpt[Int],
+        (doc \ "creationDate").extractOpt[String],
+        (partner \ "distributionId").extractOpt[String],
+        (meta \ "submissionDate").extractOpt[String],
+        weaveConfigured,
+        weaveDesktop,
+        weaveMobile,
+        (application \ "buildId").extractOpt[String],
+        (application \ "displayVersion").extractOpt[String],
+        (application \ "name").extractOpt[String],
+        (application \ "version").extractOpt[String],
         message.timestamp, // required
-        (build \ "buildId").toNullableString,
-        (build \ "version").toNullableString,
-        (build \ "architecture").toNullableString,
-        (settings \ "e10sEnabled").toNullableBool,
-        (settings \ "e10sMultiProcesses").toNullableLong,
-        (settings \ "locale").toNullableString,
-        getAttribution(settings \ "attribution").orNull,
-        (addons \ "activeExperiment" \ "id").toNullableString,
-        (addons \ "activeExperiment" \ "branch").toNullableString,
-        (info \ "reason").toNullableString,
-        (info \ "timezoneOffset").toNullableInt,
+        (build \ "buildId").extractOpt[String],
+        (build \ "version").extractOpt[String],
+        (build \ "architecture").extractOpt[String],
+        (settings \ "e10sEnabled").extractOpt[Boolean],
+        (settings \ "e10sMultiProcesses").extractOpt[Long],
+        (settings \ "locale").extractOpt[String],
+        getAttribution(settings \ "attribution"),
+        (addons \ "activeExperiment" \ "id").extractOpt[String],
+        (addons \ "activeExperiment" \ "branch").extractOpt[String],
+        (info \ "reason").extractOpt[String],
+        (info \ "timezoneOffset").extractOpt[Int],
         hsum(keyedHistograms("parent") \ "SUBPROCESS_CRASHES_WITH_DUMP" \ "pluginhang"),
         hsum(keyedHistograms("parent") \ "SUBPROCESS_ABNORMAL_ABORT" \ "plugin"),
         hsum(keyedHistograms("parent") \ "SUBPROCESS_ABNORMAL_ABORT" \ "content"),
@@ -545,60 +516,60 @@ object MainSummaryView {
         hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_SUCCESS" \ "content-crash"),
         hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_SUCCESS" \ "plugin-crash"),
         hsum(keyedHistograms("parent") \ "SUBPROCESS_KILL_HARD" \ "ShutDownKill"),
-        MainPing.countKeys(addons \ "activeAddons").orNull,
-        MainPing.getFlashVersion(addons).orNull,
-        (application \ "vendor").toNullableString,
-        (settings \ "isDefaultBrowser").toNullableBool,
-        (settings \ "defaultSearchEngineData" \ "name").toNullableString,
-        (settings \ "defaultSearchEngineData" \ "loadPath").toNullableString,
-        (settings \ "defaultSearchEngineData" \ "origin").toNullableString,
-        (settings \ "defaultSearchEngineData" \ "submissionURL").toNullableString,
-        (settings \ "defaultSearchEngine").toNullableString,
+        MainPing.countKeys(addons \ "activeAddons"),
+        MainPing.getFlashVersion(addons),
+        (application \ "vendor").extractOpt[String],
+        (settings \ "isDefaultBrowser").extractOpt[Boolean],
+        (settings \ "defaultSearchEngineData" \ "name").extractOpt[String],
+        (settings \ "defaultSearchEngineData" \ "loadPath").extractOpt[String],
+        (settings \ "defaultSearchEngineData" \ "origin").extractOpt[String],
+        (settings \ "defaultSearchEngineData" \ "submissionURL").extractOpt[String],
+        (settings \ "defaultSearchEngine").extractOpt[String],
         hsum(histograms("parent") \ "DEVTOOLS_TOOLBOX_OPENED_COUNT"),
-        (meta \ "Date").toNullableString,
-        MainPing.histogramToMean(histograms("parent") \ "PLACES_BOOKMARKS_COUNT").orNull,
-        MainPing.histogramToMean(histograms("parent") \ "PLACES_PAGES_COUNT").orNull,
+        (meta \ "Date").extractOpt[String],
+        MainPing.histogramToMean(histograms("parent") \ "PLACES_BOOKMARKS_COUNT"),
+        MainPing.histogramToMean(histograms("parent") \ "PLACES_PAGES_COUNT"),
         hsum(histograms("parent") \ "PUSH_API_NOTIFY"),
         hsum(histograms("parent") \ "WEB_NOTIFICATION_SHOWN"),
 
         MainPing.keyedEnumHistogramToMap(keyedHistograms("parent") \ "POPUP_NOTIFICATION_STATS",
-          popupNotificationStatsKeys).orNull,
+          popupNotificationStatsKeys),
 
-        MainPing.getSearchCounts(keyedHistograms("parent") \ "SEARCH_COUNTS").orNull,
+        MainPing.getSearchCounts(keyedHistograms("parent") \ "SEARCH_COUNTS"),
 
-        getActiveAddons(addons \ "activeAddons").orNull,
-        getDisabledAddons(addons \ "activeAddons", addonDetails \ "XPI").orNull,
-        getTheme(addons \ "theme").orNull,
-        (settings \ "blocklistEnabled").toNullableBool,
-        (settings \ "addonCompatibilityCheckEnabled").toNullableBool,
-        (settings \ "telemetryEnabled").toNullableBool,
-        getOldUserPrefs(settings \ "userPrefs").orNull,
+        getActiveAddons(addons \ "activeAddons"),
+        getDisabledAddons(addons \ "activeAddons", addonDetails \ "XPI"),
+        getTheme(addons \ "theme"),
+        (settings \ "blocklistEnabled").extractOpt[Boolean],
+        (settings \ "addonCompatibilityCheckEnabled").extractOpt[Boolean],
+        (settings \ "telemetryEnabled").extractOpt[Boolean],
+        getOldUserPrefs(settings \ "userPrefs"),
 
-        Option(events.flatMap {case (p, e) => Events.getEvents(e, p)}).filter(!_.isEmpty).orNull,
+        Option(events.flatMap {case (p, e) => Events.getEvents(e, p)}).filter(!_.isEmpty),
 
         // bug 1339655
-        MainPing.enumHistogramBucketCount(histograms("parent") \ "SSL_HANDSHAKE_RESULT", sslHandshakeResultKeys.head).orNull,
+        MainPing.enumHistogramBucketCount(histograms("parent") \ "SSL_HANDSHAKE_RESULT", sslHandshakeResultKeys.head),
         MainPing.enumHistogramSumCounts(histograms("parent") \ "SSL_HANDSHAKE_RESULT", sslHandshakeResultKeys.tail),
         MainPing.enumHistogramToMap(histograms("parent") \ "SSL_HANDSHAKE_RESULT", sslHandshakeResultKeys),
 
         // bug 1382002 - use scalar version when available.
         Try(MainPing.getScalarByName(scalars, scalarDefinitions, "scalar_parent_browser_engagement_active_ticks")) match {
           case Success(x: Integer) => x
-          case _ => (simpleMeasures \ "activeTicks").toNullableInt
+          case _ => (simpleMeasures \ "activeTicks").extractOpt[Int]
         },
 
         // bug 1353114 - payload.simpleMeasurements.*
-        (simpleMeasures \ "main").toNullableInt,
+        (simpleMeasures \ "main").extractOpt[Int],
 
         // Use scalar version when available.
         Try(MainPing.getScalarByName(scalars, scalarDefinitions, "scalar_parent_timestamps_first_paint")) match {
           case Success(x: Integer) => x
-          case _ => (simpleMeasures \ "firstPaint").toNullableInt
+          case _ => (simpleMeasures \ "firstPaint").extractOpt[Int]
         },
 
         // bug 1353114 - payload.simpleMeasurements.*
-        (simpleMeasures \ "sessionRestored").toNullableInt,
-        (simpleMeasures \ "totalTime").toNullableInt,
+        (simpleMeasures \ "sessionRestored").extractOpt[Int],
+        (simpleMeasures \ "totalTime").extractOpt[Int],
 
         // bug 1362520 - plugin notifications
         hsum(histograms("parent") \ "PLUGINS_NOTIFICATION_SHOWN"),
@@ -609,18 +580,18 @@ object MainSummaryView {
         hsum(histograms("parent") \ "PLUGINS_INFOBAR_DISMISSED"),
 
         // bug 1366253 - active experiments
-        getExperiments(experiments).orNull,
+        getExperiments(experiments),
 
-        (settings \ "searchCohort").toNullableString,
+        (settings \ "searchCohort").extractOpt[String],
 
         // bug 1366838 - Quantum Release Criteria
-        (system \ "gfx" \ "features" \ "compositor").toNullableString,
+        (system \ "gfx" \ "features" \ "compositor").extractOpt[String],
 
         getQuantumReady(
           settings \ "e10sEnabled",
           addons \ "activeAddons",
           addons \ "theme"
-        ).orNull,
+        ),
 
         MainPing.histogramToThresholdCount(histograms("parent") \ "GC_MAX_PAUSE_MS_2", 150),
         MainPing.histogramToThresholdCount(histograms("parent") \ "GC_MAX_PAUSE_MS_2", 250),
@@ -648,7 +619,12 @@ object MainSummaryView {
 
         MainPing.histogramToThresholdCount(histograms("parent") \ "GHOST_WINDOWS", 1),
         MainPing.histogramToThresholdCount(histograms("content") \ "GHOST_WINDOWS", 1)
-      )
+      ).map {
+        _ match {
+          case e: Option[Any] => e.orNull
+          case o => o
+        }
+      })
 
       val userPrefsRow = getUserPrefs(settings \ "userPrefs", userPrefs)
 

--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -383,16 +383,35 @@ object MainSummaryView {
     }
   }
 
-  def asInt(v: JValue): Integer = v match {
-    case JInt(x) => x.toInt
-    case _ => null
+  implicit val formats = DefaultFormats
+
+  // A note on json4s JValue extraction:
+  //
+  // JValue provides an `.extract[T]` interface for deconstructing values to
+  // native types. However, fields in the schema are mostly nullable. One
+  // way to extract the value is to use a boxed type e.g. `scala.Long` or
+  // `java.lang.Long`. These are wrappers around the primitive types and
+  // support nullable values. This can increase the the latency of the
+  // program by introducing extra overhead. [1].
+  //
+  // Here, we choose to extract the value into an Option and unwrap into a primitive Any.
+  // `JValue.extract[Option[T]].orNull -> Any`. A general short hand that works for most primitive
+  // types is to use `JValue.extractOpt[T]`. Exceptions should be noted.
+  //
+  // [1]: https://blog.scalac.io/2017/05/25/scala-specialization.html
+  //
+  implicit class RichJValue(val self: JValue) extends AnyVal {
+    @inline def toNullableInt: Any = self.extractOpt[Int].orNull
+    @inline def toNullableLong: Any = self.extractOpt[Long].orNull
+    @inline def toNullableBool: Any = self.extractOpt[Boolean].orNull
+    @inline def toNullableString: Any = self.extractOpt[String].orNull
+    @inline def toNullableSeqString: Any = self.extract[Option[Seq[String]]].orNull
   }
 
   // Convert the given Heka message containing a "main" ping
   // to a map containing just the fields we're interested in.
   def messageToRow(message: Message, scalarDefinitions: List[(String, ScalarDefinition)], histogramDefinitions: List[(String, HistogramDefinition)], userPrefs: List[UserPref] = userPrefsList): Option[Row] = {
     try {
-      implicit val formats = DefaultFormats
       val fields = message.fieldsAsMap
 
       // Don't compute the expensive stuff until we need it. We may skip a record
@@ -451,10 +470,7 @@ object MainSummaryView {
       // Get the "sum" field from histogram h as an Int. Consider a
       // wonky histogram (one for which the "sum" field is not a
       // valid number) as null.
-      val hsum = (h: JValue) => h \ "sum" match {
-        case JInt(x) => x.toInt
-        case _ => null
-      }
+      @inline def hsum(h: JValue): Any = (h \ "sum").extractOpt[Int].orNull
 
       val row = Row(
         // Row fields must match the structure in 'buildSchema'
@@ -489,83 +505,27 @@ object MainSummaryView {
           case x: String => x
           case _ => ""
         },
-        system \ "os" \ "name" match {
-          case JString(x) => x
-          case _ => null
-        },
-        system \ "os" \ "version" match {
-          case JString(x) => x
-          case JInt(x) => x.toString()
-          case _ => null
-        },
-        system \ "os" \ "servicePackMajor" match {
-          case JInt(x) => x.toLong
-          case _ => null
-        },
-        system \ "os" \ "servicePackMinor" match {
-          case JInt(x) => x.toLong
-          case _ => null
-        },
-        system \ "os" \ "windowsBuildNumber" match {
-          case JInt(x) => x.toLong
-          case _ => null
-        },
-        system \ "os" \ "windowsUBR" match {
-          case JInt(x) => x.toLong
-          case _ => null
-        },
-        system \ "os" \ "installYear" match {
-          case JInt(x) => x.toLong
-          case _ => null
-        },
-        system \ "isWow64" match {
-          case JBool(x) => x
-          case _ => null
-        },
-        system \ "memoryMB" match {
-          case JInt(x) => x.toInt
-          case _ => null
-        },
-        system \ "appleModelId" match {
-          case JString(x) => x
-          case _ => null
-        },
-        // unfortunately, JNull.extractOpt[Seq[String]] -> List()
-        (system \ "sec" \ "antivirus").extract[Option[Seq[String]]].orNull,
-        (system \ "sec" \ "antispyware").extract[Option[Seq[String]]].orNull,
-        (system \ "sec" \ "firewall").extract[Option[Seq[String]]].orNull,
-        profile \ "creationDate" match {
-          case JInt(x) => x.toLong
-          case _ => null
-        },
-        profile \ "resetDate" match {
-          case JInt(x) => x.toLong
-          case _ => null
-        },
-        info \ "subsessionStartDate" match {
-          case JString(x) => x
-          case _ => null
-        },
-        info \ "subsessionLength" match {
-          case JInt(x) => x.toLong
-          case _ => null
-        },
-        info \ "subsessionCounter" match {
-          case JInt(x) => x.toInt
-          case _ => null
-        },
-        info \ "profileSubsessionCounter" match {
-          case JInt(x) => x.toInt
-          case _ => null
-        },
-        payload \ "creationDate" match {
-          case JString(x) => x
-          case _ => null
-        },
-        partner \ "distributionId" match {
-          case JString(x) => x
-          case _ => null
-        },
+        (system \ "os" \ "name").toNullableString,
+        (system \ "os" \ "version").toNullableString,
+        (system \ "os" \ "servicePackMajor").toNullableLong,
+        (system \ "os" \ "servicePackMinor").toNullableLong,
+        (system \ "os" \ "windowsBuildNumber").toNullableLong,
+        (system \ "os" \ "windowsUBR").toNullableLong,
+        (system \ "os" \ "installYear").toNullableLong,
+        (system \ "isWow64").toNullableBool,
+        (system \ "memoryMB").toNullableInt,
+        (system \ "appleModelId").toNullableString,
+        (system \ "sec" \ "antivirus").toNullableSeqString,
+        (system \ "sec" \ "antispyware").toNullableSeqString,
+        (system \ "sec" \ "firewall").toNullableSeqString,
+        (profile \ "creationDate").toNullableLong,
+        (profile \ "resetDate").toNullableLong,
+        (info \ "subsessionStartDate").toNullableString,
+        (info \ "subsessionLength").toNullableLong,
+        (info \ "subsessionCounter").toNullableInt,
+        (info \ "profileSubsessionCounter").toNullableInt,
+        (payload \ "creationDate").toNullableString,
+        (partner \ "distributionId").toNullableString,
         fields.getOrElse("submissionDate", None) match {
           case x: String => x
           case _ => return None // required
@@ -573,61 +533,22 @@ object MainSummaryView {
         weaveConfigured.orNull,
         weaveDesktop.orNull,
         weaveMobile.orNull,
-        application \ "buildId" match {
-          case JString(x) => x
-          case _ => null
-        },
-        application \ "displayVersion" match {
-          case JString(x) => x
-          case _ => null
-        },
-        application \ "name" match {
-          case JString(x) => x
-          case _ => null
-        },
-        application \ "version" match {
-          case JString(x) => x
-          case _ => null
-        },
+        (application \ "buildId").toNullableString,
+        (application \ "displayVersion").toNullableString,
+        (application \ "name").toNullableString,
+        (application \ "version").toNullableString,
         message.timestamp, // required
-        build \ "buildId" match {
-          case JString(x) => x
-          case _ => null
-        },
-        build \ "version" match {
-          case JString(x) => x
-          case _ => null
-        },
-        build \ "architecture" match {
-          case JString(x) => x
-          case _ => null
-        },
-        settings \ "e10sEnabled" match {
-          case JBool(x) => x
-          case _ => null
-        },
-        settings \ "e10sMultiProcesses" match {
-          case JInt(x) => x.toLong
-          case _ => null
-        },
-        settings \ "locale" match {
-          case JString(x) => x
-          case _ => null
-        },
+        (build \ "buildId").toNullableString,
+        (build \ "version").toNullableString,
+        (build \ "architecture").toNullableString,
+        (settings \ "e10sEnabled").toNullableBool,
+        (settings \ "e10sMultiProcesses").toNullableLong,
+        (settings \ "locale").toNullableString,
         getAttribution(settings \ "attribution").orNull,
-        addons \ "activeExperiment" \ "id" match {
-          case JString(x) => x
-          case _ => null
-        },
-        addons \ "activeExperiment" \ "branch" match {
-          case JString(x) => x
-          case _ => null
-        },
-        info \ "reason" match {
-          case JString(x) => x
-          case _ => null
-        },
-        asInt(info \ "timezoneOffset"),
+        (addons \ "activeExperiment" \ "id").toNullableString,
+        (addons \ "activeExperiment" \ "branch").toNullableString,
+        (info \ "reason").toNullableString,
+        (info \ "timezoneOffset").toNullableInt,
         hsum(keyedHistograms("parent") \ "SUBPROCESS_CRASHES_WITH_DUMP" \ "pluginhang"),
         hsum(keyedHistograms("parent") \ "SUBPROCESS_ABNORMAL_ABORT" \ "plugin"),
         hsum(keyedHistograms("parent") \ "SUBPROCESS_ABNORMAL_ABORT" \ "content"),
@@ -642,42 +563,15 @@ object MainSummaryView {
         hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_SUCCESS" \ "content-crash"),
         hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_SUCCESS" \ "plugin-crash"),
         hsum(keyedHistograms("parent") \ "SUBPROCESS_KILL_HARD" \ "ShutDownKill"),
-        MainPing.countKeys(addons \ "activeAddons") match {
-          case Some(x) => x
-          case _ => null
-        },
-        MainPing.getFlashVersion(addons) match {
-          case Some(x) => x
-          case _ => null
-        },
-        application \ "vendor" match {
-          case JString(x) => x
-          case _ => null
-        },
-        settings \ "isDefaultBrowser" match {
-          case JBool(x) => x
-          case _ => null
-        },
-        settings \ "defaultSearchEngineData" \ "name" match {
-          case JString(x) => x
-          case _ => null
-        },
-        settings \ "defaultSearchEngineData" \ "loadPath" match {
-          case JString(x) => x
-          case _ => null
-        },
-        settings \ "defaultSearchEngineData" \ "origin" match {
-          case JString(x) => x
-          case _ => null
-        },
-        settings \ "defaultSearchEngineData" \ "submissionURL" match {
-          case JString(x) => x
-          case _ => null
-        },
-        settings \ "defaultSearchEngine" match {
-          case JString(x) => x
-          case _ => null
-        },
+        MainPing.countKeys(addons \ "activeAddons").orNull,
+        MainPing.getFlashVersion(addons).orNull,
+        (application \ "vendor").toNullableString,
+        (settings \ "isDefaultBrowser").toNullableBool,
+        (settings \ "defaultSearchEngineData" \ "name").toNullableString,
+        (settings \ "defaultSearchEngineData" \ "loadPath").toNullableString,
+        (settings \ "defaultSearchEngineData" \ "origin").toNullableString,
+        (settings \ "defaultSearchEngineData" \ "submissionURL").toNullableString,
+        (settings \ "defaultSearchEngine").toNullableString,
         hsum(histograms("parent") \ "DEVTOOLS_TOOLBOX_OPENED_COUNT"),
         fields.getOrElse("Date", None) match {
           case x: String => x
@@ -696,18 +590,9 @@ object MainSummaryView {
         getActiveAddons(addons \ "activeAddons").orNull,
         getDisabledAddons(addons \ "activeAddons", addonDetails \ "XPI").orNull,
         getTheme(addons \ "theme").orNull,
-        settings \ "blocklistEnabled" match {
-          case JBool(x) => x
-          case _ => null
-        },
-        settings \ "addonCompatibilityCheckEnabled" match {
-          case JBool(x) => x
-          case _ => null
-        },
-        settings \ "telemetryEnabled" match {
-          case JBool(x) => x
-          case _ => null
-        },
+        (settings \ "blocklistEnabled").toNullableBool,
+        (settings \ "addonCompatibilityCheckEnabled").toNullableBool,
+        (settings \ "telemetryEnabled").toNullableBool,
         getOldUserPrefs(settings \ "userPrefs").orNull,
 
         Option(events.flatMap {case (p, e) => Events.getEvents(e, p)}).filter(!_.isEmpty).orNull,
@@ -720,21 +605,21 @@ object MainSummaryView {
         // bug 1382002 - use scalar version when available.
         Try(MainPing.getScalarByName(scalars, scalarDefinitions, "scalar_parent_browser_engagement_active_ticks")) match {
           case Success(x: Integer) => x
-          case _ => asInt (simpleMeasures \ "activeTicks")
+          case _ => (simpleMeasures \ "activeTicks").toNullableInt
         },
 
         // bug 1353114 - payload.simpleMeasurements.*
-        asInt(simpleMeasures \ "main"),
+        (simpleMeasures \ "main").toNullableInt,
 
         // Use scalar version when available.
         Try(MainPing.getScalarByName(scalars, scalarDefinitions, "scalar_parent_timestamps_first_paint")) match {
           case Success(x: Integer) => x
-          case _ => asInt (simpleMeasures \ "firstPaint")
+          case _ => (simpleMeasures \ "firstPaint").toNullableInt
         },
 
         // bug 1353114 - payload.simpleMeasurements.*
-        asInt(simpleMeasures \ "sessionRestored"),
-        asInt(simpleMeasures \ "totalTime"),
+        (simpleMeasures \ "sessionRestored").toNullableInt,
+        (simpleMeasures \ "totalTime").toNullableInt,
 
         // bug 1362520 - plugin notifications
         hsum(histograms("parent") \ "PLUGINS_NOTIFICATION_SHOWN"),
@@ -747,16 +632,10 @@ object MainSummaryView {
         // bug 1366253 - active experiments
         getExperiments(experiments).orNull,
 
-        settings \ "searchCohort" match {
-          case JString(x) => x
-          case _ => null
-        },
+        (settings \ "searchCohort").toNullableString,
 
         // bug 1366838 - Quantum Release Criteria
-        system \ "gfx" \ "features" \ "compositor" match {
-          case JString(x) => x
-          case _ => null
-        },
+        (system \ "gfx" \ "features" \ "compositor").toNullableString,
 
         getQuantumReady(
           settings \ "e10sEnabled",

--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -393,247 +393,256 @@ object MainSummaryView {
       val payload = doc \ "payload"
       val meta = doc \ "meta"
 
-      val addons = environment \ "addons"
-      val addonDetails = payload \ "addonDetails"
-      val application = doc \ "application"
-      val build = environment \ "build"
-      val experiments = environment \ "experiments"
-      val profile = environment \ "profile"
-      val partner = environment \ "partner"
-      val settings = environment \ "settings"
-      val system = environment \ "system"
-      val info = payload \ "info"
-      val simpleMeasures = payload \ "simpleMeasurements"
+      // required fields
+      val documentId = (meta \ "documentId").extractOpt[String]
+      val submissionDate = (meta \ "submissionDate").extractOpt[String]
 
-      val histograms = MainPing.ProcessTypes.map{
-        _ match {
-          case "parent" => "parent" -> payload \ "histograms"
-          case p => p -> payload \ "processes" \ p \ "histograms"
+      if (documentId.isDefined && submissionDate.isDefined) {
+
+        val addons = environment \ "addons"
+        val addonDetails = payload \ "addonDetails"
+        val application = doc \ "application"
+        val build = environment \ "build"
+        val experiments = environment \ "experiments"
+        val profile = environment \ "profile"
+        val partner = environment \ "partner"
+        val settings = environment \ "settings"
+        val system = environment \ "system"
+        val info = payload \ "info"
+        val simpleMeasures = payload \ "simpleMeasurements"
+
+        val histograms = MainPing.ProcessTypes.map {
+          _ match {
+            case "parent" => "parent" -> payload \ "histograms"
+            case p => p -> payload \ "processes" \ p \ "histograms"
+          }
+        }.toMap
+
+        val keyedHistograms = MainPing.ProcessTypes.map {
+          _ match {
+            case "parent" => "parent" -> payload \ "keyedHistograms"
+            case p => p -> payload \ "processes" \ p \ "keyedHistograms"
+          }
+        }.toMap
+
+        val scalars = MainPing.ProcessTypes.map {
+          p => p -> payload \ "processes" \ p \ "scalars"
+        }.toMap
+
+        val keyedScalars = MainPing.ProcessTypes.map {
+          p => p -> payload \ "processes" \ p \ "keyedScalars"
+        }.toMap
+
+        val weaveConfigured = MainPing.booleanHistogramToBoolean(histograms("parent") \ "WEAVE_CONFIGURED")
+        val weaveDesktop = MainPing.enumHistogramToCount(histograms("parent") \ "WEAVE_DEVICE_COUNT_DESKTOP")
+        val weaveMobile = MainPing.enumHistogramToCount(histograms("parent") \ "WEAVE_DEVICE_COUNT_MOBILE")
+
+        val events = ("dynamic" :: MainPing.ProcessTypes).map {
+          p => p -> payload \ "processes" \ p \ "events"
         }
-      }.toMap
 
-      val keyedHistograms = MainPing.ProcessTypes.map{
-        _ match {
-          case "parent" => "parent" -> payload \ "keyedHistograms"
-          case p => p -> payload \ "processes" \ p \ "keyedHistograms"
-        }
-      }.toMap
+        val sslHandshakeResultKeys = (0 to 671).map(_.toString)
 
-      val scalars = MainPing.ProcessTypes.map{
-        p => p -> payload \ "processes" \ p \ "scalars"
-      }.toMap
+        // Messy list of known enum values for POPUP_NOTIFICATION_STATS.
+        val popupNotificationStatsKeys = (0 to 8).union(10 to 11).union(20 to 28).union(30 to 31).map(_.toString)
 
-      val keyedScalars = MainPing.ProcessTypes.map{
-        p => p -> payload \ "processes" \ p \ "keyedScalars"
-      }.toMap
+        val pluginNotificationUserActionKeys = (0 to 2).map(_.toString)
 
-      val weaveConfigured = MainPing.booleanHistogramToBoolean(histograms("parent") \ "WEAVE_CONFIGURED")
-      val weaveDesktop = MainPing.enumHistogramToCount(histograms("parent") \ "WEAVE_DEVICE_COUNT_DESKTOP")
-      val weaveMobile = MainPing.enumHistogramToCount(histograms("parent") \ "WEAVE_DEVICE_COUNT_MOBILE")
+        // Get the "sum" field from histogram h as an Int. Consider a
+        // wonky histogram (one for which the "sum" field is not a
+        // valid number) as null.
+        @inline def hsum(h: JValue): Any = (h \ "sum").extractOpt[Int]
 
-      val events = ("dynamic" :: MainPing.ProcessTypes).map {
-        p => p -> payload \ "processes" \ p \ "events"
+        val row = Row.fromSeq(Seq(
+          // Row fields must match the structure in 'buildSchema'
+          documentId,
+          (meta \ "clientId").extractOpt[String],
+          (meta \ "sampleId").extractOpt[Long],
+          (meta \ "appUpdateChannel").extractOpt[String],
+          (meta \ "normalizedChannel").extractOpt[String],
+          (meta \ "geoCountry").extractOpt[String],
+          (meta \ "geoCity").extractOpt[String],
+          (system \ "os" \ "name").extractOpt[String],
+          (system \ "os" \ "version").extractOpt[String],
+          (system \ "os" \ "servicePackMajor").extractOpt[Long],
+          (system \ "os" \ "servicePackMinor").extractOpt[Long],
+          (system \ "os" \ "windowsBuildNumber").extractOpt[Long],
+          (system \ "os" \ "windowsUBR").extractOpt[Long],
+          (system \ "os" \ "installYear").extractOpt[Long],
+          (system \ "isWow64").extractOpt[Boolean],
+          (system \ "memoryMB").extractOpt[Int],
+          (system \ "appleModelId").extractOpt[String],
+          (system \ "sec" \ "antivirus").extract[Option[Seq[String]]],
+          (system \ "sec" \ "antispyware").extract[Option[Seq[String]]],
+          (system \ "sec" \ "firewall").extract[Option[Seq[String]]],
+          (profile \ "creationDate").extractOpt[Long],
+          (profile \ "resetDate").extractOpt[Long],
+          (info \ "subsessionStartDate").extractOpt[String],
+          (info \ "subsessionLength").extractOpt[Long],
+          (info \ "subsessionCounter").extractOpt[Int],
+          (info \ "profileSubsessionCounter").extractOpt[Int],
+          (doc \ "creationDate").extractOpt[String],
+          (partner \ "distributionId").extractOpt[String],
+          submissionDate,
+          weaveConfigured,
+          weaveDesktop,
+          weaveMobile,
+          (application \ "buildId").extractOpt[String],
+          (application \ "displayVersion").extractOpt[String],
+          (application \ "name").extractOpt[String],
+          (application \ "version").extractOpt[String],
+          (meta \ "Timestamp").extractOpt[Long], // required
+          (build \ "buildId").extractOpt[String],
+          (build \ "version").extractOpt[String],
+          (build \ "architecture").extractOpt[String],
+          (settings \ "e10sEnabled").extractOpt[Boolean],
+          (settings \ "e10sMultiProcesses").extractOpt[Long],
+          (settings \ "locale").extractOpt[String],
+          getAttribution(settings \ "attribution"),
+          (addons \ "activeExperiment" \ "id").extractOpt[String],
+          (addons \ "activeExperiment" \ "branch").extractOpt[String],
+          (info \ "reason").extractOpt[String],
+          (info \ "timezoneOffset").extractOpt[Int],
+          hsum(keyedHistograms("parent") \ "SUBPROCESS_CRASHES_WITH_DUMP" \ "pluginhang"),
+          hsum(keyedHistograms("parent") \ "SUBPROCESS_ABNORMAL_ABORT" \ "plugin"),
+          hsum(keyedHistograms("parent") \ "SUBPROCESS_ABNORMAL_ABORT" \ "content"),
+          hsum(keyedHistograms("parent") \ "SUBPROCESS_ABNORMAL_ABORT" \ "gmplugin"),
+          hsum(keyedHistograms("parent") \ "SUBPROCESS_CRASHES_WITH_DUMP" \ "plugin"),
+          hsum(keyedHistograms("parent") \ "SUBPROCESS_CRASHES_WITH_DUMP" \ "content"),
+          hsum(keyedHistograms("parent") \ "SUBPROCESS_CRASHES_WITH_DUMP" \ "gmplugin"),
+          hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_ATTEMPT" \ "main-crash"),
+          hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_ATTEMPT" \ "content-crash"),
+          hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_ATTEMPT" \ "plugin-crash"),
+          hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_SUCCESS" \ "main-crash"),
+          hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_SUCCESS" \ "content-crash"),
+          hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_SUCCESS" \ "plugin-crash"),
+          hsum(keyedHistograms("parent") \ "SUBPROCESS_KILL_HARD" \ "ShutDownKill"),
+          MainPing.countKeys(addons \ "activeAddons"),
+          MainPing.getFlashVersion(addons),
+          (application \ "vendor").extractOpt[String],
+          (settings \ "isDefaultBrowser").extractOpt[Boolean],
+          (settings \ "defaultSearchEngineData" \ "name").extractOpt[String],
+          (settings \ "defaultSearchEngineData" \ "loadPath").extractOpt[String],
+          (settings \ "defaultSearchEngineData" \ "origin").extractOpt[String],
+          (settings \ "defaultSearchEngineData" \ "submissionURL").extractOpt[String],
+          (settings \ "defaultSearchEngine").extractOpt[String],
+          hsum(histograms("parent") \ "DEVTOOLS_TOOLBOX_OPENED_COUNT"),
+          (meta \ "Date").extractOpt[String],
+          MainPing.histogramToMean(histograms("parent") \ "PLACES_BOOKMARKS_COUNT"),
+          MainPing.histogramToMean(histograms("parent") \ "PLACES_PAGES_COUNT"),
+          hsum(histograms("parent") \ "PUSH_API_NOTIFY"),
+          hsum(histograms("parent") \ "WEB_NOTIFICATION_SHOWN"),
+
+          MainPing.keyedEnumHistogramToMap(keyedHistograms("parent") \ "POPUP_NOTIFICATION_STATS",
+            popupNotificationStatsKeys),
+
+          MainPing.getSearchCounts(keyedHistograms("parent") \ "SEARCH_COUNTS"),
+
+          getActiveAddons(addons \ "activeAddons"),
+          getDisabledAddons(addons \ "activeAddons", addonDetails \ "XPI"),
+          getTheme(addons \ "theme"),
+          (settings \ "blocklistEnabled").extractOpt[Boolean],
+          (settings \ "addonCompatibilityCheckEnabled").extractOpt[Boolean],
+          (settings \ "telemetryEnabled").extractOpt[Boolean],
+          getOldUserPrefs(settings \ "userPrefs"),
+
+          Option(events.flatMap { case (p, e) => Events.getEvents(e, p) }).filter(!_.isEmpty),
+
+          // bug 1339655
+          MainPing.enumHistogramBucketCount(histograms("parent") \ "SSL_HANDSHAKE_RESULT", sslHandshakeResultKeys.head),
+          MainPing.enumHistogramSumCounts(histograms("parent") \ "SSL_HANDSHAKE_RESULT", sslHandshakeResultKeys.tail),
+          MainPing.enumHistogramToMap(histograms("parent") \ "SSL_HANDSHAKE_RESULT", sslHandshakeResultKeys),
+
+          // bug 1382002 - use scalar version when available.
+          Try(MainPing.getScalarByName(scalars, scalarDefinitions, "scalar_parent_browser_engagement_active_ticks")) match {
+            case Success(x: Integer) => x
+            case _ => (simpleMeasures \ "activeTicks").extractOpt[Int]
+          },
+
+          // bug 1353114 - payload.simpleMeasurements.*
+          (simpleMeasures \ "main").extractOpt[Int],
+
+          // Use scalar version when available.
+          Try(MainPing.getScalarByName(scalars, scalarDefinitions, "scalar_parent_timestamps_first_paint")) match {
+            case Success(x: Integer) => x
+            case _ => (simpleMeasures \ "firstPaint").extractOpt[Int]
+          },
+
+          // bug 1353114 - payload.simpleMeasurements.*
+          (simpleMeasures \ "sessionRestored").extractOpt[Int],
+          (simpleMeasures \ "totalTime").extractOpt[Int],
+
+          // bug 1362520 - plugin notifications
+          hsum(histograms("parent") \ "PLUGINS_NOTIFICATION_SHOWN"),
+          MainPing.enumHistogramToRow(histograms("parent") \ "PLUGINS_NOTIFICATION_USER_ACTION", pluginNotificationUserActionKeys),
+          hsum(histograms("parent") \ "PLUGINS_INFOBAR_SHOWN"),
+          hsum(histograms("parent") \ "PLUGINS_INFOBAR_BLOCK"),
+          hsum(histograms("parent") \ "PLUGINS_INFOBAR_ALLOW"),
+          hsum(histograms("parent") \ "PLUGINS_INFOBAR_DISMISSED"),
+
+          // bug 1366253 - active experiments
+          getExperiments(experiments),
+
+          (settings \ "searchCohort").extractOpt[String],
+
+          // bug 1366838 - Quantum Release Criteria
+          (system \ "gfx" \ "features" \ "compositor").extractOpt[String],
+
+          getQuantumReady(
+            settings \ "e10sEnabled",
+            addons \ "activeAddons",
+            addons \ "theme"
+          ),
+
+          MainPing.histogramToThresholdCount(histograms("parent") \ "GC_MAX_PAUSE_MS_2", 150),
+          MainPing.histogramToThresholdCount(histograms("parent") \ "GC_MAX_PAUSE_MS_2", 250),
+          MainPing.histogramToThresholdCount(histograms("parent") \ "GC_MAX_PAUSE_MS_2", 2500),
+
+          MainPing.histogramToThresholdCount(histograms("content") \ "GC_MAX_PAUSE_MS_2", 150),
+          MainPing.histogramToThresholdCount(histograms("content") \ "GC_MAX_PAUSE_MS_2", 250),
+          MainPing.histogramToThresholdCount(histograms("content") \ "GC_MAX_PAUSE_MS_2", 2500),
+
+          MainPing.histogramToThresholdCount(histograms("parent") \ "CYCLE_COLLECTOR_MAX_PAUSE", 150),
+          MainPing.histogramToThresholdCount(histograms("parent") \ "CYCLE_COLLECTOR_MAX_PAUSE", 250),
+          MainPing.histogramToThresholdCount(histograms("parent") \ "CYCLE_COLLECTOR_MAX_PAUSE", 2500),
+
+          MainPing.histogramToThresholdCount(histograms("content") \ "CYCLE_COLLECTOR_MAX_PAUSE", 150),
+          MainPing.histogramToThresholdCount(histograms("content") \ "CYCLE_COLLECTOR_MAX_PAUSE", 250),
+          MainPing.histogramToThresholdCount(histograms("content") \ "CYCLE_COLLECTOR_MAX_PAUSE", 2500),
+
+          MainPing.histogramToThresholdCount(histograms("parent") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 150),
+          MainPing.histogramToThresholdCount(histograms("parent") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 250),
+          MainPing.histogramToThresholdCount(histograms("parent") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 2500),
+
+          MainPing.histogramToThresholdCount(histograms("content") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 150),
+          MainPing.histogramToThresholdCount(histograms("content") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 250),
+          MainPing.histogramToThresholdCount(histograms("content") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 2500),
+
+          MainPing.histogramToThresholdCount(histograms("parent") \ "GHOST_WINDOWS", 1),
+          MainPing.histogramToThresholdCount(histograms("content") \ "GHOST_WINDOWS", 1)
+        ).map {
+          _ match {
+            case e: Option[Any] => e.orNull
+            case o => o
+          }
+        })
+
+        val userPrefsRow = getUserPrefs(settings \ "userPrefs", userPrefs)
+
+        val scalarRow = MainPing.scalarsToRow(
+          MainPing.ProcessTypes.map { p => p -> (scalars(p) merge keyedScalars(p)) }.toMap,
+          scalarDefinitions
+        )
+        val histogramRow = MainPing.histogramsToRow(
+          MainPing.ProcessTypes.map { p => p -> (histograms(p) merge keyedHistograms(p)) }.toMap,
+          histogramDefinitions
+        )
+
+        Some(Row.merge(row, userPrefsRow, scalarRow, histogramRow))
       }
-
-      val sslHandshakeResultKeys = (0 to 671).map(_.toString)
-
-      // Messy list of known enum values for POPUP_NOTIFICATION_STATS.
-      val popupNotificationStatsKeys = (0 to 8).union(10 to 11).union(20 to 28).union(30 to 31).map(_.toString)
-
-      val pluginNotificationUserActionKeys = (0 to 2).map(_.toString)
-
-      // Get the "sum" field from histogram h as an Int. Consider a
-      // wonky histogram (one for which the "sum" field is not a
-      // valid number) as null.
-      @inline def hsum(h: JValue): Any = (h \ "sum").extractOpt[Int]
-
-      val row = Row.fromSeq(Seq(
-        // Row fields must match the structure in 'buildSchema'
-        (meta \ "documentId").extractOpt[String],
-        (meta \ "clientId").extractOpt[String],
-        (meta \ "sampleId").extractOpt[Long],
-        (meta \ "appUpdateChannel").extractOpt[String],
-        (meta \ "normalizedChannel").extractOpt[String],
-        (meta \ "geoCountry").extractOpt[String],
-        (meta \ "geoCity").extractOpt[String],
-        (system \ "os" \ "name").extractOpt[String],
-        (system \ "os" \ "version").extractOpt[String],
-        (system \ "os" \ "servicePackMajor").extractOpt[Long],
-        (system \ "os" \ "servicePackMinor").extractOpt[Long],
-        (system \ "os" \ "windowsBuildNumber").extractOpt[Long],
-        (system \ "os" \ "windowsUBR").extractOpt[Long],
-        (system \ "os" \ "installYear").extractOpt[Long],
-        (system \ "isWow64").extractOpt[Boolean],
-        (system \ "memoryMB").extractOpt[Int],
-        (system \ "appleModelId").extractOpt[String],
-        (system \ "sec" \ "antivirus").extract[Option[Seq[String]]],
-        (system \ "sec" \ "antispyware").extract[Option[Seq[String]]],
-        (system \ "sec" \ "firewall").extract[Option[Seq[String]]],
-        (profile \ "creationDate").extractOpt[Long],
-        (profile \ "resetDate").extractOpt[Long],
-        (info \ "subsessionStartDate").extractOpt[String],
-        (info \ "subsessionLength").extractOpt[Long],
-        (info \ "subsessionCounter").extractOpt[Int],
-        (info \ "profileSubsessionCounter").extractOpt[Int],
-        (doc \ "creationDate").extractOpt[String],
-        (partner \ "distributionId").extractOpt[String],
-        (meta \ "submissionDate").extractOpt[String],
-        weaveConfigured,
-        weaveDesktop,
-        weaveMobile,
-        (application \ "buildId").extractOpt[String],
-        (application \ "displayVersion").extractOpt[String],
-        (application \ "name").extractOpt[String],
-        (application \ "version").extractOpt[String],
-        (meta \ "Timestamp").extractOpt[Long], // required
-        (build \ "buildId").extractOpt[String],
-        (build \ "version").extractOpt[String],
-        (build \ "architecture").extractOpt[String],
-        (settings \ "e10sEnabled").extractOpt[Boolean],
-        (settings \ "e10sMultiProcesses").extractOpt[Long],
-        (settings \ "locale").extractOpt[String],
-        getAttribution(settings \ "attribution"),
-        (addons \ "activeExperiment" \ "id").extractOpt[String],
-        (addons \ "activeExperiment" \ "branch").extractOpt[String],
-        (info \ "reason").extractOpt[String],
-        (info \ "timezoneOffset").extractOpt[Int],
-        hsum(keyedHistograms("parent") \ "SUBPROCESS_CRASHES_WITH_DUMP" \ "pluginhang"),
-        hsum(keyedHistograms("parent") \ "SUBPROCESS_ABNORMAL_ABORT" \ "plugin"),
-        hsum(keyedHistograms("parent") \ "SUBPROCESS_ABNORMAL_ABORT" \ "content"),
-        hsum(keyedHistograms("parent") \ "SUBPROCESS_ABNORMAL_ABORT" \ "gmplugin"),
-        hsum(keyedHistograms("parent") \ "SUBPROCESS_CRASHES_WITH_DUMP" \ "plugin"),
-        hsum(keyedHistograms("parent") \ "SUBPROCESS_CRASHES_WITH_DUMP" \ "content"),
-        hsum(keyedHistograms("parent") \ "SUBPROCESS_CRASHES_WITH_DUMP" \ "gmplugin"),
-        hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_ATTEMPT" \ "main-crash"),
-        hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_ATTEMPT" \ "content-crash"),
-        hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_ATTEMPT" \ "plugin-crash"),
-        hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_SUCCESS" \ "main-crash"),
-        hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_SUCCESS" \ "content-crash"),
-        hsum(keyedHistograms("parent") \ "PROCESS_CRASH_SUBMIT_SUCCESS" \ "plugin-crash"),
-        hsum(keyedHistograms("parent") \ "SUBPROCESS_KILL_HARD" \ "ShutDownKill"),
-        MainPing.countKeys(addons \ "activeAddons"),
-        MainPing.getFlashVersion(addons),
-        (application \ "vendor").extractOpt[String],
-        (settings \ "isDefaultBrowser").extractOpt[Boolean],
-        (settings \ "defaultSearchEngineData" \ "name").extractOpt[String],
-        (settings \ "defaultSearchEngineData" \ "loadPath").extractOpt[String],
-        (settings \ "defaultSearchEngineData" \ "origin").extractOpt[String],
-        (settings \ "defaultSearchEngineData" \ "submissionURL").extractOpt[String],
-        (settings \ "defaultSearchEngine").extractOpt[String],
-        hsum(histograms("parent") \ "DEVTOOLS_TOOLBOX_OPENED_COUNT"),
-        (meta \ "Date").extractOpt[String],
-        MainPing.histogramToMean(histograms("parent") \ "PLACES_BOOKMARKS_COUNT"),
-        MainPing.histogramToMean(histograms("parent") \ "PLACES_PAGES_COUNT"),
-        hsum(histograms("parent") \ "PUSH_API_NOTIFY"),
-        hsum(histograms("parent") \ "WEB_NOTIFICATION_SHOWN"),
-
-        MainPing.keyedEnumHistogramToMap(keyedHistograms("parent") \ "POPUP_NOTIFICATION_STATS",
-          popupNotificationStatsKeys),
-
-        MainPing.getSearchCounts(keyedHistograms("parent") \ "SEARCH_COUNTS"),
-
-        getActiveAddons(addons \ "activeAddons"),
-        getDisabledAddons(addons \ "activeAddons", addonDetails \ "XPI"),
-        getTheme(addons \ "theme"),
-        (settings \ "blocklistEnabled").extractOpt[Boolean],
-        (settings \ "addonCompatibilityCheckEnabled").extractOpt[Boolean],
-        (settings \ "telemetryEnabled").extractOpt[Boolean],
-        getOldUserPrefs(settings \ "userPrefs"),
-
-        Option(events.flatMap {case (p, e) => Events.getEvents(e, p)}).filter(!_.isEmpty),
-
-        // bug 1339655
-        MainPing.enumHistogramBucketCount(histograms("parent") \ "SSL_HANDSHAKE_RESULT", sslHandshakeResultKeys.head),
-        MainPing.enumHistogramSumCounts(histograms("parent") \ "SSL_HANDSHAKE_RESULT", sslHandshakeResultKeys.tail),
-        MainPing.enumHistogramToMap(histograms("parent") \ "SSL_HANDSHAKE_RESULT", sslHandshakeResultKeys),
-
-        // bug 1382002 - use scalar version when available.
-        Try(MainPing.getScalarByName(scalars, scalarDefinitions, "scalar_parent_browser_engagement_active_ticks")) match {
-          case Success(x: Integer) => x
-          case _ => (simpleMeasures \ "activeTicks").extractOpt[Int]
-        },
-
-        // bug 1353114 - payload.simpleMeasurements.*
-        (simpleMeasures \ "main").extractOpt[Int],
-
-        // Use scalar version when available.
-        Try(MainPing.getScalarByName(scalars, scalarDefinitions, "scalar_parent_timestamps_first_paint")) match {
-          case Success(x: Integer) => x
-          case _ => (simpleMeasures \ "firstPaint").extractOpt[Int]
-        },
-
-        // bug 1353114 - payload.simpleMeasurements.*
-        (simpleMeasures \ "sessionRestored").extractOpt[Int],
-        (simpleMeasures \ "totalTime").extractOpt[Int],
-
-        // bug 1362520 - plugin notifications
-        hsum(histograms("parent") \ "PLUGINS_NOTIFICATION_SHOWN"),
-        MainPing.enumHistogramToRow(histograms("parent") \ "PLUGINS_NOTIFICATION_USER_ACTION", pluginNotificationUserActionKeys),
-        hsum(histograms("parent") \ "PLUGINS_INFOBAR_SHOWN"),
-        hsum(histograms("parent") \ "PLUGINS_INFOBAR_BLOCK"),
-        hsum(histograms("parent") \ "PLUGINS_INFOBAR_ALLOW"),
-        hsum(histograms("parent") \ "PLUGINS_INFOBAR_DISMISSED"),
-
-        // bug 1366253 - active experiments
-        getExperiments(experiments),
-
-        (settings \ "searchCohort").extractOpt[String],
-
-        // bug 1366838 - Quantum Release Criteria
-        (system \ "gfx" \ "features" \ "compositor").extractOpt[String],
-
-        getQuantumReady(
-          settings \ "e10sEnabled",
-          addons \ "activeAddons",
-          addons \ "theme"
-        ),
-
-        MainPing.histogramToThresholdCount(histograms("parent") \ "GC_MAX_PAUSE_MS_2", 150),
-        MainPing.histogramToThresholdCount(histograms("parent") \ "GC_MAX_PAUSE_MS_2", 250),
-        MainPing.histogramToThresholdCount(histograms("parent") \ "GC_MAX_PAUSE_MS_2", 2500),
-
-        MainPing.histogramToThresholdCount(histograms("content") \ "GC_MAX_PAUSE_MS_2", 150),
-        MainPing.histogramToThresholdCount(histograms("content") \ "GC_MAX_PAUSE_MS_2", 250),
-        MainPing.histogramToThresholdCount(histograms("content") \ "GC_MAX_PAUSE_MS_2", 2500),
-
-        MainPing.histogramToThresholdCount(histograms("parent") \ "CYCLE_COLLECTOR_MAX_PAUSE", 150),
-        MainPing.histogramToThresholdCount(histograms("parent") \ "CYCLE_COLLECTOR_MAX_PAUSE", 250),
-        MainPing.histogramToThresholdCount(histograms("parent") \ "CYCLE_COLLECTOR_MAX_PAUSE", 2500),
-
-        MainPing.histogramToThresholdCount(histograms("content") \ "CYCLE_COLLECTOR_MAX_PAUSE", 150),
-        MainPing.histogramToThresholdCount(histograms("content") \ "CYCLE_COLLECTOR_MAX_PAUSE", 250),
-        MainPing.histogramToThresholdCount(histograms("content") \ "CYCLE_COLLECTOR_MAX_PAUSE", 2500),
-
-        MainPing.histogramToThresholdCount(histograms("parent") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 150),
-        MainPing.histogramToThresholdCount(histograms("parent") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 250),
-        MainPing.histogramToThresholdCount(histograms("parent") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 2500),
-
-        MainPing.histogramToThresholdCount(histograms("content") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 150),
-        MainPing.histogramToThresholdCount(histograms("content") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 250),
-        MainPing.histogramToThresholdCount(histograms("content") \ "INPUT_EVENT_RESPONSE_COALESCED_MS", 2500),
-
-        MainPing.histogramToThresholdCount(histograms("parent") \ "GHOST_WINDOWS", 1),
-        MainPing.histogramToThresholdCount(histograms("content") \ "GHOST_WINDOWS", 1)
-      ).map {
-        _ match {
-          case e: Option[Any] => e.orNull
-          case o => o
-        }
-      })
-
-      val userPrefsRow = getUserPrefs(settings \ "userPrefs", userPrefs)
-
-      val scalarRow = MainPing.scalarsToRow(
-        MainPing.ProcessTypes.map{ p => p -> (scalars(p) merge keyedScalars(p)) }.toMap,
-        scalarDefinitions
-      )
-
-      val histogramRow = MainPing.histogramsToRow(
-        MainPing.ProcessTypes.map{ p => p -> (histograms(p) merge keyedHistograms(p)) }.toMap,
-        histogramDefinitions
-      )
-
-      Some(Row.merge(row, userPrefsRow, scalarRow, histogramRow))
+      else {
+        None
+      }
     } catch {
       case e: Exception =>
         None

--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -421,47 +421,45 @@ object MainSummaryView {
       val payload = doc \ "payload"
       val meta = doc \ "meta"
 
-      // Don't compute the expensive stuff until we need it. We may skip a record
-      // due to missing required fields.
-      lazy val addons = environment \ "addons"
-      lazy val addonDetails = payload \ "addonDetails"
-      lazy val application = doc \ "application"
-      lazy val build = environment \ "build"
-      lazy val experiments = environment \ "experiments"
-      lazy val profile = environment \ "profile"
-      lazy val partner = environment \ "partner"
-      lazy val settings = environment \ "settings"
-      lazy val system = environment \ "system"
-      lazy val info = payload \ "info"
-      lazy val simpleMeasures = payload \ "simpleMeasurements"
+      val addons = environment \ "addons"
+      val addonDetails = payload \ "addonDetails"
+      val application = doc \ "application"
+      val build = environment \ "build"
+      val experiments = environment \ "experiments"
+      val profile = environment \ "profile"
+      val partner = environment \ "partner"
+      val settings = environment \ "settings"
+      val system = environment \ "system"
+      val info = payload \ "info"
+      val simpleMeasures = payload \ "simpleMeasurements"
 
-      lazy val histograms = MainPing.ProcessTypes.map{
+      val histograms = MainPing.ProcessTypes.map{
         _ match {
           case "parent" => "parent" -> payload \ "histograms"
           case p => p -> payload \ "processes" \ p \ "histograms"
         }
       }.toMap
 
-      lazy val keyedHistograms = MainPing.ProcessTypes.map{
+      val keyedHistograms = MainPing.ProcessTypes.map{
         _ match {
           case "parent" => "parent" -> payload \ "keyedHistograms"
           case p => p -> payload \ "processes" \ p \ "keyedHistograms"
         }
       }.toMap
 
-      lazy val scalars = MainPing.ProcessTypes.map{
+      val scalars = MainPing.ProcessTypes.map{
         p => p -> payload \ "processes" \ p \ "scalars"
       }.toMap
 
-      lazy val keyedScalars = MainPing.ProcessTypes.map{
+      val keyedScalars = MainPing.ProcessTypes.map{
         p => p -> payload \ "processes" \ p \ "keyedScalars"
       }.toMap
 
-      lazy val weaveConfigured = MainPing.booleanHistogramToBoolean(histograms("parent") \ "WEAVE_CONFIGURED")
-      lazy val weaveDesktop = MainPing.enumHistogramToCount(histograms("parent") \ "WEAVE_DEVICE_COUNT_DESKTOP")
-      lazy val weaveMobile = MainPing.enumHistogramToCount(histograms("parent") \ "WEAVE_DEVICE_COUNT_MOBILE")
+      val weaveConfigured = MainPing.booleanHistogramToBoolean(histograms("parent") \ "WEAVE_CONFIGURED")
+      val weaveDesktop = MainPing.enumHistogramToCount(histograms("parent") \ "WEAVE_DEVICE_COUNT_DESKTOP")
+      val weaveMobile = MainPing.enumHistogramToCount(histograms("parent") \ "WEAVE_DEVICE_COUNT_MOBILE")
 
-      lazy val events = ("dynamic" :: MainPing.ProcessTypes).map {
+      val events = ("dynamic" :: MainPing.ProcessTypes).map {
         p => p -> payload \ "processes" \ p \ "events"
       }
 

--- a/src/test/scala/com/mozilla/telemetry/views/MainSummaryViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/MainSummaryViewTest.scala
@@ -524,20 +524,20 @@ class MainSummaryViewTest extends FlatSpec with Matchers {
 
   it can "be built" in {
     val userPrefsSchema = MainSummaryView.buildUserPrefsSchema(testUserPrefs)
-    userPrefsSchema.fields.length should be (3)
+    userPrefsSchema.fields.length should be(3)
 
-    userPrefsSchema.fieldNames should be (List("user_pref_p1", "user_pref_p2", "user_pref_p3_messy"))
+    userPrefsSchema.fieldNames should be(List("user_pref_p1", "user_pref_p2", "user_pref_p3_messy"))
 
-    userPrefsSchema.fields(0).dataType should be (IntegerType)
-    userPrefsSchema.fields(1).dataType should be (BooleanType)
-    userPrefsSchema.fields(2).dataType should be (StringType)
+    userPrefsSchema.fields(0).dataType should be(IntegerType)
+    userPrefsSchema.fields(1).dataType should be(BooleanType)
+    userPrefsSchema.fields(2).dataType should be(StringType)
   }
 
   it can "be added to MainSummary schema" in {
     val schemaWithPrefs = MainSummaryView.buildSchema(testUserPrefs, List(), List())
 
-    schemaWithPrefs.fieldNames.contains("user_pref_p3_messy") should be (true)
-    schemaWithPrefs.fieldNames.contains("user_pref_p4") should be (false)
+    schemaWithPrefs.fieldNames.contains("user_pref_p3_messy") should be(true)
+    schemaWithPrefs.fieldNames.contains("user_pref_p4") should be(false)
   }
 
   it can "be added to the top-level" in {
@@ -1707,13 +1707,13 @@ class MainSummaryViewTest extends FlatSpec with Matchers {
   "Malformed message" should "be ignored" in {
 
     var message = RichMessage("1234", Map("documentId" -> "foo", "submissionDate" -> "1234"), None)
-    defaultMessageToRow(message).isDefined should be (true)
+    defaultMessageToRow(message).isDefined should be(true)
 
     message = RichMessage("1234", Map("submissionDate" -> "1234"), None)
-    defaultMessageToRow(message) should be (None)
+    defaultMessageToRow(message) should be(None)
 
     // broken messages should not be parsed
     message = RichMessage("1234", Map("documentId" -> "foo", "submissionDate" -> "1234", "submission" -> "{broken json}"), None)
-    message.toJValue should be (None)
+    message.toJValue should be(None)
   }
 }

--- a/src/test/scala/com/mozilla/telemetry/views/MainSummaryViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/MainSummaryViewTest.scala
@@ -121,7 +121,7 @@ class MainSummaryViewTest extends FlatSpec with Matchers {
       var count = 0
       for (message <- File.parse(input)) {
         message.timestamp should be(1460036116829920000l)
-        message.`type`.get should be("telemetry")
+        message.dtype.get should be("telemetry")
         message.logger.get should be("telemetry")
 
         for (summary <- defaultMessageToRow(message)) {

--- a/src/test/scala/com/mozilla/telemetry/views/MainSummaryViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/MainSummaryViewTest.scala
@@ -1703,4 +1703,17 @@ class MainSummaryViewTest extends FlatSpec with Matchers {
     )
     compare(message, expected)
   }
+
+  "Malformed message" should "be ignored" in {
+
+    var message = RichMessage("1234", Map("documentId" -> "foo", "submissionDate" -> "1234"), None)
+    defaultMessageToRow(message).isDefined should be (true)
+
+    message = RichMessage("1234", Map("submissionDate" -> "1234"), None)
+    defaultMessageToRow(message) should be (None)
+
+    // broken messages should not be parsed
+    message = RichMessage("1234", Map("documentId" -> "foo", "submissionDate" -> "1234", "submission" -> "{broken json}"), None)
+    message.toJValue should be (None)
+  }
 }

--- a/src/test/scala/com/mozilla/telemetry/views/MainSummaryViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/MainSummaryViewTest.scala
@@ -37,8 +37,10 @@ class MainSummaryViewTest extends FlatSpec with Matchers {
 
   val defaultSchema = MainSummaryView.buildSchema(userPrefs, scalarDefs, histogramDefs)
 
-  val defaultMessageToRow = (m: Message) =>
-    MainSummaryView.messageToRow(m, scalarDefs, histogramDefs)
+  val defaultMessageToRow = (m: Message) => {
+    val doc = m.toJValue.get
+    MainSummaryView.messageToRow(doc, scalarDefs, histogramDefs)
+  }
 
   // Apply the given schema to the given potentially-generic Row.
   def applySchema(row: Row, schema: StructType): Row = new GenericRowWithSchema(row.toSeq.toArray, schema)
@@ -61,8 +63,8 @@ class MainSummaryViewTest extends FlatSpec with Matchers {
               histogramDefinitions: List[(String, HistogramDefinition)] = histogramDefs,
               testInvalidFields: List[String] = Nil
              ): Unit = {
-
-    val summary = MainSummaryView.messageToRow(message, scalarDefinitions, histogramDefinitions, userPreferences)
+    val doc = message.toJValue.get
+    val summary = MainSummaryView.messageToRow(doc, scalarDefinitions, histogramDefinitions, userPreferences)
     val applied = applySchema(summary.get, MainSummaryView.buildSchema(userPreferences, scalarDefinitions, histogramDefinitions))
     val actual = applied.getValuesMap(expected.keys.toList)
 


### PR DESCRIPTION
I've added some methods for extracting nullable types from JValues. I liked the concise notation of `JValue.extractOpt[T].orNull` as opposed to the 2 line match statement. 

I ended up putting these methods into an extension class that makes it easy to add and modify methods. These are apparently treated as static method calls once it's been compiled/jit'ed, so they should be fairly fast. [1] On the other-hand, I'm not entirely sure how fast the json4s `extract` methods are compared to pattern matching since it's a generic method. [2]

I might try out the different cases (original, implicit class + pattern matching, implicit class + extract) and see if it makes a significance difference on runtime.

[1] http://docs.scala-lang.org/sips/completed/value-classes.html
[2] https://blog.scalac.io/2017/05/25/scala-specialization.html