### PR TITLE
Bug 1450079 - Add option to align number of input partitions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val root = (project in file(".")).
     libraryDependencies += "org.apache.hadoop" % "hadoop-client" % "2.7.1" excludeAll(ExclusionRule(organization = "javax.servlet")),
     libraryDependencies += "org.apache.hadoop" % "hadoop-aws" % "2.7.1" excludeAll(ExclusionRule(organization = "javax.servlet")),
     libraryDependencies += "com.github.nscala-time" %% "nscala-time" % "2.10.0",
-    libraryDependencies += "org.rogach" %% "scallop" % "1.0.2",
+    libraryDependencies += "org.rogach" %% "scallop" % "3.1.2",
     libraryDependencies += "org.apache.spark" %% "spark-core" % sparkVersion,
     libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion,
     libraryDependencies += "org.apache.spark" %% "spark-mllib" % sparkVersion,


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1450079)

The `--alignment` option is an integer representing a multiple of
defaultParallelism. If this is set, then the number of partitions will
be `alignment*sc.defaultParallelism`.

The number of documents in the first-shutdown ping is much smaller than main pings. The number of input partitions is `total document size / 268 MB`. This means the default tuning for moztelemetry and MainSummaryView will lead to poor performance on smaller document sets. This improves the performance with a smaller set of machines in the cluster (10 vs 25) on a large dataset, or a smaller dataset with a larger number of machines (first-shutdown instead of main). 

The option preserves the current behavior, but it would marginally improve MainSummary run time with a value of 4 (3 hours vs 3.4 hours) if added to the airflow config.

## Performance Evaluation
The setup is 3 c3.4xlarge workers from ATMO. This uses a single day of first-shutdown pings from 2018-03-01.

### Unaligned
```
time spark-submit \
--master yarn \
--class com.mozilla.telemetry.views.MainSummaryView \
target/scala-2.11/telemetry-batch-view-1.1.jar \
--to 20180301 \
--from 20180301 \
--bucket telemetry-test-bucket \
--doc-type first_shutdown
```

The number of input partitions is 3.

```
real	39m42.862s
user	1m5.712s
sys	0m9.408s
```


### With alignment
```
time spark-submit \
--master yarn \
--class com.mozilla.telemetry.views.MainSummaryView \
target/scala-2.11/telemetry-batch-view-1.1.jar \
--to 20180301 \
--from 20180301 \
--bucket telemetry-test-bucket \
--doc-type first_shutdown \
--alignment 4
```

The number of input partitions is 256.

```
real    8m43.580s
user    1m3.660s
sys     0m8.820s
```
