### PR TITLE
Versions update

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You may need to increase the amount of memory allocated to Docker for this to wo
 
 You can also pass arguments to sbt (the scala build tool we use for running the tests) through the runtests.sh. For example, to run only the addon tests, try:
 
-    ./run-sbt.sh "test-only com.mozilla.telemetry.AddonsViewTest"
+    ./run-sbt.sh "testOnly com.mozilla.telemetry.AddonsViewTest"
 
 If you wish to import the project into IntelliJ IDEA, apply the following changes to `Preferences` -> `Languages & Frameworks` -> `Scala Compile Server`:
 
@@ -56,7 +56,7 @@ See the [documentation for specific views](https://github.com/mozilla/telemetry-
 
 For example, to create a longitudinal view locally:
 ```bash
-sbt "run-main com.mozilla.telemetry.views.LongitudinalView --from 20160101 --to 20160701 --bucket telemetry-test-bucket"
+sbt "runMain com.mozilla.telemetry.views.LongitudinalView --from 20160101 --to 20160701 --bucket telemetry-test-bucket"
 ```
 
 For distributed execution we pack all of the classes together into a single JAR and submit it to the cluster:

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ val localMaven = "s3://net-mozaws-data-us-west-2-ops-mavenrepo/"
 
 resolvers += "S3 local maven snapshots" at localMavenHttps + "snapshots"
 
-val sparkVersion = "2.0.2"
+val sparkVersion = "2.3.0"
 
 lazy val root = (project in file(".")).
   settings(
@@ -22,7 +22,7 @@ lazy val root = (project in file(".")).
     libraryDependencies += "org.apache.parquet" % "parquet-avro" % "1.7.0",
     libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4",
     libraryDependencies += "net.sandrogrzicic" %% "scalabuff-runtime" % "1.4.0",
-    libraryDependencies += "com.holdenkarau" %% "spark-testing-base" % "2.0.0_0.4.7" % "test",
+    libraryDependencies += "com.holdenkarau" %% "spark-testing-base" % "2.3.0_0.9.0" % "test",
     libraryDependencies += "org.xerial.snappy" % "snappy-java" % "1.1.2",
     libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.2.10",
     libraryDependencies += "joda-time" % "joda-time" % "2.9.2",

--- a/docs/CrashAggregateView.md
+++ b/docs/CrashAggregateView.md
@@ -3,7 +3,7 @@ The Crash Aggregate View
 
 To generate the dataset for April 10, 2016 to April 11, 2016:
 ```bash
-sbt "run-main com.mozilla.telemetry.views.CrashAggregateView --from 20160410 --to 20160411 --bucket telemetry-bucket"
+sbt "runMain com.mozilla.telemetry.views.CrashAggregateView --from 20160410 --to 20160411 --bucket telemetry-bucket"
 ```
 
 **Note:** Currently, due to [avro-parquet

--- a/java.policy
+++ b/java.policy
@@ -1,0 +1,9 @@
+// https://docs.oracle.com/javase/8/docs/technotes/guides/security/permissions.html
+// https://docs.oracle.com/javase/8/docs/technotes/guides/security/PolicyFiles.html
+
+grant {
+  // https://issues.apache.org/jira/browse/SPARK-22918
+  // Because sbt imposes a SecurityManager to trap exit statuses, derby throws exceptions;
+  // adding this permission is the recommended path forward if a SecurityManager is in effect.
+  permission org.apache.derby.security.SystemPermission "engine", "usederbyinternals";
+};

--- a/run-sbt.sh
+++ b/run-sbt.sh
@@ -12,15 +12,18 @@ if [ ! -f /.dockerenv ]; then
     exit $?
 fi
 
+# Set options that sbt will pass to the JVM
+export SBT_OPTS="-Xss2M -Djava.security.policy=java.policy"
+
 # Run tests
 if [ $TRAVIS_BRANCH ]; then
    # under travis, submit code coverage data
-   sbt -J-Xss2M "$@"
+   sbt "$@"
    bash <(curl -s https://codecov.io/bash)
 elif [ $# -gt 0 ]; then
    # if args specified, run the tests with those
-   sbt -J-Xss2M "$@"
+   sbt "$@"
 else
    # default: just run the tests
-   sbt -J-Xss2M test
+   sbt test
 fi

--- a/src/test/scala/com/mozilla/telemetry/ml/AddonRecommenderTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/ml/AddonRecommenderTest.scala
@@ -3,8 +3,8 @@ package com.mozilla.telemetry.ml
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
+import com.holdenkarau.spark.testing.DatasetSuiteBase
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers, PrivateMethodTester}
-import com.mozilla.telemetry.utils.getOrCreateSparkSession
 import org.apache.spark.sql.Dataset
 
 import scala.collection.Map
@@ -28,10 +28,8 @@ private case class TestLongitudinalRow(client_id: Option[String],
                                        active_addons: Option[Seq[Map[String, TestActiveAddonData]]],
                                        build: Option[Seq[TestBuildData]])
 
-class AddonRecommenderTest extends FlatSpec with BeforeAndAfterAll with Matchers with PrivateMethodTester{
+class AddonRecommenderTest extends FlatSpec with BeforeAndAfterAll with Matchers with PrivateMethodTester with DatasetSuiteBase {
   private var amoDB: Map[String, AMOAddonInfo] = Map[String, AMOAddonInfo]()
-  private val spark = getOrCreateSparkSession("AddonRecommenderTest", enableHiveSupport = true)
-  import spark.implicits._
 
   override def beforeAll() {
     // Generate a sample AMO database cache file and save it.
@@ -137,11 +135,13 @@ class AddonRecommenderTest extends FlatSpec with BeforeAndAfterAll with Matchers
 
     // Init the AMO Database.
     amoDB = AMODatabase.getAddonMap()
+
+    super.beforeAll()
   }
 
   override def afterAll(): Unit = {
     Files.deleteIfExists(AMODatabase.getLocalCachePath())
-    spark.stop()
+    super.afterAll()
   }
 
   "hash" must "return positive hash codes" in {
@@ -153,6 +153,9 @@ class AddonRecommenderTest extends FlatSpec with BeforeAndAfterAll with Matchers
   }
 
   "getAddonData" must "filter undesired addons" in {
+
+    import spark.implicits._
+
     val dataset = List(
       // This user has an add-on which is not on AMO and a webextension one.
       TestLongitudinalRow(Some("foo_id"),

--- a/src/test/scala/com/mozilla/telemetry/views/CrashAggregateViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/CrashAggregateViewTest.scala
@@ -30,12 +30,12 @@ class CrashAggregateViewTest extends FlatSpec with Matchers with BeforeAndAfterA
   )
 
   var spark: SparkSession = _
-  override def beforeAll(configMap: org.scalatest.ConfigMap) {
+  override def beforeAll() {
     spark = getOrCreateSparkSession("KPI")
     spark.sparkContext.setLogLevel("WARN")
   }
 
-  override def afterAll(configMap: org.scalatest.ConfigMap) {
+  override def afterAll() {
     spark.stop()
   }
 

--- a/src/test/scala/com/mozilla/telemetry/views/CrossSectionalViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/CrossSectionalViewTest.scala
@@ -1,11 +1,11 @@
 package com.mozilla.telemetry
 
-import com.mozilla.telemetry.utils.getOrCreateSparkSession
+import com.holdenkarau.spark.testing.DatasetSuiteBase
 import com.mozilla.telemetry.views._
 import org.apache.spark.sql.Dataset
 import org.scalatest.FlatSpec
 
-class CrossSectionalViewTest extends FlatSpec {
+class CrossSectionalViewTest extends FlatSpec with DatasetSuiteBase {
 
   // Add compare method to classes extending the Product trait (including
   // case classes)
@@ -202,7 +202,6 @@ class CrossSectionalViewTest extends FlatSpec {
   }
 
   "CrossSectional" must "be calculated correctly" in {
-    val spark = getOrCreateSparkSession("CrossSectionalTest")
     spark.sparkContext.setLogLevel("WARN")
     import spark.implicits._
 
@@ -217,7 +216,6 @@ class CrossSectionalViewTest extends FlatSpec {
     ).toDS
 
     assert(compareDS(actual, expected))
-    spark.stop()
   }
 
   it must "summarize active_addons properly" in {

--- a/src/test/scala/com/mozilla/telemetry/views/GenericLongitudinalTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/GenericLongitudinalTest.scala
@@ -1,12 +1,11 @@
 package com.mozilla.telemetry.views
 
-import com.mozilla.telemetry.utils.getOrCreateSparkSession
+import com.holdenkarau.spark.testing.DatasetSuiteBase
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.hive.HiveContext
 import org.apache.spark.sql.types._
 import org.scalatest.FlatSpec
 
-class GenericLongitudinalTest extends FlatSpec {
+class GenericLongitudinalTest extends FlatSpec with DatasetSuiteBase {
   val tablename = "test_table"
   val colNames = List("random_data", "client_id", "submission_date_s3", "os", "ordering")
   val data = List(
@@ -67,51 +66,46 @@ class GenericLongitudinalTest extends FlatSpec {
     "--output-path" :: "missing-bucket" ::
     "--ordering-columns" :: "long_val" :: Nil
 
-  val fixture = {
+  // We make this lazy so that it doesn't run until beforeAll() has
+  // had a chance to set up the spark context.
+  lazy val fixture = {
     new {
-      private val spark = getOrCreateSparkSession("Generic Longitudinal Test")
-
-      private val sc = spark.sparkContext
-      private val hiveContext = new HiveContext(sc)
-
       import spark.implicits._
       data.toDF(colNames: _*).registerTempTable(tablename)
 
       private val opts = new GenericLongitudinalView.Opts(args.toArray)
-      private val groupedDf = GenericLongitudinalView.run(hiveContext, opts)
+      private val groupedDf = GenericLongitudinalView.run(spark, opts)
 
       val longitudinal = groupedDf.collect()
       val fieldIndex: String => Integer = longitudinal.head.fieldIndex
 
       val intOrdering = GenericLongitudinalView.run(
-        hiveContext,
+        spark,
         new GenericLongitudinalView.Opts(intOrderingArgs.toArray)
       ).collect()
 
       val secondaryOrdering = GenericLongitudinalView.run(
-        hiveContext,
+        spark,
         new GenericLongitudinalView.Opts(secondaryOrderingArgs.toArray)
       ).collect()
 
       val alternateGrouping = GenericLongitudinalView.run(
-        hiveContext,
+        spark,
         new GenericLongitudinalView.Opts(alternateGroupingArgs.toArray)
       ).collect()
 
       nestedData.toDF(nestedDataColNames: _*).registerTempTable(nestedDataTableName)
       val nestedGroup = GenericLongitudinalView.run(
-        hiveContext,
+        spark,
         new GenericLongitudinalView.Opts(nestedArgs.toArray)
       ).collect()
 
       // Test Long sorting - can't use List.toDF for nulled Long
       spark.createDataFrame(sc.parallelize(longData), longSchema).registerTempTable(longTempTableName)
       val groupedLongDF = GenericLongitudinalView.run(
-        hiveContext,
+        spark,
         new GenericLongitudinalView.Opts(longArgs.toArray)
       ).collect()
-
-      spark.stop()
     }
   }
 


### PR DESCRIPTION
Support for hyphen-separated key names was dropped in sbt 1.0.0;
see https://www.scala-sbt.org/1.x/docs/sbt-1.0-Release-Notes.html#sbt+1.0.0

Also updates to the Spark version used by current default EMR in ATMO.