### PR TITLE
Use Scalastyle for enforcing style rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,10 +147,10 @@ workflows:
   build:
     jobs:
       - test
+      - lint
       - assembly
-      # - lint  # enable once https://github.com/mozilla/telemetry-batch-view/pull/442 is merged
       - deploy:
           requires:
             - test
+            - lint
             - assembly
-            # - lint  # enable once https://github.com/mozilla/telemetry-batch-view/pull/442 is merged

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ If you wish to import the project into IntelliJ IDEA, apply the following change
 
 Note that the first time the project is opened it takes some time to download all the dependencies.
 
+### Scala style checker
+[Scalastyle](http://www.scalastyle.org/) is used on the CI for enforcing style rules. In order to run it locally, use:
+```bash
+sbt scalastyle test:scalastyle
+```
+
 ### Generating Datasets
 
 See the [documentation for specific views](https://github.com/mozilla/telemetry-batch-view/tree/master/docs) for details about running/generating them.

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,6 @@ lazy val root = (project in file(".")).
     name := "telemetry-batch-view",
     version := "1.1",
     scalaVersion := "2.11.8",
-    retrieveManaged := true,
     // Hack to get releases to not fail to upload when the same jar name already exists. Later we will need auto versioning
     isSnapshot := true,
     scalaModuleInfo := scalaModuleInfo.value.map(_.withOverrideScalaVersion(true)),

--- a/build.sbt
+++ b/build.sbt
@@ -87,3 +87,7 @@ publishTo := {
 // Speeds up finding snapshot releases:
 // https://www.scala-sbt.org/1.x/docs/Combined+Pages.html#Latest+SNAPSHOTs
 updateOptions := updateOptions.value.withLatestSnapshots(false)
+
+val scalaStyleConfigUrl = Some(url("https://raw.githubusercontent.com/mozilla/moztelemetry/master/scalastyle-config.xml"))
+(scalastyleConfigUrl in Compile) := scalaStyleConfigUrl
+(scalastyleConfigUrl in Test) := scalaStyleConfigUrl

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,10 @@
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint")
-scalacOptions ++= Seq("-Xmax-classfile-name", "242")
+scalacOptions ++= Seq(
+    "-Xmax-classfile-name", "242",
+    "-feature",
+    "-Ywarn-unused",
+    "-Ywarn-unused-import"
+)
 
 val localMavenHttps = "https://s3-us-west-2.amazonaws.com/net-mozaws-data-us-west-2-ops-mavenrepo/"
 val localMaven = "s3://net-mozaws-data-us-west-2-ops-mavenrepo/"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,3 +2,4 @@ resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.14.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")

--- a/src/main/scala/com/mozilla/telemetry/Partitioning.scala
+++ b/src/main/scala/com/mozilla/telemetry/Partitioning.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry
 
 import org.json4s._

--- a/src/main/scala/com/mozilla/telemetry/avro/JSON2Avro.scala
+++ b/src/main/scala/com/mozilla/telemetry/avro/JSON2Avro.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.avro
 
 import com.mozilla.telemetry.utils._

--- a/src/main/scala/com/mozilla/telemetry/experiments/Permutations.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/Permutations.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.experiments
 
 import scala.util.hashing.MurmurHash3

--- a/src/main/scala/com/mozilla/telemetry/experiments/analyzers/Aggregators.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/analyzers/Aggregators.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.experiments.analyzers
 
 import org.apache.spark.sql.Encoder
@@ -25,21 +28,25 @@ abstract class GroupAggregator[T]
 
 object GroupBooleanAggregator extends GroupAggregator[Boolean] {
   def bufferEncoder: Encoder[Map[Boolean, Long]] = ExpressionEncoder()
+
   def outputEncoder: Encoder[Map[Boolean, Long]] = ExpressionEncoder()
 }
 
 object GroupUintAggregator extends GroupAggregator[Int] {
   def bufferEncoder: Encoder[Map[Int, Long]] = ExpressionEncoder()
+
   def outputEncoder: Encoder[Map[Int, Long]] = ExpressionEncoder()
 }
 
 object GroupLongAggregator extends GroupAggregator[Long] {
   def bufferEncoder: Encoder[Map[Long, Long]] = ExpressionEncoder()
+
   def outputEncoder: Encoder[Map[Long, Long]] = ExpressionEncoder()
 }
 
 object GroupStringAggregator extends GroupAggregator[String] {
   def bufferEncoder: Encoder[Map[String, Long]] = ExpressionEncoder()
+
   def outputEncoder: Encoder[Map[String, Long]] = ExpressionEncoder()
 }
 
@@ -59,11 +66,14 @@ abstract class MapAggregator[T]
 object BooleanAggregator extends MapAggregator[Boolean] {
   def finish(b: Map[Boolean, Long]): Map[Long, HistogramPoint] = {
     val sum = b.values.sum.toDouble
-    if (sum == 0) return Map.empty[Long, HistogramPoint]
-    val f = b.getOrElse(false, 0L).toDouble
-    val t = b.getOrElse(true, 0L).toDouble
+    if (sum == 0) {
+      Map.empty[Long, HistogramPoint]
+    } else {
+      val f = b.getOrElse(false, 0L).toDouble
+      val t = b.getOrElse(true, 0L).toDouble
 
-    Map(0L -> HistogramPoint(f/sum, f, Some("False")), 1L -> HistogramPoint(t/sum, t, Some("True")))
+      Map(0L -> HistogramPoint(f / sum, f, Some("False")), 1L -> HistogramPoint(t / sum, t, Some("True")))
+    }
   }
 
   def bufferEncoder: Encoder[Map[Boolean, Long]] = ExpressionEncoder()
@@ -72,8 +82,11 @@ object BooleanAggregator extends MapAggregator[Boolean] {
 object UintAggregator extends MapAggregator[Int] {
   def finish(b: Map[Int, Long]): Map[Long, HistogramPoint] = {
     val sum = b.values.sum.toDouble
-    if (sum == 0) return Map.empty[Long, HistogramPoint]
-    b.map { case (k: Int, v) => k.toLong -> HistogramPoint(v.toDouble / sum, v.toDouble, None) }
+    if (sum == 0) {
+      Map.empty[Long, HistogramPoint]
+    } else {
+      b.map { case (k: Int, v) => k.toLong -> HistogramPoint(v.toDouble / sum, v.toDouble, None) }
+    }
   }
 
   def bufferEncoder: Encoder[Map[Int, Long]] = ExpressionEncoder()
@@ -82,8 +95,11 @@ object UintAggregator extends MapAggregator[Int] {
 object LongAggregator extends MapAggregator[Long] {
   def finish(b: Map[Long, Long]): Map[Long, HistogramPoint] = {
     val sum = b.values.sum.toDouble
-    if (sum == 0) return Map.empty[Long, HistogramPoint]
-    b.map { case (k: Long, v) => k -> HistogramPoint(v.toDouble / sum, v.toDouble, None) }
+    if (sum == 0) {
+      Map.empty[Long, HistogramPoint]
+    } else {
+      b.map { case (k: Long, v) => k -> HistogramPoint(v.toDouble / sum, v.toDouble, None) }
+    }
   }
 
   def bufferEncoder: Encoder[Map[Long, Long]] = ExpressionEncoder()
@@ -92,11 +108,14 @@ object LongAggregator extends MapAggregator[Long] {
 object StringAggregator extends MapAggregator[String] {
   def finish(b: Map[String, Long]): Map[Long, HistogramPoint] = {
     val sum = b.values.sum.toDouble
-    if (sum == 0) return Map.empty[Long, HistogramPoint]
-    // We can't assign real numeric indexes until we combine all the histograms across all branches
-    // so just assign any number for now
-    b.zipWithIndex.map {
-      case ((l: String, v), i) => i.toLong -> HistogramPoint(v.toDouble / sum, v.toDouble, Some(l))
+    if (sum == 0) {
+      Map.empty[Long, HistogramPoint]
+    } else {
+      // We can't assign real numeric indexes until we combine all the histograms across all branches
+      // so just assign any number for now
+      b.zipWithIndex.map {
+        case ((l: String, v), i) => i.toLong -> HistogramPoint(v.toDouble / sum, v.toDouble, Some(l))
+      }
     }
   }
 

--- a/src/main/scala/com/mozilla/telemetry/experiments/analyzers/CrashAnalyzer.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/analyzers/CrashAnalyzer.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.experiments.analyzers
 
 import org.apache.spark.sql.{Column, DataFrame}
@@ -6,7 +9,7 @@ import org.apache.spark.sql.types._
 
 object CrashAnalyzer {
 
-  val CrashTypes = 
+  val CrashTypes =
     "main_crashes"             ::
     "content_crashes"          ::
     "gpu_crashes"              ::

--- a/src/main/scala/com/mozilla/telemetry/experiments/analyzers/ExperimentAnalyzer.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/analyzers/ExperimentAnalyzer.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.experiments.analyzers
 
 import org.apache.spark.sql.{DataFrame, Dataset}

--- a/src/main/scala/com/mozilla/telemetry/experiments/analyzers/HistogramAnalyzer.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/analyzers/HistogramAnalyzer.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.experiments.analyzers
 
 import com.mozilla.telemetry.metrics.HistogramDefinition

--- a/src/main/scala/com/mozilla/telemetry/experiments/analyzers/MetricAnalyzer.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/analyzers/MetricAnalyzer.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.experiments.analyzers
 
 import com.mozilla.telemetry.experiments.statistics.{ComparativeStatistics, DescriptiveStatistics}

--- a/src/main/scala/com/mozilla/telemetry/experiments/analyzers/ScalarAnalyzer.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/analyzers/ScalarAnalyzer.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.experiments.analyzers
 
 import com.mozilla.telemetry.metrics._
@@ -167,9 +170,9 @@ class StringScalarAnalyzer(name: String, md: ScalarDefinition, df: DataFrame, nu
       a.histogram.values.map {p: HistogramPoint => p.label.get -> p.count.toLong}.toMap[String, Long]
     }
 
-    if (counts.isEmpty)
+    if (counts.isEmpty) {
       aggregates
-    else {
+    } else {
       val indexes = counts.reduce(addHistograms[String]).toSeq.sortWith(_._2 > _._2).zipWithIndex.map {
         case ((key, _), index) => key -> index.toLong
       }.toMap

--- a/src/main/scala/com/mozilla/telemetry/experiments/analyzers/package.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/analyzers/package.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.experiments
 
 import scala.collection.Map

--- a/src/main/scala/com/mozilla/telemetry/experiments/statistics/ComparativeStatistics.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/statistics/ComparativeStatistics.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.experiments.statistics
 
 import com.mozilla.telemetry.experiments.analyzers.{HistogramPoint, MetricAnalysis, Statistic}

--- a/src/main/scala/com/mozilla/telemetry/experiments/statistics/DescriptiveStatistics.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/statistics/DescriptiveStatistics.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.experiments.statistics
 
 import com.mozilla.telemetry.experiments.analyzers.{HistogramPoint, MetricAnalysis, Statistic}
@@ -82,12 +85,12 @@ object Percentile {
   }
 
   protected def getNthValue(n: Long, h: Map[Long, HistogramPoint]): Long = {
-    @tailrec def _getNthValue(n: Long, l: List[(Long, Long)], cumulative: Long): Long = {
+    @tailrec def getNthValue(n: Long, l: List[(Long, Long)], cumulative: Long): Long = {
       val (bucket, count) = l.head
-      if (cumulative + count >= n) bucket else _getNthValue(n, l.tail, cumulative + count)
+      if (cumulative + count >= n) bucket else getNthValue(n, l.tail, cumulative + count)
     }
 
-    _getNthValue(n, h.toList.sortBy(_._1).map { case (bucket, point) => (bucket, point.count.toLong) }, 0L)
+    getNthValue(n, h.toList.sortBy(_._1).map { case (bucket, point) => (bucket, point.count.toLong) }, 0L)
   }
 }
 

--- a/src/main/scala/com/mozilla/telemetry/experiments/statistics/package.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/statistics/package.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.experiments
 
 package object statistics {

--- a/src/main/scala/com/mozilla/telemetry/metrics/Metric.scala
+++ b/src/main/scala/com/mozilla/telemetry/metrics/Metric.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.metrics
 
 import com.mozilla.telemetry.utils.MainPing

--- a/src/main/scala/com/mozilla/telemetry/metrics/Scalars.scala
+++ b/src/main/scala/com/mozilla/telemetry/metrics/Scalars.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.metrics
 
 import java.util
@@ -21,7 +24,7 @@ trait ScalarType {
     case false => name
   }
 
-  def getParquetType = keyed match {
+  def getParquetType: DataType = keyed match {
     case true => MapType(StringType, dataType, valueContainsNull = true)
     case false => dataType
   }
@@ -160,4 +163,4 @@ class ScalarsClass extends MetricsClass {
   }
 }
 
-package object Scalars extends ScalarsClass
+object Scalars extends ScalarsClass

--- a/src/main/scala/com/mozilla/telemetry/ml/AMODatabase.scala
+++ b/src/main/scala/com/mozilla/telemetry/ml/AMODatabase.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.ml
 
 import java.nio.charset.StandardCharsets

--- a/src/main/scala/com/mozilla/telemetry/ml/AddonRecommender.scala
+++ b/src/main/scala/com/mozilla/telemetry/ml/AddonRecommender.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.ml
 
 import java.nio.charset.StandardCharsets
@@ -159,6 +162,7 @@ object AddonRecommender {
     }.sortWith((x, y) => x._2 > y._2)
   }
 
+  // scalastyle:off methodLength
   private def train(localOutputDir: String, runDate: String, privateBucket: String, publicBucket: String) = {
     // The AMODatabase init needs to happen before we get the SparkContext,
     // otherwise the job will fail due to all the workers being idle.
@@ -266,6 +270,7 @@ object AddonRecommender {
 
     sc.stop()
   }
+  // scalastyle:on methodLength
 
   def main(args: Array[String]) {
     val conf = new Conf(args)
@@ -275,7 +280,9 @@ object AddonRecommender {
         val addons = conf.recommend.addons().split(",")
         val top = conf.recommend.top()
         val input = conf.recommend.input()
+        // scalastyle:off print-ln
         recommend(input, addons.toSet).take(top).foreach(println)
+        // scalastyle:on print-ln
 
       case Some(command) if command == conf.train =>
         val output = conf.train.output()

--- a/src/main/scala/com/mozilla/telemetry/ml/NaNRegressionEvaluator.scala
+++ b/src/main/scala/com/mozilla/telemetry/ml/NaNRegressionEvaluator.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.apache.spark.ml.evaluation
 
 import org.apache.spark.ml.param.{BooleanParam, Param, ParamMap, ParamValidators}

--- a/src/main/scala/com/mozilla/telemetry/parquet/ParquetFile.scala
+++ b/src/main/scala/com/mozilla/telemetry/parquet/ParquetFile.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.parquet
 
 import java.util.logging.Logger

--- a/src/main/scala/com/mozilla/telemetry/utils/Aggregation.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/Aggregation.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.utils
 
 package object aggregation {
@@ -10,7 +13,7 @@ package object aggregation {
   }
 
   def weightedMean(pairs: Seq[(Long, Long)]): Option[Double] = {
-    val ttl_weight = pairs.foldLeft(0l)((acc, pair) => acc + pair._2)
+    val ttl_weight = pairs.foldLeft(0L)((acc, pair) => acc + pair._2)
     val sum_prod = pairs.foldLeft(0.0)((acc, pair) => acc + (pair._1 * pair._2))
 
     if (ttl_weight > 0) {

--- a/src/main/scala/com/mozilla/telemetry/utils/Events.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/Events.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.utils
 
 import org.apache.spark.sql.Row
@@ -98,7 +101,7 @@ object Events {
   }
 
 
-  def buildEventSchema = StructType(List(
+  def buildEventSchema: StructType = StructType(List(
     StructField("timestamp",    LongType, nullable = false),
     StructField("category",     StringType, nullable = false),
     StructField("method",       StringType, nullable = false),

--- a/src/main/scala/com/mozilla/telemetry/utils/MainPing.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/MainPing.scala
@@ -1,10 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.utils
 
 import com.mozilla.telemetry.metrics._
-import org.json4s.DefaultFormats
-import org.json4s.JsonAST._
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
+import org.json4s.DefaultFormats
+import org.json4s.JsonAST._
 
 import scala.util.{Success, Try}
 
@@ -50,24 +53,24 @@ abstract class UserPref {
 }
 
 case class IntegerUserPref(name: String) extends UserPref {
-  override def dataType = IntegerType
-  override def getValue(v: JValue) = v match {
+  override def dataType: IntegerType = IntegerType
+  override def getValue(v: JValue): Any = v match {
     case JInt(x) => x.toInt
     case _ => null
   }
 }
 
 case class BooleanUserPref(name: String) extends UserPref {
-  override def dataType = BooleanType
-  override def getValue(v: JValue) = v match {
+  override def dataType: BooleanType = BooleanType
+  override def getValue(v: JValue): Any = v match {
     case JBool(x) => x
     case _ => null
   }
 }
 
 case class StringUserPref(name: String) extends UserPref {
-  override def dataType = StringType
-  override def getValue(v: JValue) = v match {
+  override def dataType: StringType = StringType
+  override def getValue(v: JValue): Any = v match {
     case JString(x) => x
     case _ => null
   }
@@ -85,7 +88,7 @@ object MainPing{
       case _ => None
     }
   }
-
+  // scalastyle:off return
   def compareFlashVersions(x: Option[String], y: Option[String]): Option[Int] = {
     (x, y) match {
       case (Some(a), None) => Some(1)
@@ -135,13 +138,11 @@ object MainPing{
       case _ => None
     }
   }
+  // scalastyle:on return
 
   private def maxFlashVersion(a: String, b: String): String = {
     val c = compareFlashVersions(Some(a), Some(b)).getOrElse(1)
-    if (c < 0)
-      b
-    else
-      a
+    if (c < 0) b else a
   }
 
   // See also:
@@ -154,10 +155,7 @@ object MainPing{
       if addonName == "Shockwave Flash"
     } yield addonVersion
 
-    if (flashVersions.nonEmpty)
-      Some(flashVersions.reduceLeft(maxFlashVersion(_, _)))
-    else
-      None
+    if (flashVersions.nonEmpty) Some(flashVersions.reduceLeft(maxFlashVersion(_, _))) else None
   }
 
   private val searchKeyPattern = "^(.+)\\.(.+)$".r
@@ -184,8 +182,7 @@ object MainPing{
       for ((k, v) <- x) {
         buf.append(searchHistogramToRow(k, v))
       }
-      if (buf.isEmpty) None
-      else Some(buf.toList)
+      if (buf.isEmpty) None else Some(buf.toList)
     case _ => None
   }
 
@@ -248,10 +245,7 @@ object MainPing{
       if enumRow != null
     } yield (enumKey, enumRow))
 
-    if (enums.isEmpty)
-      None
-    else
-      Some(enums)
+    if (enums.isEmpty) None else Some(enums)
   }
 
   // Find the largest numeric bucket that contains a value greater than zero.
@@ -304,8 +298,7 @@ object MainPing{
           JObject(values) <- h \ "values"
           JField(bucket, JInt(count)) <- values
         } yield count).sum
-        if (totalCount == 0) None
-        else Some((sum / totalCount).toInt)
+        if (totalCount == 0) None else Some((sum / totalCount).toInt)
       }
       case _ => None
     }
@@ -345,10 +338,7 @@ object MainPing{
       if scalarVal != null
     } yield (key, scalarVal))
 
-    if (keys.isEmpty)
-      None
-    else
-      Some(keys)
+    if (keys.isEmpty) None else Some(keys)
   }
 
   def getScalarByName(scalars: Map[String, JValue], definitions: List[(String, ScalarDefinition)],

--- a/src/main/scala/com/mozilla/telemetry/utils/SyncPingConversion.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/SyncPingConversion.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.utils
 
 import org.apache.spark.sql.Row
@@ -7,6 +10,7 @@ import org.json4s.{DefaultFormats, JValue}
 import org.json4s.JsonAST._
 import java.util.UUID
 
+// scalastyle:off return methodLength
 // Common conversion code for SyncView and SyncFlatView. Schema for sync pings described here:
 // https://dxr.mozilla.org/mozilla-central/source/services/sync/tests/unit/sync_ping_schema.json
 object SyncPingConversion {
@@ -77,7 +81,7 @@ object SyncPingConversion {
   ))
 
   // The record of a single sync event.
-  def nestedSyncType = StructType(List(
+  def nestedSyncType: StructType = StructType(List(
     // These field names are the same as used by MainSummaryView
     StructField("app_build_id", StringType, nullable = true), // application/buildId
     StructField("app_display_version", StringType, nullable = true), // application/displayVersion
@@ -102,7 +106,7 @@ object SyncPingConversion {
     StructField("devices", ArrayType(deviceType, containsNull = false), nullable = true)
   ))
 
-  def singleEngineFlatSyncType = StructType(List(
+  def singleEngineFlatSyncType: StructType = StructType(List(
     // These field names are the same as used by MainSummaryView
     StructField("app_build_id", StringType, nullable = true), // application/buildId
     StructField("app_display_version", StringType, nullable = true), // application/displayVersion
@@ -199,8 +203,7 @@ object SyncPingConversion {
   private def toDeviceRows(devices: JValue): List[Row] = devices match {
     case JArray(x) =>
       val rows = x.flatMap(d => deviceToRow(d))
-      if (rows.isEmpty) null
-      else rows
+      if (rows.isEmpty) null else rows
     case _ => null
   }
 
@@ -351,8 +354,7 @@ object SyncPingConversion {
       for (e <- x) {
         buf.append(engineToRow(e))
       }
-      if (buf.isEmpty) null
-      else buf.toList
+      if (buf.isEmpty) null else buf.toList
     case _ => null
   }
 
@@ -613,3 +615,4 @@ object SyncPingConversion {
   }
 
 }
+// scalastyle:on return methodLength

--- a/src/main/scala/com/mozilla/telemetry/utils/udfs.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/udfs.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.utils
 
 import java.math.BigDecimal

--- a/src/main/scala/com/mozilla/telemetry/views/AddonsView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/AddonsView.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.views
 
 import com.mozilla.telemetry.utils.{S3Store, getOrCreateSparkSession}
@@ -8,6 +11,8 @@ import org.joda.time.{DateTime, Days, format}
 import org.rogach.scallop._
 
 object AddonsView {
+  private val logger = org.apache.log4j.Logger.getLogger(this.getClass.getName)
+
   def schemaVersion: String = "v2"
   def jobName: String = "addons"
 
@@ -56,8 +61,8 @@ object AddonsView {
       val currentDate = from.plusDays(offset)
       val currentDateString = currentDate.toString("yyyyMMdd")
 
-      println("=======================================================================================")
-      println(s"BEGINNING JOB $jobName $schemaVersion FOR $currentDateString")
+      logger.info("=======================================================================================")
+      logger.info(s"BEGINNING JOB $jobName $schemaVersion FOR $currentDateString")
 
       val mainSummary = spark.read.parquet(s"s3://$inputBucket/main_summary/${MainSummaryView.schemaVersion}/submission_date_s3=$currentDateString")
       val addons = addonsFromMain(mainSummary)
@@ -75,8 +80,8 @@ object AddonsView {
       // Then remove the _SUCCESS file so we don't break Spark partition discovery.
       S3Store.deleteKey(conf.outputBucket(), s"$s3prefix/_SUCCESS")
 
-      println(s"JOB $jobName COMPLETED SUCCESSFULLY FOR $currentDateString")
-      println("=======================================================================================")
+      logger.info(s"JOB $jobName COMPLETED SUCCESSFULLY FOR $currentDateString")
+      logger.info("=======================================================================================")
     }
 
     spark.stop()

--- a/src/main/scala/com/mozilla/telemetry/views/ClientsDailyView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/ClientsDailyView.scala
@@ -1,14 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.views
 
-import com.mozilla.telemetry.utils.getOrCreateSparkSession
-import com.mozilla.telemetry.utils.{AggSearchCounts, AggMapFirst}
-import org.apache.spark.sql.{Column, DataFrame}
+import com.mozilla.telemetry.utils.{AggMapFirst, AggSearchCounts, getOrCreateSparkSession}
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.{Column, DataFrame}
 import org.rogach.scallop._
 
 object ClientsDailyView {
-  val jobName: String = "clients_daily"
-  val schemaVersion: String = "v6"
+  private val jobName: String = "clients_daily"
+  private val schemaVersion: String = "v6"
 
   class Conf(args: Array[String]) extends ScallopConf(args) {
     val date = opt[String](
@@ -91,18 +93,18 @@ object ClientsDailyView {
       )
   }
 
-  def aggFirst(field: String): Column = first(field, ignoreNulls = true).alias(field)
+  private def aggFirst(field: String): Column = first(field, ignoreNulls = true).alias(field)
 
-  def aggFirst(expression: Column, alias: String): Column = first(expression, ignoreNulls = true).alias(alias)
+  private def aggFirst(expression: Column, alias: String): Column = first(expression, ignoreNulls = true).alias(alias)
 
-  val mapFirst = new AggMapFirst()
-  def aggMapFirst(field: String): Column = mapFirst(col(field)).alias(field)
+  private val mapFirst = new AggMapFirst()
+  private def aggMapFirst(field: String): Column = mapFirst(col(field)).alias(field)
 
-  def aggMax(field: String): Column = max(field).alias(s"${field}_max")
+  private def aggMax(field: String): Column = max(field).alias(s"${field}_max")
 
-  def aggMean(field: String): Column = mean(field).alias(s"${field}_mean")
+  private def aggMean(field: String): Column = mean(field).alias(s"${field}_mean")
 
-  val searchSources = List(
+  private val searchSources = List(
     "abouthome",
     "contextmenu",
     "newtab",
@@ -110,14 +112,14 @@ object ClientsDailyView {
     "system",
     "urlbar"
   )
-  val searchCounts = new AggSearchCounts(searchSources)
-  def aggSearchCounts(field: String): Column = searchCounts(col(field)).alias(field)
+  private val searchCounts = new AggSearchCounts(searchSources)
+  private def aggSearchCounts(field: String): Column = searchCounts(col(field)).alias(field)
 
-  def aggSum(field: String): Column = sum(field).alias(s"${field}_sum")
+  private def aggSum(field: String): Column = sum(field).alias(s"${field}_sum")
 
-  def aggSum(expression: Column, alias: String): Column = sum(expression).alias(alias)
+  private def aggSum(expression: Column, alias: String): Column = sum(expression).alias(alias)
 
-  def fieldAggregators = List(
+  private val fieldAggregators = List(
     aggSum("aborts_content"),
     aggSum("aborts_gmplugin"),
     aggSum("aborts_plugin"),
@@ -206,7 +208,10 @@ object ClientsDailyView {
     aggSum("push_api_notify"),
     aggFirst("sample_id"),
     aggFirst("sandbox_effective_content_process_level"),
-    aggSum(col("scalar_parent_webrtc_nicer_stun_retransmits") + col("scalar_content_webrtc_nicer_stun_retransmits"), "scalar_combined_webrtc_nicer_stun_retransmits_sum"),
+    aggSum(
+      col("scalar_parent_webrtc_nicer_stun_retransmits") + col("scalar_content_webrtc_nicer_stun_retransmits"),
+      "scalar_combined_webrtc_nicer_stun_retransmits_sum"
+    ),
     aggSum(col("scalar_parent_webrtc_nicer_turn_401s") + col("scalar_content_webrtc_nicer_turn_401s"), "scalar_combined_webrtc_nicer_turn_401s_sum"),
     aggSum(col("scalar_parent_webrtc_nicer_turn_403s") + col("scalar_content_webrtc_nicer_turn_403s"), "scalar_combined_webrtc_nicer_turn_403s_sum"),
     aggSum(col("scalar_parent_webrtc_nicer_turn_438s") + col("scalar_content_webrtc_nicer_turn_438s"), "scalar_combined_webrtc_nicer_turn_438s_sum"),

--- a/src/main/scala/com/mozilla/telemetry/views/CrashSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/CrashSummaryView.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.views
 
 import com.mozilla.telemetry.heka.Dataset
@@ -160,6 +163,8 @@ case class CrashSummary (
 }
 
 object CrashSummaryView {
+  private val logger = org.apache.log4j.Logger.getLogger(this.getClass.getName)
+
   private class Opts(args: Array[String]) extends ScallopConf(args) {
     val outputBucket = opt[String](
       "outputBucket",
@@ -255,11 +260,11 @@ object CrashSummaryView {
         val path = s"s3://${outputBucket}/${prefix}/submission_date=${currentDateString}"
         dataset.write.mode(SaveMode.Overwrite).parquet(path)
       }
-      println("************************************")
-      println(s"Total pings: ${dataset.count()}")
-      println(s"Processed pings: ${processedPings.value}")
-      println(s"Discarded pings: ${discardedPings.value}")
-      println("************************************")
+      logger.info("************************************")
+      logger.info(s"Total pings: ${dataset.count()}")
+      logger.info(s"Processed pings: ${processedPings.value}")
+      logger.info(s"Discarded pings: ${discardedPings.value}")
+      logger.info("************************************")
     }
     sc.stop()
   }

--- a/src/main/scala/com/mozilla/telemetry/views/ExperimentAnalysisView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/ExperimentAnalysisView.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.views
 
 import com.mozilla.telemetry.experiments.analyzers._
@@ -11,13 +14,13 @@ import org.rogach.scallop.ScallopConf
 import scala.util.{Failure, Success, Try}
 
 object ExperimentAnalysisView {
-  def defaultErrorAggregatesBucket = "net-mozaws-prod-us-west-2-pipeline-data"
-  def errorAggregatesPath = "experiment_error_aggregates/v1"
-  def jobName = "experiment_analysis"
-  def schemaVersion = "v1"
+  private val defaultErrorAggregatesBucket = "net-mozaws-prod-us-west-2-pipeline-data"
+  private val errorAggregatesPath = "experiment_error_aggregates/v1"
+  private val jobName = "experiment_analysis"
+  private val schemaVersion = "v1"
   // This gives us ~120MB partitions with the columns we have now. We should tune this as we add more columns.
-  def rowsPerPartition = 25000
-  val defaultJackknifeBlocks = 100
+  private val rowsPerPartition = 25000
+  private val defaultJackknifeBlocks = 100
 
   private val logger = org.apache.log4j.Logger.getLogger(this.getClass.getSimpleName)
 
@@ -148,7 +151,7 @@ object ExperimentAnalysisView {
     }
   }
 
-  def getMetrics(conf: Conf) = {
+  def getMetrics(conf: Conf): List[(String, MetricDefinition)] = {
     conf.metric.get match {
       case Some(m) => {
         List((m, (Histograms.definitions(includeOptin = true, nameJoiner = Histograms.prefixProcessJoiner _) ++ Scalars.definitions())(m.toLowerCase)))

--- a/src/main/scala/com/mozilla/telemetry/views/GenericCountView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/GenericCountView.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.views
 
 import com.github.nscala_time.time.Imports._

--- a/src/main/scala/com/mozilla/telemetry/views/GenericLongitudinal.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/GenericLongitudinal.scala
@@ -1,10 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.views
 
 import com.github.nscala_time.time.Imports._
 import com.mozilla.telemetry.utils.{CollectList, getOrCreateSparkSession}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.{DataFrame, SQLContext}
+import org.apache.spark.sql.{Column, DataFrame, SQLContext}
 import org.rogach.scallop._
 
 object GenericLongitudinalView {
@@ -166,7 +169,8 @@ object GenericLongitudinalView {
     group(data, groupingColumn, orderingColumns, maxArrayLength)
   }
 
-  def group(df: DataFrame, groupColumn: String = "client_id", orderColumns: List[String] = List("submission_date_s3"), maxLength: Option[Int] = None): DataFrame = {
+  def group(df: DataFrame, groupColumn: String = "client_id", orderColumns: List[String] = List("submission_date_s3"),
+            maxLength: Option[Int] = None): DataFrame = {
     // We can't order on the grouping column
     assert(!orderColumns.contains(groupColumn))
 
@@ -190,7 +194,7 @@ object GenericLongitudinalView {
     aggregated.select(col(groupColumn) :: getChildren(aggregateColName, aggregated): _*)
   }
 
-  def getChildren(colname: String, df: DataFrame) = {
+  def getChildren(colname: String, df: DataFrame): List[Column] = {
     df.schema(colname)
       .dataType
       .asInstanceOf[StructType]

--- a/src/main/scala/com/mozilla/telemetry/views/MainEventsView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainEventsView.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.views
 
 import com.mozilla.telemetry.utils.{Events, S3Store, getOrCreateSparkSession}
@@ -7,6 +10,8 @@ import org.joda.time.{DateTime, Days, format}
 import org.rogach.scallop._
 
 object MainEventsView {
+  private val logger = org.apache.log4j.Logger.getLogger(this.getClass.getName)
+
   def schemaVersion: String = "v1"
   def jobName: String = "events"
 
@@ -56,8 +61,8 @@ object MainEventsView {
       val currentDate = from.plusDays(offset)
       val currentDateString = currentDate.toString("yyyyMMdd")
 
-      println("=======================================================================================")
-      println(s"BEGINNING JOB $jobName $schemaVersion FOR $currentDateString")
+      logger.info("=======================================================================================")
+      logger.info(s"BEGINNING JOB $jobName $schemaVersion FOR $currentDateString")
 
       val mainSummary = spark.read.parquet(s"s3://$inputBucket/main_summary/${MainSummaryView.schemaVersion}/submission_date_s3=$currentDateString")
       val events = eventsFromMain(mainSummary, conf.sampleId.get)
@@ -75,8 +80,8 @@ object MainEventsView {
       // Then remove the _SUCCESS file so we don't break Spark partition discovery.
       S3Store.deleteKey(conf.outputBucket(), s"$s3prefix/_SUCCESS")
 
-      println(s"JOB $jobName COMPLETED SUCCESSFULLY FOR $currentDateString")
-      println("=======================================================================================")
+      logger.info(s"JOB $jobName COMPLETED SUCCESSFULLY FOR $currentDateString")
+      logger.info("=======================================================================================")
     }
     spark.stop()
   }

--- a/src/main/scala/com/mozilla/telemetry/views/QuantumRCView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/QuantumRCView.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.views
 
 import com.github.nscala_time.time.Imports._

--- a/src/main/scala/com/mozilla/telemetry/views/RetentionView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/RetentionView.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.views
 
 

--- a/src/main/scala/com/mozilla/telemetry/views/SyncEventView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/SyncEventView.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.views
 
 import com.mozilla.telemetry.heka.{Dataset, Message}
@@ -11,6 +14,8 @@ import org.json4s.{JValue, string2JsonInput}
 import org.rogach.scallop._
 
 object SyncEventView {
+  private val logger = org.apache.log4j.Logger.getLogger(this.getClass.getName)
+
   def schemaVersion: String = "v1"
   def jobName: String = "sync_events"
 
@@ -26,8 +31,9 @@ object SyncEventView {
 
   def main(args: Array[String]) {
     val conf = new Conf(args) // parse command line arguments
-    if (!conf.outputBucket.supplied && !conf.outputFilename.supplied)
+    if (!conf.outputBucket.supplied && !conf.outputFilename.supplied) {
       conf.errorMessageHandler("One of outputBucket or outputFilename must be specified")
+    }
     val fmt = format.DateTimeFormat.forPattern("yyyyMMdd")
     val to = conf.to.get match {
       case Some(t) => fmt.parseDateTime(t)
@@ -53,8 +59,8 @@ object SyncEventView {
       val currentDate = from.plusDays(offset)
       val currentDateString = currentDate.toString("yyyyMMdd")
 
-      println("=======================================================================================")
-      println(s"BEGINNING JOB $jobName FOR $currentDateString")
+      logger.info("=======================================================================================")
+      logger.info(s"BEGINNING JOB $jobName FOR $currentDateString")
 
       val ignoredCount = sc.longAccumulator("Number of Records Ignored")
       val processedCount = sc.longAccumulator("Number of Records Processed")
@@ -101,17 +107,17 @@ object SyncEventView {
 
         // Then remove the _SUCCESS file so we don't break Spark partition discovery.
         S3Store.deleteKey(conf.outputBucket(), s"$s3prefix/_SUCCESS")
-        println(s"Wrote data to s3 path $s3path")
+        logger.info(s"Wrote data to s3 path $s3path")
       } else {
         // Write the data to a local file.
         records.write.parquet(conf.outputFilename())
-        println(s"Wrote data to local file ${conf.outputFilename()}")
+        logger.info(s"Wrote data to local file ${conf.outputFilename()}")
       }
 
-      println(s"JOB $jobName COMPLETED SUCCESSFULLY FOR $currentDateString")
-      println(s"     RECORDS SEEN:    ${ignoredCount.value + processedCount.value}")
-      println(s"     RECORDS IGNORED: ${ignoredCount.value}")
-      println("=======================================================================================")
+      logger.info(s"JOB $jobName COMPLETED SUCCESSFULLY FOR $currentDateString")
+      logger.info(s"     RECORDS SEEN:    ${ignoredCount.value + processedCount.value}")
+      logger.info(s"     RECORDS IGNORED: ${ignoredCount.value}")
+      logger.info("=======================================================================================")
     }
 
     spark.stop()
@@ -169,6 +175,7 @@ object SyncEventConverter {
     events.flatMap(event => eventToRow(ping, event))
   }
 
+  // scalastyle:off return
   private def eventToRow(ping: JValue, event: List[Any]): Option[Row] = {
     val application = ping \ "application"
     val payload = ping \ "payload"
@@ -275,4 +282,5 @@ object SyncEventConverter {
 
     Some(Row.fromSeq(common ++ eventObject.toList ++ values))
   }
+  // scalastyle:on return
 }

--- a/src/main/scala/com/mozilla/telemetry/views/SyncView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/SyncView.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.views
 
 import com.mozilla.telemetry.heka.Dataset
@@ -10,6 +13,8 @@ import org.rogach.scallop._ // Just for my attempted mocks below.....
 
 
 object SyncView {
+  private val logger = org.apache.log4j.Logger.getLogger(this.getClass.getName)
+
   def schemaVersion: String = "v2"
   def jobName: String = "sync_summary"
 
@@ -25,8 +30,9 @@ object SyncView {
 
   def main(args: Array[String]) {
     val conf = new Conf(args) // parse command line arguments
-    if (!conf.outputBucket.supplied && !conf.outputFilename.supplied)
+    if (!conf.outputBucket.supplied && !conf.outputFilename.supplied) {
       conf.errorMessageHandler("One of outputBucket or outputFilename must be specified")
+    }
     val fmt = format.DateTimeFormat.forPattern("yyyyMMdd")
     val to = conf.to.get match {
       case Some(t) => fmt.parseDateTime(t)
@@ -53,8 +59,8 @@ object SyncView {
       val currentDate = from.plusDays(offset)
       val currentDateString = currentDate.toString("yyyyMMdd")
 
-      println("=======================================================================================")
-      println(s"BEGINNING JOB $jobName $schemaVersion FOR $currentDateString")
+      logger.info("=======================================================================================")
+      logger.info(s"BEGINNING JOB $jobName $schemaVersion FOR $currentDateString")
 
       val ignoredCount = spark.sparkContext.longAccumulator("Number of Records Ignored")
       val processedCount = spark.sparkContext.longAccumulator("Number of Records Processed")
@@ -114,18 +120,18 @@ object SyncView {
 
         // Then remove the _SUCCESS file so we don't break Spark partition discovery.
         S3Store.deleteKey(conf.outputBucket(), s"$s3prefix/_SUCCESS")
-        println(s"Wrote data to s3 path $s3path")
+        logger.info(s"Wrote data to s3 path $s3path")
       } else {
         // Write the data to a local file.
         records.write.parquet(conf.outputFilename())
-        println(s"Wrote data to local file ${conf.outputFilename()}")
+        logger.info(s"Wrote data to local file ${conf.outputFilename()}")
       }
 
-      println(s"JOB $jobName COMPLETED SUCCESSFULLY FOR $currentDateString")
-      println(s"     RECORDS SEEN:    ${ignoredCount.value + processedCount.value + failedCount.value}")
-      println(s"     RECORDS IGNORED: ${ignoredCount.value}")
-      println(s"     RECORDS FAILED:  ${failedCount.value}")
-      println("=======================================================================================")
+      logger.info(s"JOB $jobName COMPLETED SUCCESSFULLY FOR $currentDateString")
+      logger.info(s"     RECORDS SEEN:    ${ignoredCount.value + processedCount.value + failedCount.value}")
+      logger.info(s"     RECORDS IGNORED: ${ignoredCount.value}")
+      logger.info(s"     RECORDS FAILED:  ${failedCount.value}")
+      logger.info("=======================================================================================")
     }
 
     spark.stop()

--- a/src/main/scala/com/mozilla/telemetry/views/pioneer/PioneerOnlineNewsDedupe.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/pioneer/PioneerOnlineNewsDedupe.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.views.pioneer
 
 import java.time.format.DateTimeFormatter
@@ -35,7 +38,7 @@ object PioneerOnlineNewsDedupeView {
   case class ExplodedEntry(ping_timestamp: Long, document_id: String, pioneer_id: String, study_name: String,
                            geo_city: String, geo_country: String, submission_date_s3: String, entry_timestamp: Long,
                            branch: String, details: String, url: String) {
-    def toKey = EntryKey(pioneer_id, entry_timestamp, branch, details, url)
+    def toKey: EntryKey = EntryKey(pioneer_id, entry_timestamp, branch, details, url)
   }
 
   val jobName = "PioneerOnlineNewsDedupe"
@@ -133,11 +136,9 @@ object PioneerOnlineNewsDedupeView {
     val fs = FileSystem.get(spark.sparkContext.hadoopConfiguration)
     val outputPath = new Path(conf.outputLocation())
     val tempPath = new Path(conf.tempLocation())
-    if (fs.exists(tempPath))
-      fs.delete(tempPath, true)
+    if (fs.exists(tempPath)) fs.delete(tempPath, true)
 
-    if (!fs.exists(outputPath))
-      fs.mkdirs(outputPath)
+    if (!fs.exists(outputPath)) fs.mkdirs(outputPath)
 
     dedupeByDay(startDate, endDate, conf)
     fs.delete(tempPath, true)

--- a/src/test/scala/com/mozilla/telemetry/experiments/PermutationsTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/experiments/PermutationsTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.experiments
 
 import com.holdenkarau.spark.testing.DatasetSuiteBase

--- a/src/test/scala/com/mozilla/telemetry/experiments/analyzers/ExperimentAnalyzerTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/experiments/analyzers/ExperimentAnalyzerTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.experiments.analyzers
 
 import com.holdenkarau.spark.testing.DatasetSuiteBase

--- a/src/test/scala/com/mozilla/telemetry/experiments/analyzers/HistogramAnalyzerTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/experiments/analyzers/HistogramAnalyzerTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.experiments.analyzers
 
 import com.holdenkarau.spark.testing.DatasetSuiteBase

--- a/src/test/scala/com/mozilla/telemetry/experiments/analyzers/ScalarAnalyzerTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/experiments/analyzers/ScalarAnalyzerTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.experiments.analyzers
 
 import com.holdenkarau.spark.testing.DatasetSuiteBase

--- a/src/test/scala/com/mozilla/telemetry/experiments/statistics/ComparativeStatisticsTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/experiments/statistics/ComparativeStatisticsTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.experiments.statistics
 
 import org.scalatest.{FlatSpec, Matchers}

--- a/src/test/scala/com/mozilla/telemetry/experiments/statistics/DescriptiveStatisticsTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/experiments/statistics/DescriptiveStatisticsTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.experiments.statistics
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase

--- a/src/test/scala/com/mozilla/telemetry/metrics/HistogramsTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/metrics/HistogramsTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import com.mozilla.telemetry.metrics.HistogramsClass
 
 import scala.io.Source

--- a/src/test/scala/com/mozilla/telemetry/metrics/ScalarsTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/metrics/ScalarsTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import com.mozilla.telemetry.metrics.ScalarsClass
 
 import scala.io.Source
@@ -15,9 +18,9 @@ class ScalarsTest extends FlatSpec with Matchers {
       private val optStatuses = List(true, false)
 
       val names = optStatuses map {
-        optStatus => 
+        optStatus =>
             optStatus -> scalars.definitions(optStatus).map{
-              case (k, value) => 
+              case (k, value) =>
                 k.toLowerCase
             }
       } toMap

--- a/src/test/scala/com/mozilla/telemetry/ml/AMODatabaseTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/ml/AMODatabaseTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.ml
 
 import java.nio.file.Files

--- a/src/test/scala/com/mozilla/telemetry/ml/AddonRecommenderTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/ml/AddonRecommenderTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.ml
 
 import java.nio.charset.StandardCharsets

--- a/src/test/scala/com/mozilla/telemetry/utils/AggregationTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/utils/AggregationTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry
 
 import com.mozilla.telemetry.utils.aggregation
@@ -5,22 +8,22 @@ import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
 
 class AggregationTest extends FlatSpec {
-  private val tol= 1e-7
+  private val tol = 1e-7
 
   "The weighted mode" must "combine repeated keys" in {
-    val mode = aggregation.weightedMode(Seq(("DE", 3l), ("IT", 6l), ("DE", 4l)))
+    val mode = aggregation.weightedMode(Seq(("DE", 3L), ("IT", 6L), ("DE", 4L)))
     assert(mode == Some("DE"))
   }
 
   it must "respect weights" in {
-    val mode = aggregation.weightedMode(Seq(("DE", 3l), ("IT", 1l), ("IT", 1l)))
+    val mode = aggregation.weightedMode(Seq(("DE", 3L), ("IT", 1L), ("IT", 1L)))
     assert(mode == Some("DE"))
   }
 
   "The weighted mean" must "handle empty sequences" in {
     assert(aggregation.weightedMean(Seq()) == None)
   }
-  
+
   it must "handle 0 weights" in {
     assert(aggregation.weightedMean(Seq((1, 0))) == None)
   }

--- a/src/test/scala/com/mozilla/telemetry/utils/DatasetComparatorTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/utils/DatasetComparatorTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.utils
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
@@ -13,7 +16,8 @@ class DatasetComparatorTest extends FlatSpec with DataFrameSuiteBase with Before
 
   private val date = "test"
 
-  def getConf(original: String, test: String, where: String = "", select: String = "document_id", dateField: String = "submission_date_s3"): DatasetComparator.Conf = {
+  def getConf(original: String, test: String, where: String = "", select: String = "document_id",
+              dateField: String = "submission_date_s3"): DatasetComparator.Conf = {
     val args =
       "--date" :: date ::
       "--date-field" :: dateField ::

--- a/src/test/scala/com/mozilla/telemetry/utils/EventsTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/utils/EventsTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase

--- a/src/test/scala/com/mozilla/telemetry/utils/MainPingTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/utils/MainPingTest.scala
@@ -1,13 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.utils
-
-import org.scalatest.{FlatSpec, Matchers}
-import org.json4s.JsonAST._
-import org.json4s.jackson.JsonMethods._
-import org.apache.spark.sql.Row
-import scala.io.Source
 
 import com.mozilla.telemetry.metrics._
 import com.mozilla.telemetry.views.MainSummaryView
+import org.apache.spark.sql.Row
+import org.json4s.JsonAST._
+import org.json4s.jackson.JsonMethods._
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.io.Source
 
 class MainPingTest extends FlatSpec with Matchers {
  val scalarUrlMock = (a: String, b: String) => Source.fromFile("src/test/resources/Scalars.yaml")
@@ -327,13 +330,13 @@ class MainPingTest extends FlatSpec with Matchers {
     """.stripMargin)
 
   "Search counts" can "be converted" in {
-    var expected = 0l
+    var expected = 0L
     for ((k, e, s, c) <- List(
-      ("google.abouthome", "google", "abouthome", 1l),
-      ("google.urlbar",    "google", "urlbar",    67l),
-      ("yahoo.urlbar",     "yahoo",  "urlbar",    78l),
+      ("google.abouthome", "google", "abouthome", 1L),
+      ("google.urlbar",    "google", "urlbar",    67L),
+      ("yahoo.urlbar",     "yahoo",  "urlbar",    78L),
       ("toast1",           null,     null,        null),
-      ("toast2",           null,     null,        10l),
+      ("toast2",           null,     null,        10L),
       ("toast3.badcount",  "toast3", "badcount",  null))) {
       val m = MainPing.searchHistogramToRow(k, exampleSearches \ k)
       m(0) shouldBe e
@@ -347,7 +350,7 @@ class MainPingTest extends FlatSpec with Matchers {
 
     MainPing.searchHistogramToRow("toast1", exampleSearches \ "toast1") should be (Row(null, null, null))
 
-    var actual = 0l
+    var actual = 0L
     for (search <- MainPing.getSearchCounts(exampleSearches).get) {
 
       actual = actual + (search.get(2) match {
@@ -358,11 +361,11 @@ class MainPingTest extends FlatSpec with Matchers {
     actual should be (expected)
 
     val json = parse(testPayload)
-    var payloadCount = 0l
+    var payloadCount = 0L
     for (search <- MainPing.getSearchCounts(json \ "payload" \ "keyedHistograms" \ "SEARCH_COUNTS").get) {
       payloadCount = payloadCount + search.getLong(2)
     }
-    payloadCount should be (88l)
+    payloadCount should be (88L)
   }
 
   "Histogram means" can "be computed" in {
@@ -578,7 +581,8 @@ class MainPingTest extends FlatSpec with Matchers {
     // Doesn't have scalars
     val jNoScalars = parse(
       """{}""")
-    MainPing.scalarsToRow(makeScalarsMap(jNoScalars), scalarDefs) should be (makeExpected(List(null, null, null, null, null, null, null, null, null, null)))
+    MainPing.scalarsToRow(makeScalarsMap(jNoScalars), scalarDefs) should be
+    (makeExpected(List(null, null, null, null, null, null, null, null, null, null)))
 
     // Has scalars, but none of the expected ones
     val jUnexpectedScalars = parse(
@@ -586,7 +590,8 @@ class MainPingTest extends FlatSpec with Matchers {
         |  "example1": 249,
         |  "example2": 2
         |}""".stripMargin)
-    MainPing.scalarsToRow(makeScalarsMap(jUnexpectedScalars), scalarDefs) should be (makeExpected(List(null, null, null, null, null, null, null, null, null, null)))
+    MainPing.scalarsToRow(makeScalarsMap(jUnexpectedScalars), scalarDefs) should be
+    (makeExpected(List(null, null, null, null, null, null, null, null, null, null)))
 
     // Has scalars, and some of the expected ones
     val jSomeExpectedScalars = parse(
@@ -594,7 +599,8 @@ class MainPingTest extends FlatSpec with Matchers {
         |  "mock.scalar.uint": 2,
         |  "mock.uint.optin": 97
         |}""".stripMargin)
-    MainPing.scalarsToRow(makeScalarsMap(jSomeExpectedScalars), scalarDefs) should be (makeExpected(List(null, null, null, null, null, null, 2, 97, null, null)))
+    MainPing.scalarsToRow(makeScalarsMap(jSomeExpectedScalars), scalarDefs) should be
+    (makeExpected(List(null, null, null, null, null, null, 2, 97, null, null)))
 
     // Keyed scalars convert correctly
     val jKeyedScalar = parse(
@@ -602,7 +608,7 @@ class MainPingTest extends FlatSpec with Matchers {
         |  "mock.keyed.scalar.uint": {"a": 1, "b": 2}
         |}""".stripMargin)
     MainPing.scalarsToRow(makeScalarsMap(jKeyedScalar), scalarDefs) should be
-      (makeExpected(List(null, null, null, Map("a" -> 1, "b" -> 2), null, null, null, null, null, null)))
+    (makeExpected(List(null, null, null, Map("a" -> 1, "b" -> 2), null, null, null, null, null, null)))
 
     // Has scalars, all of the expected ones
     val jAllScalars = parse(
@@ -677,9 +683,9 @@ class MainPingTest extends FlatSpec with Matchers {
     MainPing.getScalarByName(makeScalarsMap(jUnexpectedScalars), scalarDefs, "scalar_content_mock_scalar_uint") should === (null)
     MainPing.getScalarByName(makeScalarsMap(jUnexpectedScalars), scalarDefs, "scalar_content_mock_uint_optin") should === (null)
     MainPing.getScalarByName(makeScalarsMap(jUnexpectedScalars), scalarDefs, "scalar_content_mock_uint_optout") should === (null)
-    an [IllegalArgumentException] should be thrownBy
+    an[IllegalArgumentException] should be thrownBy
       MainPing.getScalarByName(makeScalarsMap(jUnexpectedScalars), scalarDefs, "example1")
-    an [IllegalArgumentException] should be thrownBy
+    an[IllegalArgumentException] should be thrownBy
       MainPing.getScalarByName(makeScalarsMap(jUnexpectedScalars), scalarDefs, "example2")
 
     // Has scalars, and some of the expected ones
@@ -710,10 +716,10 @@ class MainPingTest extends FlatSpec with Matchers {
     MainPing.getScalarByName(makeScalarsMap(jAllScalars), scalarDefs, "scalar_content_mock_uint_optin") should be (1)
     MainPing.getScalarByName(makeScalarsMap(jAllScalars), scalarDefs, "scalar_content_mock_uint_optout") should be (42)
     //Expect exception when scalarDefs has duplicates.
-    an [IllegalArgumentException] should be thrownBy
+    an[IllegalArgumentException] should be thrownBy
       MainPing.getScalarByName(makeScalarsMap(jAllScalars), scalarDefs ++ scalarDefs, "scalar_parent_mock_scalar_uint")
     // Expect an exception because the scalar does not exist in the definition.
-    an [IllegalArgumentException] should be thrownBy
+    an[IllegalArgumentException] should be thrownBy
       MainPing.getScalarByName(makeScalarsMap(jAllScalars), scalarDefs, "scalar_content_mock_random_scalar")
 
     // Has scalars with weird data

--- a/src/test/scala/com/mozilla/telemetry/views/AddonsViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/AddonsViewTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
@@ -34,12 +37,12 @@ class AddonsViewTest extends FlatSpec with Matchers with DataFrameSuiteBase {
     import spark.implicits._
 
     val mains = Seq(
-      PartialMain("doc1", "client1", 1l, "2016-10-01T00:00:00", "release", Seq(
+      PartialMain("doc1", "client1", 1L, "2016-10-01T00:00:00", "release", Seq(
         Addon("addon1", true, "addon1name", false, false, "1.0", 1, "plugin", true, false, 10, 11, 0, true, false, true),
         Addon("addon2", true, "addon2name", false, false, "1.0", 1, "plugin", true, false, 10, 11, 0, false, true, true))),
-      PartialMain("doc2", "client2", 2l, "2016-10-01T00:00:00", "release", null),
-      PartialMain("doc3", "client2", 2l, "2016-10-01T00:00:00", "release", Seq()),
-      PartialMain("doc4", "client3", 3l, "2016-10-01T00:00:00", "release", Seq(
+      PartialMain("doc2", "client2", 2L, "2016-10-01T00:00:00", "release", null),
+      PartialMain("doc3", "client2", 2L, "2016-10-01T00:00:00", "release", Seq()),
+      PartialMain("doc4", "client3", 3L, "2016-10-01T00:00:00", "release", Seq(
         Addon("addon1", true, "addon1name", false, false, "1.0", 1, "plugin", true, false, 10, 11, 0, true, false, true),
         Addon("addon3", true, "addon3name", false, false, "1.0", 1, "plugin", true, false, 10, 11, 0, false, true, false),
         Addon("addon4", true, "addon4name", false, false, "1.0", 1, "plugin", true, false, 10, 11, 0, false, false, false)))

--- a/src/test/scala/com/mozilla/telemetry/views/ClientsDailyViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/ClientsDailyViewTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.views
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase

--- a/src/test/scala/com/mozilla/telemetry/views/ClientsDailyViewTestPayloads.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/ClientsDailyViewTestPayloads.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.views
 
 object ClientsDailyViewTestPayloads {
@@ -147,7 +150,7 @@ object ClientsDailyViewTestPayloads {
     windows_ubr: Option[Long] = None
   )
 
-  def getRowAggFirst(sValue: Option[String], bValue: Option[Boolean], iValue: Option[Int]) = MainSummaryRow(
+  def getRowAggFirst(sValue: Option[String], bValue: Option[Boolean], iValue: Option[Int]): MainSummaryRow = MainSummaryRow(
     active_experiment_branch = sValue,
     active_experiment_id = sValue,
     addon_compatibility_check_enabled = bValue,
@@ -214,7 +217,7 @@ object ClientsDailyViewTestPayloads {
     windows_ubr = Some(iValue.get)
   )
 
-  def getExpectAggFirst(sValue: String, bValue: Boolean, iValue: Int) = Map(
+  def getExpectAggFirst(sValue: String, bValue: Boolean, iValue: Int): Map[String, Any] = Map(
     "active_experiment_branch" -> sValue,
     "active_experiment_id" -> sValue,
     "addon_compatibility_check_enabled" -> bValue,
@@ -279,19 +282,19 @@ object ClientsDailyViewTestPayloads {
     "windows_ubr" -> iValue
   )
 
-  def getRowAggMax(value: Option[Int]) = MainSummaryRow(
+  def getRowAggMax(value: Option[Int]): MainSummaryRow = MainSummaryRow(
     scalar_parent_browser_engagement_max_concurrent_tab_count = value,
     scalar_parent_browser_engagement_max_concurrent_window_count = value,
     scalar_parent_browser_engagement_unique_domains_count = value
   )
 
-  def getExpectAggMax(value: Int) = Map(
+  def getExpectAggMax(value: Int): Map[String, Int] = Map(
     "scalar_parent_browser_engagement_max_concurrent_tab_count_max" -> value,
     "scalar_parent_browser_engagement_max_concurrent_window_count_max" -> value,
     "scalar_parent_browser_engagement_unique_domains_count_max" -> value
   )
 
-  def getRowAggMean(value: Option[Int]) = MainSummaryRow(
+  def getRowAggMean(value: Option[Int]): MainSummaryRow = MainSummaryRow(
     active_addons_count = Some(value.get),
     client_clock_skew = Some(value.get),
     client_submission_latency = Some(value.get),
@@ -302,7 +305,7 @@ object ClientsDailyViewTestPayloads {
     session_restored = value
   )
 
-  def getExpectAggMean(value: Int) = Map(
+  def getExpectAggMean(value: Int): Map[String, Int] = Map(
     "active_addons_count_mean" -> value,
     "client_clock_skew_mean" -> value,
     "client_submission_latency_mean" -> value,
@@ -313,7 +316,7 @@ object ClientsDailyViewTestPayloads {
     "session_restored_mean" -> value
   )
 
-  def getRowAggSum(value: Option[Int]) = MainSummaryRow(
+  def getRowAggSum(value: Option[Int]): MainSummaryRow = MainSummaryRow(
     aborts_content = value,
     aborts_gmplugin = value,
     aborts_plugin = value,
@@ -365,7 +368,7 @@ object ClientsDailyViewTestPayloads {
     web_notification_shown = value
   )
 
-  def getExpectAggSum(value: Int) = Map(
+  def getExpectAggSum(value: Int): Map[String, Int] = Map(
     "aborts_content_sum" -> value,
     "aborts_gmplugin_sum" -> value,
     "aborts_plugin_sum" -> value,

--- a/src/test/scala/com/mozilla/telemetry/views/CrashAggregateViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/CrashAggregateViewTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
@@ -90,10 +93,12 @@ class CrashAggregateViewTest extends FlatSpec with Matchers with DataFrameSuiteB
         )
 
       val isMain = dimensions("doc_type") == "main"
-      val info = if (isMain)
+      val info = if (isMain) {
         ("subsessionLength" -> JInt(SCALAR_VALUE)) ~
-        ("subsessionStartDate" -> JString(dimensions("activity_date").asInstanceOf[String]))
-      else JObject()
+          ("subsessionStartDate" -> JString(dimensions("activity_date").asInstanceOf[String]))
+      } else {
+        JObject()
+      }
       val system =
         ("os" ->
           ("name" -> dimensions("os_name").asInstanceOf[String]) ~

--- a/src/test/scala/com/mozilla/telemetry/views/CrashSummaryViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/CrashSummaryViewTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry
 
 import scala.io.Source
@@ -9,7 +12,7 @@ import com.mozilla.telemetry.views.{CrashSummaryView, CrashSummary, CrashPing}
 
 class CrashSummaryViewTest extends FlatSpec with Matchers {
 
-  def fixture = {
+  private def fixture = {
     val crashPingsPath = getClass.getResource("/crash_ping_indented.json").getPath()
     val crashPingsJson = Source.fromFile(crashPingsPath).mkString
     implicit val formats = DefaultFormats

--- a/src/test/scala/com/mozilla/telemetry/views/CrossSectionalViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/CrossSectionalViewTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
@@ -12,7 +15,7 @@ class CrossSectionalViewTest extends FlatSpec with DataFrameSuiteBase {
   // case classes)
   // TODO(harterrt):Consider moving to triple equals: http://www.scalatest.org/user_guide/using_assertions
   implicit class ComparableProduct(p: Product) {
-    def compare(that: Product, epsilon: Double = 1E-7) = {
+    def compare(that: Product, epsilon: Double = 1E-7): Boolean = {
       // Performs fuzzy comparison of two datasets containing Products (usually
       // case classes)
       //
@@ -29,12 +32,12 @@ class CrossSectionalViewTest extends FlatSpec with DataFrameSuiteBase {
       }
 
       def productToSeq(prod: Product): Seq[Any] = {
-        // Creates a Seq containing the fields of an object extending the 
+        // Creates a Seq containing the fields of an object extending the
         // Product trait
         (0 until prod.productArity).map(prod.productElement(_))
       }
 
-      p.productArity == that.productArity && 
+      p.productArity == that.productArity &&
         (productToSeq(p) zip productToSeq(that))
           .foldLeft(true)((acc, pair) => acc && compareElement(pair)
       )
@@ -46,7 +49,7 @@ class CrossSectionalViewTest extends FlatSpec with DataFrameSuiteBase {
       .foldLeft(true)((acc, pair) => acc && (pair._1 compare  pair._2))
   }
 
-  def getExampleActiveAddon(foreign: Boolean = false, name: String = "Name") = {
+  def getExampleActiveAddon(foreign: Boolean = false, name: String = "Name"): ActiveAddon = {
     new ActiveAddon(
       Some(false), Some("Description"), Some(name), Some(false),
       Some(false), Some("Version"), Some(1), Some("Type"), Some(foreign),
@@ -54,7 +57,7 @@ class CrossSectionalViewTest extends FlatSpec with DataFrameSuiteBase {
     )
   }
 
-  def getExampleActivePlugin() = {
+  def getExampleActivePlugin(): ActivePlugin = {
     new ActivePlugin(
       Some("Name"), Some("Version"), Some("Description"), Some(true),
       Some(false), Some(false), Some(Seq("mime1", "mime2")), Some(123)
@@ -64,7 +67,7 @@ class CrossSectionalViewTest extends FlatSpec with DataFrameSuiteBase {
   def getExampleLongitudinal(
     client_id: String,
     active_addons: Option[Seq[Map[String, ActiveAddon]]] = None
-  ) = {
+  ): Longitudinal = {
     new Longitudinal(
       client_id = client_id,
       normalized_channel = "release",
@@ -87,7 +90,7 @@ class CrossSectionalViewTest extends FlatSpec with DataFrameSuiteBase {
       memory_mb = Some(Seq(Some(1023), Some(1023), Some(1023))),
       os_name = Some(Seq(Some("Windows_NT"), Some("Windows_NT"), Some("Windows_NT"))),
       os_version = Some(Seq(Some("5.1"), Some("5.1"), Some("5.1"))),
-      pages_count = Some(Seq(Some(100l), Some(200l), Some(400l))),
+      pages_count = Some(Seq(Some(100L), Some(200L), Some(400L))),
       active_plugins = Some(Seq(
         Seq(getExampleActivePlugin(), getExampleActivePlugin()),
         Seq(getExampleActivePlugin()),
@@ -97,9 +100,9 @@ class CrossSectionalViewTest extends FlatSpec with DataFrameSuiteBase {
       profile_creation_date = Some(Seq("2016-04-21T00:00:00.000Z",
         "2016-04-21T00:00:00.000Z", "2016-04-21T00:00:00.000Z")),
       profile_subsession_counter = Some(Seq(3,2,1)),
-      search_counts = Some(Map("dogpile" -> Seq(1l, 0l, 2l, 10l),
-                               "ask_jeeves" -> Seq(20l, 0l, 0l, 0l),
-                               "hooli" -> Seq(5l, 4l, 0l, 0l))),
+      search_counts = Some(Map("dogpile" -> Seq(1L, 0L, 2L, 10L),
+                               "ask_jeeves" -> Seq(20L, 0L, 0L, 0L),
+                               "hooli" -> Seq(5L, 4L, 0L, 0L))),
       session_id = Some(Seq("A", "B", "C")),
       application_name = Some(Seq(Some("firefox"), Some("firefox"), Some("firefox")))
     )
@@ -114,7 +117,7 @@ class CrossSectionalViewTest extends FlatSpec with DataFrameSuiteBase {
     addon_count_configs: Option[Long] = None,
     addon_count_mode: Option[Long] = None,
     addon_names_list: Option[Seq[Option[String]]] = None
-  ) = {
+  ): CrossSectional = {
     new CrossSectional(
       client_id = client_id,
       normalized_channel = "release",
@@ -220,7 +223,7 @@ class CrossSectionalViewTest extends FlatSpec with DataFrameSuiteBase {
   }
 
   it must "summarize active_addons properly" in {
-    def getExampleActiveAddon(foreign: Boolean = false, name: String = "Name") = {
+    def getExampleActiveAddon(foreign: Boolean = false, name: String = "Name"): ActiveAddon = {
       new ActiveAddon(
         Some(false), Some("Description"), Some(name), Some(false),
         Some(false), Some("Version"), Some(1), Some("Type"), Some(foreign),

--- a/src/test/scala/com/mozilla/telemetry/views/ExperimentAnalysisViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/ExperimentAnalysisViewTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase

--- a/src/test/scala/com/mozilla/telemetry/views/ExperimentSummaryViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/ExperimentSummaryViewTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase

--- a/src/test/scala/com/mozilla/telemetry/views/GenericCountViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/GenericCountViewTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase

--- a/src/test/scala/com/mozilla/telemetry/views/GenericLongitudinalTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/GenericLongitudinalTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.views
 
 import com.holdenkarau.spark.testing.DatasetSuiteBase

--- a/src/test/scala/com/mozilla/telemetry/views/LongitudinalViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/LongitudinalViewTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.views
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
@@ -267,7 +270,8 @@ class LongitudinalViewTest extends FlatSpec with Matchers with PrivateMethodTest
       val optinRow =  optinRows(0)
 
       private val nonOsPayload = createPayload(1) - "os"
-      private val missingOsRecord = (LongitudinalView  invokePrivate buildRecord((nonOsPayload +: payloads) ++ dupes, optinSchema, optinHistogramDefs, optinScalarDefs)).get
+      private val missingOsRecord = (LongitudinalView  invokePrivate buildRecord((nonOsPayload +: payloads) ++
+        dupes, optinSchema, optinHistogramDefs, optinScalarDefs)).get
       private val missingOsPath = ParquetFile.serialize(List(missingOsRecord).toIterator, optinSchema)
       private val missingOsFilename = missingOsPath.toString.replace("file:", "")
 
@@ -471,10 +475,11 @@ class LongitudinalViewTest extends FlatSpec with Matchers with PrivateMethodTest
       assert(h.length == 101)
 
       for ((value, key) <- h.zipWithIndex) {
-        if (key == 1)
+        if (key == 1) {
           assert(value == ParentConstant)
-        else
+        } else {
           assert(value == 0)
+        }
       }
     }
   }
@@ -509,10 +514,11 @@ class LongitudinalViewTest extends FlatSpec with Matchers with PrivateMethodTest
       assert(h.length == 13)
 
       for ((value, key) <- h.zipWithIndex) {
-        if (key == 1)
+        if (key == 1) {
           assert(value == ParentConstant)
-        else
+        } else {
           assert(value == 0)
+        }
       }
     }
   }

--- a/src/test/scala/com/mozilla/telemetry/views/MainEventsViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/MainEventsViewTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase

--- a/src/test/scala/com/mozilla/telemetry/views/QuantumRCViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/QuantumRCViewTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase

--- a/src/test/scala/com/mozilla/telemetry/views/RetentionViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/RetentionViewTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase

--- a/src/test/scala/com/mozilla/telemetry/views/SyncEventViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/SyncEventViewTest.scala
@@ -1,14 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
-import com.mozilla.telemetry.utils.getOrCreateSparkSession
 import com.mozilla.telemetry.views.SyncEventConverter
-import org.json4s.DefaultFormats
 import org.json4s.jackson.JsonMethods.parse
+import org.json4s.{DefaultFormats, JValue}
 import org.scalatest.{FlatSpec, Matchers}
 
 class SyncEventViewTest extends FlatSpec with Matchers with DataFrameSuiteBase {
-  def sync_payload = parse(
+  def syncPayload: JValue = parse(
     """
       |{
       |  "type": "sync",
@@ -147,7 +149,7 @@ class SyncEventViewTest extends FlatSpec with Matchers with DataFrameSuiteBase {
       |}
     """.stripMargin)
 
-  def sync_payload_with_os = parse(
+  def syncPayloadWithOs: JValue = parse(
     """
       |{
       |  "type": "sync",
@@ -191,7 +193,7 @@ class SyncEventViewTest extends FlatSpec with Matchers with DataFrameSuiteBase {
   "Sync Events" can "be serialized" in {
     implicit val formats = DefaultFormats
     sc.setLogLevel("WARN")
-    val row = SyncEventConverter.pingToRows(sync_payload)
+    val row = SyncEventConverter.pingToRows(syncPayload)
     val rdd = sc.parallelize(row)
 
     val dataframe = spark.createDataFrame(rdd, SyncEventConverter.syncEventSchema)
@@ -200,14 +202,14 @@ class SyncEventViewTest extends FlatSpec with Matchers with DataFrameSuiteBase {
     dataframe.count() should be(2)
     val checkRow = dataframe.first()
 
-    checkRow.getAs[String]("document_id") should be((sync_payload \ "id").extract[String])
-    checkRow.getAs[String]("app_build_id") should be((sync_payload \ "application" \ "buildId").extract[String])
-    checkRow.getAs[String]("app_display_version") should be((sync_payload \ "application" \ "displayVersion").extract[String])
-    checkRow.getAs[String]("app_name") should be((sync_payload \ "application" \ "name").extract[String])
-    checkRow.getAs[String]("app_version") should be((sync_payload \ "application" \ "version").extract[String])
-    checkRow.getAs[String]("app_channel") should be((sync_payload \ "application" \ "channel").extract[String])
+    checkRow.getAs[String]("document_id") should be((syncPayload \ "id").extract[String])
+    checkRow.getAs[String]("app_build_id") should be((syncPayload \ "application" \ "buildId").extract[String])
+    checkRow.getAs[String]("app_display_version") should be((syncPayload \ "application" \ "displayVersion").extract[String])
+    checkRow.getAs[String]("app_name") should be((syncPayload \ "application" \ "name").extract[String])
+    checkRow.getAs[String]("app_version") should be((syncPayload \ "application" \ "version").extract[String])
+    checkRow.getAs[String]("app_channel") should be((syncPayload \ "application" \ "channel").extract[String])
 
-    val payload = sync_payload \ "payload"
+    val payload = syncPayload \ "payload"
     checkRow.getAs[String]("why") should be((payload \ "why").extract[String])
     checkRow.getAs[String]("uid") should be((payload \ "uid").extract[String])
     checkRow.getAs[String]("device_id") should be((payload \ "deviceID").extract[String])
@@ -232,7 +234,7 @@ class SyncEventViewTest extends FlatSpec with Matchers with DataFrameSuiteBase {
   "Sync Events" can "contain os information for sending device" in {
     sc.setLogLevel("WARN")
     implicit val formats = DefaultFormats
-    val row = SyncEventConverter.pingToRows(sync_payload_with_os)
+    val row = SyncEventConverter.pingToRows(syncPayloadWithOs)
     val rdd = sc.parallelize(row)
 
     val dataframe = spark.createDataFrame(rdd, SyncEventConverter.syncEventSchema)
@@ -241,7 +243,7 @@ class SyncEventViewTest extends FlatSpec with Matchers with DataFrameSuiteBase {
     dataframe.count() should be(1)
     val checkRow = dataframe.first()
 
-    val payload = sync_payload \ "payload"
+    val payload = syncPayload \ "payload"
 
     checkRow.getAs[String]("device_os_name") should be("iOS")
     checkRow.getAs[String]("device_os_version") should be("10.0")

--- a/src/test/scala/com/mozilla/telemetry/views/SyncFlatViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/SyncFlatViewTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase

--- a/src/test/scala/com/mozilla/telemetry/views/SyncViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/SyncViewTest.scala
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase

--- a/src/test/scala/com/mozilla/telemetry/views/SyncViewTestPayloads.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/SyncViewTestPayloads.scala
@@ -1,12 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry
 
+import org.json4s.JValue
 import org.json4s.jackson.JsonMethods._
 
 object SyncViewTestPayloads {
   // Test payloads, typically taken directly from about:telemetry.
 
   // An "old style" payload where each "ping" recorded exactly 1 sync.
-  def singleSyncPing = parse("""{
+  def singleSyncPing: JValue = parse("""{
     |  "type": "sync",
     |  "id": "824bb059-d22f-4930-b915-45580ecf463e",
     |  "creationDate": "2016-09-02T04:35:18.787Z",
@@ -85,7 +89,7 @@ object SyncViewTestPayloads {
     |}""".stripMargin)
 
   // A "new style" payload where there may be any number of syncs in a single ping.
-  def multiSyncPing = parse(
+  def multiSyncPing: JValue = parse(
     """
     |{
     |  "type": "sync",
@@ -204,7 +208,7 @@ object SyncViewTestPayloads {
     """.stripMargin)
 
   // Sync ping payload with devices and validation data.
-  def complexSyncPing = parse(
+  def complexSyncPing: JValue = parse(
     """
       |{
       |  "type": "sync",
@@ -299,7 +303,7 @@ object SyncViewTestPayloads {
     """.stripMargin)
 
   // This also stores the os at the top level for compatibility with android (bug 1409860)
-  def multiSyncPingWithTopLevelIds = parse(
+  def multiSyncPingWithTopLevelIds: JValue = parse(
     """
       |{
       |  "type": "sync",


### PR DESCRIPTION
This introduces Scalastyle to t-b-v. In cases where simple refactorings were not enough for adhering to style rules, checker is turned off (using `// scalastyle:off` comments). These cases will be fixed in separate PRs.

Also:
* sbt version is bumped
* some useful compiler warnings are turned on (next step would be getting rid of them and failing the build on any warnings)

Before merging, Scalastyle-related commits should be squashed.