### PR TITLE
Bug 1417571 - Improve test times via parallel Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,6 @@ jobs:
         - PURPOSE='stage the uberjar to S3'
       script:
         - pip install --user awscli
-        - export AWS_ACCESS_KEY_ID=$ARTIFACTS_KEY
-        - export AWS_SECRET_ACCESS_KEY=$ARTIFACTS_SECRET
-        - export AWS_REGION=$ARTIFACTS_REGION
         - docker build -t telemetry-batch-view .
         - docker-run ./run-sbt.sh "set test in assembly := {}" assembly && aws s3 cp $LOCAL_JAR $STAGED_JAR_URL
     # The deploy stage jobs only run once all jobs from the previous phase succeed.
@@ -68,9 +65,6 @@ jobs:
         - PURPOSE='deploy the staged uberjar to S3'
       script:
         - pip install --user awscli
-        - export AWS_ACCESS_KEY_ID=$ARTIFACTS_KEY
-        - export AWS_SECRET_ACCESS_KEY=$ARTIFACTS_SECRET
-        - export AWS_REGION=$ARTIFACTS_REGION
         - mkdir -p $(dirname $LOCAL_JAR)
         - aws s3 cp $STAGED_JAR_URL $LOCAL_JAR
         - JAR=$LOCAL_JAR bash deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,40 +3,75 @@ sudo: required
 services:
   - docker
 
+# Try to keep things quick here since this section runs on every job whether it invokes sbt or not.
 before_install:
+  - export LOCAL_JAR='target/scala-2.11/telemetry-batch-view-1.1.jar'
+  - export STAGED_JAR_URL="s3://$ARTIFACTS_BUCKET/tmp/$TRAVIS_REPO_SLUG/build-$TRAVIS_BUILD_NUMBER.jar"
   - shopt -s expand_aliases
   - env | grep TRAVIS > .travis-env
   - CI_ENV=`bash <(curl -s https://codecov.io/env)`
-  - docker build -t telemetry-batch-view .
   - alias docker-run='docker run -v $PWD:/telemetry-batch-view $CI_ENV --env-file .travis-env telemetry-batch-view'
 
+env:
+  - SCALATEST_ARGS='-n ScalarAnalyzerBuild'
+  - SCALATEST_ARGS='-n ExperimentsBuild'
+  - SCALATEST_ARGS='-n ClientsDailyBuild'
+  # This final build must exclude (-l) all of the tags above and no others
+  # in order to assure we get full test coverage across the parallel builds.
+  - SCALATEST_ARGS='-l "ScalarAnalyzerBuild ExperimentsBuild ClientsDailyBuild"'
+
+# Code to run for the main test jobs.
 script:
   - export TEST_SKIP_REGEX="\[skip-tests\]"
   - if [[ (! $TRAVIS_COMMIT_MESSAGE =~ $TEST_SKIP_REGEX) || -n $TRAVIS_TAG || $TRAVIS_BRANCH == "master" ]]; then
-      docker-run ./run-sbt.sh coverage slow:test coverageReport;
+      docker build -t telemetry-batch-view .;
+      docker-run ./run-sbt.sh coverage "testOnly * -- $SCALATEST_ARGS" coverageReport;
     else
       echo "Skipping tests";
     fi
 
 before_deploy:
-  - export JAR="target/scala-2.11/telemetry-batch-view-1.1.jar"
-  - docker-run ./run-sbt.sh assembly
   - git config --local user.name "Auto Deployer"
   - git config --local user.email "telemetry-alerts@mozilla.com"
   - git tag "$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)"
 
-deploy:
-  - provider: releases
-    skip_cleanup: true
-    api_key:
-      secure: Kac5/sXg9TM8cBHrwNch78UiVTl4aA2KQ9jnv0vipUzi341XfmO3EbdEnSCWN+ew39Pc+tAR+nOB+e/AHbOyFjJ5gggA3Z/3UWPYse/8iIPcRs8GC55KfprDrVkD8HO3pPzOXOyDtn64Y6z3cQXGj110QKfPjG6v+LHzNDSl1oxZB7f8bnoNEom5WxZCMAvZO3odbrnKPP333gPpjtmXfe24WlPqBMg3FN+RJMy1lz+bjlDB0hd1qbVdUO3DYivodcn/q1Sdp98EipwCWnOq3JqrmfDhf9rRL1UnSC+WsbcxJL73ee36EkNORSTYVFzhfoSRmNlhqNgGI8DdDhO654fKecXPiWDHyZw+cF/DQHsvmSk5zr5VobeqyByM9cqFj+5gs3RN3CI2UaUbceRwuerwpuFCAVt2WHSw2heYeOlmoLNX2+HFYPCXFJOkzQ5pZl5fEsc280riU/9wlvNfLhKTIJNyP3n3OlU/YlU0FYfR2jF637KAhLX9z8LxY1aEcdcAI7sWCz5jyMGRwvCS7prRneg1ouPn+bUSab7+GMi8F3Rdf1qWZx8IivpXiOw3MubsLLBeXep+PbE70n6AFB68ThgKEAhJsJpqtZKbqpz3w+w6iOe9Ig85P+WdXTK7zC4itWzZfEihk8TTGzerlSHgpMR9lBgvkzJkFY3MQqI=
-    on:
-      repo: mozilla/telemetry-batch-view
-      condition: $TRAVIS_COMMIT_MESSAGE == *"[auto-deploy]"*
-      branch: master
-  - provider: script
-    script: bash deploy.sh
-    skip_cleanup: true
-    on:
-      repo: mozilla/telemetry-batch-view
-      all_branches: true
+jobs:
+  include:
+    # Add an additional job to the 'test' stage for assembling the uberjar and staging in S3.
+    - stage: test
+      env:
+        - PURPOSE='stage the uberjar to S3'
+      script:
+        - pip install --user awscli
+        - export AWS_ACCESS_KEY_ID=$ARTIFACTS_KEY
+        - export AWS_SECRET_ACCESS_KEY=$ARTIFACTS_SECRET
+        - export AWS_REGION=$ARTIFACTS_REGION
+        - docker build -t telemetry-batch-view .
+        - docker-run ./run-sbt.sh "set test in assembly := {}" assembly && aws s3 cp $LOCAL_JAR $STAGED_JAR_URL
+    # The deploy stage jobs only run once all jobs from the previous phase succeed.
+    - stage: deploy
+      env:
+        - PURPOSE='run a GitHub release'
+      script: skip
+      deploy:
+      - provider: releases
+        skip_cleanup: true
+        api_key:
+          secure: Kac5/sXg9TM8cBHrwNch78UiVTl4aA2KQ9jnv0vipUzi341XfmO3EbdEnSCWN+ew39Pc+tAR+nOB+e/AHbOyFjJ5gggA3Z/3UWPYse/8iIPcRs8GC55KfprDrVkD8HO3pPzOXOyDtn64Y6z3cQXGj110QKfPjG6v+LHzNDSl1oxZB7f8bnoNEom5WxZCMAvZO3odbrnKPP333gPpjtmXfe24WlPqBMg3FN+RJMy1lz+bjlDB0hd1qbVdUO3DYivodcn/q1Sdp98EipwCWnOq3JqrmfDhf9rRL1UnSC+WsbcxJL73ee36EkNORSTYVFzhfoSRmNlhqNgGI8DdDhO654fKecXPiWDHyZw+cF/DQHsvmSk5zr5VobeqyByM9cqFj+5gs3RN3CI2UaUbceRwuerwpuFCAVt2WHSw2heYeOlmoLNX2+HFYPCXFJOkzQ5pZl5fEsc280riU/9wlvNfLhKTIJNyP3n3OlU/YlU0FYfR2jF637KAhLX9z8LxY1aEcdcAI7sWCz5jyMGRwvCS7prRneg1ouPn+bUSab7+GMi8F3Rdf1qWZx8IivpXiOw3MubsLLBeXep+PbE70n6AFB68ThgKEAhJsJpqtZKbqpz3w+w6iOe9Ig85P+WdXTK7zC4itWzZfEihk8TTGzerlSHgpMR9lBgvkzJkFY3MQqI=
+        on:
+          repo: mozilla/telemetry-batch-view
+          condition: $TRAVIS_COMMIT_MESSAGE == *"[auto-deploy]"*
+          branch: master
+    - stage: deploy
+      if: repo = mozilla/telemetry-batch-view
+      env:
+        - PURPOSE='deploy the staged uberjar to S3'
+      script:
+        - pip install --user awscli
+        - export AWS_ACCESS_KEY_ID=$ARTIFACTS_KEY
+        - export AWS_SECRET_ACCESS_KEY=$ARTIFACTS_SECRET
+        - export AWS_REGION=$ARTIFACTS_REGION
+        - mkdir -p $(dirname $LOCAL_JAR)
+        - aws s3 cp $STAGED_JAR_URL $LOCAL_JAR
+        - JAR=$LOCAL_JAR bash deploy.sh
+        - aws s3 rm $STAGED_JAR_URL

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ before_install:
   - alias docker-run='docker run -v $PWD:/telemetry-batch-view $CI_ENV --env-file .travis-env telemetry-batch-view'
 
 env:
+  # There should be one job defined for each Scalatest tag defined in
+  # src/test/scala/com/mozilla/telemetry/tags/Tags.scala
   - SCALATEST_ARGS='-n ScalarAnalyzerBuild'
   - SCALATEST_ARGS='-n ExperimentsBuild'
   - SCALATEST_ARGS='-n ClientsDailyBuild'

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,8 @@ jobs:
       script:
         - pip install --user awscli
         - docker build -t telemetry-batch-view .
-        - docker-run ./run-sbt.sh "set test in assembly := {}" assembly && aws s3 cp $LOCAL_JAR $STAGED_JAR_URL
+        - docker-run ./run-sbt.sh assembly
+        - aws s3 cp $LOCAL_JAR $STAGED_JAR_URL
     # The deploy stage jobs only run once all jobs from the previous phase succeed.
     - stage: deploy
       env:

--- a/README.md
+++ b/README.md
@@ -65,6 +65,21 @@ sbt assembly
 spark-submit --master yarn --deploy-mode client --class com.mozilla.telemetry.views.LongitudinalView target/scala-2.11/telemetry-batch-view-*.jar --from 20160101 --to 20160701 --bucket telemetry-test-bucket
 ```
 
+### Maintaining Tests
+
+Running the full suite of test cases can take more than 30 minutes, so we have configured
+our CI system to run tests in parallel across multiple jobs. These jobs are defined in `.travis.yml`
+and rely on Scalatest tags to determine which test cases run in which jobs.
+
+Any new test cases that run faster than 10 seconds can remain in the catch-all job for untagged tests,
+but please consider tagging any longer-running test cases. If you're introducing several new
+long-running tasks, please define a new tag in Tags.scala, tag your tests, and update the `.travis.yml`
+to define an additional test job for that tag.
+
+We may need to periodically rebalance test cases across tags. If you notice one of the test jobs
+in TravisCI becoming the bottleneck, read through the logs for that job to see runtimes for each test
+case and consider moving some expensive tests to a different job or splitting them out to a new tag.
+
 ### Testing in Dev Airflow with `[skip-tests]`
 
 It is possible to launch the job locally exactly as it will in production. When doing this, we recommend

--- a/README.md
+++ b/README.md
@@ -73,12 +73,23 @@ and rely on Scalatest tags to determine which test cases run in which jobs.
 
 Any new test cases that run faster than 10 seconds can remain in the catch-all job for untagged tests,
 but please consider tagging any longer-running test cases. If you're introducing several new
-long-running tasks, please define a new tag in Tags.scala, tag your tests, and update the `.travis.yml`
-to define an additional test job for that tag.
+long-running tasks, please define a new tag (see checklist below).
 
 We may need to periodically rebalance test cases across tags. If you notice one of the test jobs
 in TravisCI becoming the bottleneck, read through the logs for that job to see runtimes for each test
 case and consider moving some expensive tests to a different job or splitting them out to a new tag.
+At the time of writing, setup for each job (building the Docker container, compiling the code, etc.)
+takes about 5 minutes and we target keeping the total run time for each test job to 10 minutes.
+We could benefit from more parallelism if we reduced the setup time.
+
+#### Defining a new tag
+
+Whenever you introduce a new Scalatest tag, you'll need to make the following changes:
+
+- Define the new tag in `Tags.scala`
+- Tag some long-running test cases with the new tag
+- Update `.travis.yml` to add an a new `env` case to run the new tag
+- Update `.travis.yml` to add the new tag to the list of exclusions for the catch-all test job (last line in the `env` list)
 
 ### Testing in Dev Airflow with `[skip-tests]`
 

--- a/README.md
+++ b/README.md
@@ -101,9 +101,6 @@ If you run into memory issues during compilation time or running the test suite,
 export _JAVA_OPTIONS="-Xms4G -Xmx4G -Xss4M -XX:MaxMetaspaceSize=256M"
 ```
 
-**Slow tests**
-By default slow tests are not run when using `sbt test`. To run slow tests use `./runtests.sh slow:test` (or just `sbt slow:test` outside of the Docker environment).
-
 **Running on Windows**
 
 Executing scala/Spark jobs could be particularly problematic on this platform. Here's a list of common issues and the relative solutions:

--- a/build.sbt
+++ b/build.sbt
@@ -60,16 +60,8 @@ assemblyMergeStrategy in assembly := {
 parallelExecution in Test := false
 logBuffered in Test := false
 
-lazy val Slow = config("slow").extend(Test)
-configs(Slow)
-inConfig(Slow)(Defaults.testTasks)
-
 testOptions in Test := Seq(
-  Tests.Argument("-l", "org.scalatest.tags.Slow"),
   // -oD add duration reporting; see http://www.scalatest.org/user_guide/using_scalatest_with_sbt
-  Tests.Argument("-oD")
-)
-testOptions in Slow := Seq(
   Tests.Argument("-oD")
 )
 

--- a/src/test/scala/com/mozilla/telemetry/experiments/analyzers/HistogramAnalyzerTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/experiments/analyzers/HistogramAnalyzerTest.scala
@@ -2,6 +2,7 @@ package com.mozilla.telemetry.experiments.analyzers
 
 import com.holdenkarau.spark.testing.DatasetSuiteBase
 import com.mozilla.telemetry.metrics.{EnumeratedHistogram, LinearHistogram}
+import com.mozilla.telemetry.tags.ClientsDailyBuild
 import org.apache.spark.sql.DataFrame
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -42,7 +43,7 @@ class HistogramAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase
     HistogramPoint(v.toDouble/total, v.toLong, label)
   }
 
-  "Non-keyed Histograms" can "be aggregated" in {
+  "Non-keyed Histograms" can "be aggregated" taggedAs (ClientsDailyBuild) in {
     val df = fixture
     val categoricalAnalyzer = new HistogramAnalyzer("histogram",
       EnumeratedHistogram(keyed = false, "name", 150),

--- a/src/test/scala/com/mozilla/telemetry/experiments/analyzers/ScalarAnalyzerTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/experiments/analyzers/ScalarAnalyzerTest.scala
@@ -2,6 +2,7 @@ package com.mozilla.telemetry.experiments.analyzers
 
 import com.holdenkarau.spark.testing.DatasetSuiteBase
 import com.mozilla.telemetry.metrics._
+import com.mozilla.telemetry.tags.ScalarAnalyzerBuild
 import org.apache.spark.sql.DataFrame
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -69,7 +70,7 @@ class ScalarAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase {
     }.toMap
   }
 
-  "Uint Scalars" can "be aggregated" in {
+  "Uint Scalars" can "be aggregated" taggedAs (ScalarAnalyzerBuild) in {
     val df = fixture
     val analyzer = ScalarAnalyzer.getAnalyzer("uint_scalar",
       UintScalar(false, "name"),
@@ -109,7 +110,7 @@ class ScalarAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase {
     actual.map(_.statistics.get.map(_.name).toSet).foreach(s => assert(s == expectedStats))
   }
 
-  "Keyed Uint Scalars" can "be aggregated" in {
+  "Keyed Uint Scalars" can "be aggregated" taggedAs (ScalarAnalyzerBuild) in {
     val df = fixture
     val analyzer = ScalarAnalyzer.getAnalyzer("keyed_uint_scalar",
       UintScalar(true, "name"),
@@ -272,7 +273,7 @@ class ScalarAnalyzerTest extends FlatSpec with Matchers with DatasetSuiteBase {
     assert(actual == expected)
   }
 
-  "Invalid scalars" should "be filtered out" in {
+  "Invalid scalars" should "be filtered out" taggedAs (ScalarAnalyzerBuild) in {
     val df = fixture
     val analyzer = ScalarAnalyzer.getAnalyzer("uint_scalar",
       UintScalar(false, "name"),

--- a/src/test/scala/com/mozilla/telemetry/tags/Tags.scala
+++ b/src/test/scala/com/mozilla/telemetry/tags/Tags.scala
@@ -1,0 +1,8 @@
+package com.mozilla.telemetry.tags
+
+import org.scalatest.Tag
+
+object ScalarAnalyzerBuild extends Tag("ScalarAnalyzerBuild")
+object ExperimentsBuild extends Tag("ExperimentsBuild")
+object ClientsDailyBuild extends Tag("ClientsDailyBuild")
+

--- a/src/test/scala/com/mozilla/telemetry/tags/Tags.scala
+++ b/src/test/scala/com/mozilla/telemetry/tags/Tags.scala
@@ -2,6 +2,11 @@ package com.mozilla.telemetry.tags
 
 import org.scalatest.Tag
 
+// These tags are used to parallelize tests when they run on TravisCI;
+// The .travis.yml defines the different test jobs and it's expected that
+// there will be one job per tag defined here plus one additional job to
+// catch all untagged tests.
+
 object ScalarAnalyzerBuild extends Tag("ScalarAnalyzerBuild")
 object ExperimentsBuild extends Tag("ExperimentsBuild")
 object ClientsDailyBuild extends Tag("ClientsDailyBuild")

--- a/src/test/scala/com/mozilla/telemetry/views/ClientsDailyViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/ClientsDailyViewTest.scala
@@ -1,12 +1,12 @@
 package com.mozilla.telemetry.views
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
-import org.apache.spark.sql.SparkSession
+import com.mozilla.telemetry.tags.ClientsDailyBuild
 import org.scalatest.{FlatSpec, Matchers}
 
 class ClientsDailyViewTest extends FlatSpec with Matchers with DataFrameSuiteBase {
 
-  "aggregates" must "aggregate properly" in {
+  "aggregates" must "aggregate properly" taggedAs (ClientsDailyBuild) in {
     import spark.implicits._
     ClientsDailyViewTestPayloads.genericTests.foreach { pair =>
       val (table, expect) = pair

--- a/src/test/scala/com/mozilla/telemetry/views/ExperimentAnalysisViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/ExperimentAnalysisViewTest.scala
@@ -2,6 +2,7 @@ package com.mozilla.telemetry
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
 import com.mozilla.telemetry.experiments.analyzers.CrashAnalyzer
+import com.mozilla.telemetry.tags.ExperimentsBuild
 import com.mozilla.telemetry.views.ExperimentAnalysisView
 import org.apache.spark.sql.functions.col
 import org.scalatest.{FlatSpec, Matchers}
@@ -59,10 +60,15 @@ class ExperimentAnalysisViewTest extends FlatSpec with Matchers with DataFrameSu
     "histogram_content_gc_max_pause_ms_2"
   )
 
-  "Child Scalars" can "be counted" in {
+  lazy val id1Data = {
+    import spark.implicits._
+    predata.toDS().toDF().where(col("experiment_id") === "id1")
+  }
+
+  "Child Scalars" can "be counted" taggedAs (ExperimentsBuild) in {
     import spark.implicits._
 
-    val data = predata.toDS().toDF().where(col("experiment_id") === "id1")
+    val data = id1Data
     val args =
       "--input" :: "telemetry-mock-bucket" ::
       "--output" :: "telemetry-mock-bucket" :: Nil
@@ -74,10 +80,10 @@ class ExperimentAnalysisViewTest extends FlatSpec with Matchers with DataFrameSu
     agg.histogram(1).pdf should be (1.0)
   }
 
-  "Child Histograms" can "be counted" in {
+  "Child Histograms" can "be counted" taggedAs (ExperimentsBuild) in {
     import spark.implicits._
 
-    val data = predata.toDS().toDF().where(col("experiment_id") === "id1")
+    val data = id1Data
     val args =
       "--input" :: "telemetry-mock-bucket" ::
       "--output" :: "telemetry-mock-bucket" :: Nil
@@ -89,10 +95,10 @@ class ExperimentAnalysisViewTest extends FlatSpec with Matchers with DataFrameSu
     agg.histogram(1).pdf should be (1.0)
   }
 
-  "Total client ids and pings" can "be counted" in {
+  "Total client ids and pings" can "be counted" taggedAs (ExperimentsBuild) in {
     import spark.implicits._
 
-    val data = predata.toDS().toDF().where(col("experiment_id") === "id1")
+    val data = id1Data
     val args =
       "--input" :: "telemetry-mock-bucket" ::
       "--output" :: "telemetry-mock-bucket" :: Nil
@@ -108,7 +114,7 @@ class ExperimentAnalysisViewTest extends FlatSpec with Matchers with DataFrameSu
     first.filter(_.name == "Total Clients").head.value should be (1.0)
   }
 
-  "Crashes" can "be crash counted correctly" in {
+  "Crashes" can "be crash counted correctly" taggedAs (ExperimentsBuild) in {
     import spark.implicits._
 
     val multiplier = 3
@@ -140,7 +146,7 @@ class ExperimentAnalysisViewTest extends FlatSpec with Matchers with DataFrameSu
     }
   }
 
-  "Experiment Analysis View" can "handle missing error_aggregates data" in {
+  "Experiment Analysis View" can "handle missing error_aggregates data" taggedAs (ExperimentsBuild) in {
     import spark.implicits._
 
     val df = spark.emptyDataFrame


### PR DESCRIPTION
This PR reduces the runtime for CI from > 30 minutes to ~12 minutes by splitting testing work into parallel jobs and moving deployment to a separate "stage" of the build.

See an example of the layout of jobs and associated runtimes in https://travis-ci.org/mozilla/telemetry-batch-view/builds/385852363

This PR consists of adding Scalatest tags in the Scala source and a significant refactoring of the .travis.yml in order to use those tags to define separate jobs.

We also add a little bit of test fixture cleanup to reduce duplicated work. 
