### PR TITLE
Roll back avro dependency versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,8 +31,8 @@ lazy val root = (project in file(".")).
     libraryDependencies += "org.apache.spark" %% "spark-hive" % sparkVersion,
 
     // Other dependencies
-    libraryDependencies += "org.apache.avro" % "avro" % "1.8.2",
-    libraryDependencies += "org.apache.parquet" % "parquet-avro" % "1.8.3",
+    libraryDependencies += "org.apache.avro" % "avro" % "1.7.7",
+    libraryDependencies += "org.apache.parquet" % "parquet-avro" % "1.7.0",
     libraryDependencies += "net.sandrogrzicic" %% "scalabuff-runtime" % "1.4.0",
     libraryDependencies += "org.xerial.snappy" % "snappy-java" % "1.1.7.2",
     libraryDependencies += "joda-time" % "joda-time" % "2.10",


### PR DESCRIPTION
https://github.com/mozilla/telemetry-batch-view/pull/434
updated versions that changed the interface for Avro and caused
Longitudinal to fail.