### PR TITLE
Use new base image that has sbt baked in

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,4 @@
-FROM java:8
-
-ENV SBT_VERSION 1.1.1
-ENV HBASE_VERSION 1.2.3
-
-# Install sbt
-RUN \
-  curl -L -o sbt-$SBT_VERSION.deb http://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb && \
-  dpkg -i sbt-$SBT_VERSION.deb && \
-  rm sbt-$SBT_VERSION.deb && \
-  apt-get update && \
-  apt-get install sbt && \
-  sbt sbtVersion
+FROM hseeberger/scala-sbt:8u151-2.12.4-1.1.1
 
 ENV _JAVA_OPTIONS="-Xms4G -Xmx4G -Xss4M -XX:MaxMetaspaceSize=512M"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mozilla/scala-sbt:8u171_1.1.1
+FROM mozilla/sbt:8u171_1.1.1
 
 ENV _JAVA_OPTIONS="-Xms4G -Xmx4G -Xss4M -XX:MaxMetaspaceSize=512M"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u151-2.12.4-1.1.1
+FROM mozilla/scala-sbt:8u171_1.1.1
 
 ENV _JAVA_OPTIONS="-Xms4G -Xmx4G -Xss4M -XX:MaxMetaspaceSize=512M"
 


### PR DESCRIPTION
This should make startup a bit faster and it will avoid the
problem on TravisCI where parallel jobs all hit bintray at the
same time, leading to throttling and intermittent failed jobs.