### PR TITLE
Add search composition experiment to excluded experiments

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/ExperimentSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/ExperimentSummaryView.scala
@@ -19,7 +19,7 @@ object ExperimentSummaryView {
   def experimentsUrl: String = "https://normandy.services.mozilla.com/api/v1/recipe/"
   def experimentsUrlParams = List(("format", "json"))
   def experimentsQualifyingAction = List("preference-experiment", "opt-out-study")
-  def excludedExperiments = List("pref-flip-screenshots-release-1369150")
+  def excludedExperiments = List("pref-flip-screenshots-release-1369150", "pref-flip-search-composition-57-release-1413565")
   private case class NormandyRecipeBranch(ratio: Int, slug: String, value: Any)
   private case class NormandyRecipeArguments(branches: List[NormandyRecipeBranch],
                                              slug: Option[String],


### PR DESCRIPTION
Waiting for confirmation from Dave Zeber that it's safe to merge this in, but this experiment is causing the downstream experiment analysis job to fail (we're up to 2B+ cumulative pings in this experiment) and the story seems to be that it's safe to ignore it since analysis has concluded on this (pending Zeber's approval)