### PR TITLE
Fix problem that caused CI on forks to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ jobs:
   include:
     # Add an additional job to the 'test' stage for assembling the uberjar and staging in S3.
     - stage: test
+      if: fork = false
       env:
         - PURPOSE='stage the uberjar to S3'
       script:
@@ -63,7 +64,7 @@ jobs:
           condition: $TRAVIS_COMMIT_MESSAGE == *"[auto-deploy]"*
           branch: master
     - stage: deploy
-      if: repo = mozilla/telemetry-batch-view
+      if: fork = false
       env:
         - PURPOSE='deploy the staged uberjar to S3'
       script:


### PR DESCRIPTION
We were trying to build an uberjar and stage in S3,
but that requires encrypted env vars that aren't avaialable to
builds on forks, so we need to make the assembly and deploy stages conditional.