### PR TITLE
Add ability to skip tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,12 @@ before_install:
   - alias docker-run='docker run -v $PWD:/telemetry-batch-view $CI_ENV --env-file .travis-env telemetry-batch-view'
 
 script:
-  - docker-run ./run-sbt.sh coverage slow:test coverageReport
+  - export TEST_SKIP_REGEX="\[skip-tests\]"
+  - if [[ (! $TRAVIS_COMMIT_MESSAGE =~ $TEST_SKIP_REGEX) || -n $TRAVIS_TAG || $TRAVIS_BRANCH == "master" ]]; then
+      docker-run ./run-sbt.sh coverage slow:test coverageReport;
+    else
+      echo "Skipping tests";
+    fi
 
 before_deploy:
   - export JAR="target/scala-2.11/telemetry-batch-view-1.1.jar"


### PR DESCRIPTION
This will support the quick-development use-case. Tests cannot
be skipped on tagged releases or master.

For example, if an engineer is working on a branch, and wants
to test out her changes using Airflow, they would need to build
the artifact and push it to s3 using a non-master branch. With
tests, that could take upwards of 1 hour -- with [skip-tests],
it should take under 5 minutes.