### PR TITLE
Bug 1395364 - Remove explicit SparkContext creation, use standard SparkSession utility instead

### DIFF
--- a/src/test/scala/com/mozilla/telemetry/views/CrossSectionalViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/CrossSectionalViewTest.scala
@@ -1,11 +1,9 @@
 package com.mozilla.telemetry
 
-import org.apache.spark.{SparkConf, SparkContext}
-import org.apache.spark.sql.SQLContext
+import com.mozilla.telemetry.utils.getOrCreateSparkSession
 import com.mozilla.telemetry.views._
-import CrossSectionalView._
-import org.scalatest.FlatSpec
 import org.apache.spark.sql.Dataset
+import org.scalatest.FlatSpec
 
 class CrossSectionalViewTest extends FlatSpec {
 
@@ -204,12 +202,9 @@ class CrossSectionalViewTest extends FlatSpec {
   }
 
   "CrossSectional" must "be calculated correctly" in {
-    val sparkConf = new SparkConf().setAppName("CrossSectionalTest")
-    sparkConf.setMaster(sparkConf.get("spark.master", "local[1]"))
-    val sc = new SparkContext(sparkConf)
-    sc.setLogLevel("WARN")
-    val sqlContext = new SQLContext(sc)
-    import sqlContext.implicits._
+    val spark = getOrCreateSparkSession("CrossSectionalTest")
+    spark.sparkContext.setLogLevel("WARN")
+    import spark.implicits._
 
     val longitudinalDataset = Seq(
       getExampleLongitudinal("a"), getExampleLongitudinal("b")
@@ -222,7 +217,7 @@ class CrossSectionalViewTest extends FlatSpec {
     ).toDS
 
     assert(compareDS(actual, expected))
-    sc.stop()
+    spark.stop()
   }
 
   it must "summarize active_addons properly" in {

--- a/src/test/scala/com/mozilla/telemetry/views/MainEventsViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/MainEventsViewTest.scala
@@ -3,7 +3,6 @@ package com.mozilla.telemetry
 import com.mozilla.telemetry.utils.getOrCreateSparkSession
 import com.mozilla.telemetry.views.MainEventsView
 import org.apache.spark.sql.{DataFrame, Row}
-import org.apache.spark.{SparkConf, SparkContext}
 import org.scalatest.{FlatSpec, Matchers}
 
 case class Event(timestamp: Long,
@@ -38,12 +37,8 @@ case class TestMainSummary(document_id: String,
 
 class MainEventsViewTest extends FlatSpec with Matchers{
   "Event records" can "be extracted from MainSummary" in {
-    val sparkConf = new SparkConf().setAppName("MainEventsViewTest")
-    sparkConf.setMaster(sparkConf.get("spark.master", "local[1]"))
-    val sc = new SparkContext(sparkConf)
-    sc.setLogLevel("WARN")
-
     val spark = getOrCreateSparkSession("MainEventsViewTest")
+    spark.sparkContext.setLogLevel("WARN")
 
     import spark.implicits._
 


### PR DESCRIPTION
This removes all remaining cases where SparkContext was explicitly created.
From now on, context is always accessed via session (and it's created via `getOrCreateSparkSession` util).