### PR TITLE
Bug 1442326 - Do not filter Android sync event pings anymore

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/SyncEventView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/SyncEventView.scala
@@ -72,8 +72,6 @@ object SyncEventView {
           case "4" | "5" => true
         }.where("docType") {
           case "sync" => true
-        }.where("appName") {
-          case "Firefox" => true
         }.where("submissionDate") {
           case date if date == currentDate.toString("yyyyMMdd") => true
         }.records(conf.limit.get)


### PR DESCRIPTION
Firefox Android sends pings with `appName: "Fennec"`.
Let's remove that filter on the SyncEventView and bring it in line with the other views.