### PR TITLE
Add test duration logging and cache CrashAggregateView test fixture

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,10 @@ lazy val Slow = config("slow").extend(Test)
 configs(Slow)
 inConfig(Slow)(Defaults.testTasks)
 
-testOptions in Test := Seq(Tests.Argument("-l", "org.scalatest.tags.Slow"))
+testOptions in Test := Seq(
+  Tests.Argument("-l", "org.scalatest.tags.Slow"),
+  // -oD add duration reporting; see http://www.scalatest.org/user_guide/using_scalatest_with_sbt
+  Tests.Argument("-oD"))
 testOptions in Slow := Seq()
 
 publishMavenStyle := true

--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,9 @@ testOptions in Test := Seq(
   Tests.Argument("-l", "org.scalatest.tags.Slow"),
   // -oD add duration reporting; see http://www.scalatest.org/user_guide/using_scalatest_with_sbt
   Tests.Argument("-oD"))
-testOptions in Slow := Seq()
+testOptions in Slow := Seq(
+  // -oD add duration reporting; see http://www.scalatest.org/user_guide/using_scalatest_with_sbt
+  Tests.Argument("-oD"))
 
 publishMavenStyle := true
 

--- a/build.sbt
+++ b/build.sbt
@@ -67,10 +67,11 @@ inConfig(Slow)(Defaults.testTasks)
 testOptions in Test := Seq(
   Tests.Argument("-l", "org.scalatest.tags.Slow"),
   // -oD add duration reporting; see http://www.scalatest.org/user_guide/using_scalatest_with_sbt
-  Tests.Argument("-oD"))
+  Tests.Argument("-oD")
+)
 testOptions in Slow := Seq(
-  // -oD add duration reporting; see http://www.scalatest.org/user_guide/using_scalatest_with_sbt
-  Tests.Argument("-oD"))
+  Tests.Argument("-oD")
+)
 
 publishMavenStyle := true
 

--- a/src/test/scala/com/mozilla/telemetry/views/CrashAggregateViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/CrashAggregateViewTest.scala
@@ -39,7 +39,7 @@ class CrashAggregateViewTest extends FlatSpec with Matchers with BeforeAndAfterA
     spark.stop()
   }
 
-  def fixture = {
+  lazy val fixture = {
     def cartesianProduct(dimensions: List[(String, List[Any])]): Iterable[Map[String, Any]] = {
       dimensions match {
         case Nil => List(Map[String, Any]())


### PR DESCRIPTION
For the following invocation:

./run-sbt.sh "testOnly *CrashAggregateViewTest"

runtime is 18 seconds with the lazy val.

Previously, this test took on order 5 minutes to run,
recreating the fixture for each individual call.