### PR TITLE
Fix handling of null search counts in clients daily

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/utils/udfs.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/udfs.scala
@@ -217,12 +217,14 @@ class AggSearchCounts(validSources: List[String], prefix: String = "search_count
     if (!input.isNullAt(0)) {
       input.getSeq(0).foreach { search_struct: Row =>
         val source: String = search_struct.getString(1)
-        val count: Long = search_struct.getLong(2)
-        if (count > 0 && validSources.contains(source)) {
-          buffer(0) = buffer.getLong(0) + count
-          // index is offset by one because the first field in the buffer is "all"
-          val index = validSources.indexOf(source) + 1
-          buffer(index) = buffer.getLong(index) + count
+        if (!search_struct.isNullAt(2)) {
+          val count: Long = search_struct.getLong(2)
+          if (count > 0 && validSources.contains(source)) {
+            buffer(0) = buffer.getLong(0) + count
+            // index is offset by one because the first field in the buffer is "all"
+            val index = validSources.indexOf(source) + 1
+            buffer(index) = buffer.getLong(index) + count
+          }
         }
       }
     }

--- a/src/test/scala/com/mozilla/telemetry/views/ClientsDailyViewTestPayloads.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/ClientsDailyViewTestPayloads.scala
@@ -461,6 +461,17 @@ object ClientsDailyViewTestPayloads {
         ))),
         // an empty row
         MainSummaryRow(),
+        // a row of null counts
+        MainSummaryRow(search_counts = Some(List(
+          SearchCount(None, Some("abouthome"), None),
+          SearchCount(None, Some("contextmenu"), None),
+          SearchCount(None, Some("newtab"), None),
+          SearchCount(None, Some("searchbar"), None),
+          SearchCount(None, Some("system"), None),
+          SearchCount(None, Some("urlbar"), None),
+          SearchCount(None, Some("invalid"), None),
+          SearchCount(None, None, None)
+        ))),
         // a row of 1s and a row of 0s for good measure
         MainSummaryRow(search_counts = Some(List(
           SearchCount(None, Some("abouthome"), Some(1)),


### PR DESCRIPTION
backfill revealed a missing test case that was breaking the AggSearchCounts udaf