### PR TITLE
Allow Addon scalar definitions in MainSummary

### DIFF
--- a/src/main/resources/addon/Scalars.yaml
+++ b/src/main/resources/addon/Scalars.yaml
@@ -1,0 +1,9 @@
+telemetry.mock:
+  string_kind:
+    description: A test scalar, no soup for you!
+    expires: never
+    kind: string
+    notification_emails:
+      - frank@mozilla.com
+    record_in_processes:
+      - 'dynamic' # All addon scalars need this!

--- a/src/main/scala/com/mozilla/telemetry/metrics/Histogram.scala
+++ b/src/main/scala/com/mozilla/telemetry/metrics/Histogram.scala
@@ -186,7 +186,7 @@ class HistogramsClass extends MetricsClass {
         val labels = v.getOrElse("labels", None).asInstanceOf[Option[Seq[Option[String]]]]
 
         val processes = getProcesses(
-          v.getOrElse("record_in_processes", Some(MainPing.ProcessTypes)).get
+          v.getOrElse("record_in_processes", Some(MainPing.DefaultProcessTypes)).get
           .asInstanceOf[List[String]]
         )
 

--- a/src/main/scala/com/mozilla/telemetry/metrics/Metric.scala
+++ b/src/main/scala/com/mozilla/telemetry/metrics/Metric.scala
@@ -14,9 +14,9 @@ class MetricsClass {
     definitionProcesses.flatMap{
       _ match {
         case "main" => "parent" :: Nil
-        case "all" => MainPing.ProcessTypes
+        case "all" => MainPing.DefaultProcessTypes
         case "all_child" | "all_childs" | "all_children" =>
-          MainPing.ProcessTypes.filter(_ != "parent")
+          MainPing.DefaultProcessTypes.filter(_ != "parent")
         case o => o :: Nil
       }
     }.distinct

--- a/src/main/scala/com/mozilla/telemetry/views/Longitudinal.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/Longitudinal.scala
@@ -820,7 +820,7 @@ object LongitudinalView {
     // Get a list of the scalars in the ping.
     val scalarsList = payloads.map{ case (x) =>
       val payload = parse(x.getOrElse("payload", return).asInstanceOf[String])
-      MainPing.ProcessTypes.map{ process =>
+      MainPing.DefaultProcessTypes.map{ process =>
         (payload \ "processes" \ process \ "scalars").toOption match {
           case Some(scalars) => process -> scalars.extract[Map[String, AnyVal]]
           case _ => process -> Map[String, AnyVal]()
@@ -830,7 +830,7 @@ object LongitudinalView {
 
     // this allows us to avoid iterating
     // through every payload on every scalar
-    val byProcessScalarList = MainPing.ProcessTypes.map{ process =>
+    val byProcessScalarList = MainPing.DefaultProcessTypes.map{ process =>
       process -> scalarsList.map(_(process))
     } toMap
 
@@ -848,7 +848,7 @@ object LongitudinalView {
 
     val scalarsList = payloads.map{ case (x) =>
       val payload = parse(x.getOrElse("payload", return).asInstanceOf[String])
-      MainPing.ProcessTypes.map{ process =>
+      MainPing.DefaultProcessTypes.map{ process =>
         (payload \ "processes" \ process \ "keyedScalars").toOption match {
           case Some(scalars) => process -> scalars.extract[Map[String, Map[String, AnyVal]]]
           case _ => process -> Map[String, Map[String, AnyVal]]()
@@ -858,7 +858,7 @@ object LongitudinalView {
 
     // this allows us to avoid iterating
     // through every payload on every scalar
-    val byProcessScalarList = MainPing.ProcessTypes.map{ process =>
+    val byProcessScalarList = MainPing.DefaultProcessTypes.map{ process =>
       process -> scalarsList.map(_(process))
     } toMap
 

--- a/src/test/scala/com/mozilla/telemetry/metrics/ScalarsTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/metrics/ScalarsTest.scala
@@ -73,4 +73,10 @@ class ScalarsTest extends FlatSpec with Matchers {
     val scalars = fixture.definitions(true)
     assert(scalars("scalar_parent_mock_uint_optin").originalName == "mock.uint.optin")
   }
+
+  "Addon scalars" must "be included" in {
+    val scalars = fixture.definitions(true)
+    assert(scalars("telemetry_mock_string_kind").originalName == "telemetry.mock.string_kind")
+    assert(scalars("telemetry_mock_string_kind").process.get == "dynamic")
+  }
 }

--- a/src/test/scala/com/mozilla/telemetry/views/LongitudinalViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/LongitudinalViewTest.scala
@@ -2,7 +2,7 @@ package com.mozilla.telemetry.views
 
 import com.mozilla.telemetry.metrics.{HistogramsClass, ScalarsClass}
 import com.mozilla.telemetry.parquet.ParquetFile
-import com.mozilla.telemetry.utils.getOrCreateSparkSession
+import com.mozilla.telemetry.utils.{getOrCreateSparkSession, MainPing}
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
 import org.apache.spark.sql.Row
@@ -244,7 +244,7 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
 
       // Opt-out only schema
       val optoutHistogramDefs = histograms.definitions(includeOptin = false)
-      val optoutScalarDefs = scalars.definitions(includeOptin = false)
+      val optoutScalarDefs = scalars.definitions(includeOptin = false).filter(_._2.process != Some(MainPing.DynamicProcess)) // Not fixing this in longitudinal
 
       private val optoutSchema = LongitudinalView invokePrivate buildSchema(optoutHistogramDefs, optoutScalarDefs)
       private val optoutRecord = (LongitudinalView  invokePrivate buildRecord(payloads ++ dupes, optoutSchema, optoutHistogramDefs, optoutScalarDefs)).get
@@ -256,7 +256,7 @@ class LongitudinalTest extends FlatSpec with Matchers with PrivateMethodTester {
 
       // Opt-out and Opt-in schema
       private val optinHistogramDefs = histograms.definitions(includeOptin = true)
-      private val optinScalarDefs = scalars.definitions(includeOptin = true)
+      private val optinScalarDefs = scalars.definitions(includeOptin = true).filter(_._2.process != Some(MainPing.DynamicProcess))
 
       private val optinSchema = LongitudinalView invokePrivate buildSchema(optinHistogramDefs, optinScalarDefs)
       private val optinRecord = (LongitudinalView  invokePrivate buildRecord(payloads ++ dupes, optinSchema, optinHistogramDefs, optinScalarDefs)).get


### PR DESCRIPTION
- Creates a new Scalars.yaml for Addon probes
- Incorporate DefaultProcess and AllowedProcesses for pings