### PR TITLE
Bug 1473641 Set maxRecordsPerFile in ExperimentsSummaryView

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/ExperimentSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/ExperimentSummaryView.scala
@@ -22,7 +22,10 @@ object ExperimentSummaryView {
   def experimentsUrl: String = "https://normandy.services.mozilla.com/api/v1/recipe/"
   def experimentsUrlParams: List[(String, String)] = List(("format", "json"))
   def experimentsQualifyingAction: List[String] = List("preference-experiment", "opt-out-study")
-  def excludedExperiments: List[String] = List("pref-flip-screenshots-release-1369150", "pref-flip-search-composition-57-release-1413565")
+  def excludedExperiments: List[String] = List(
+    "pref-flip-screenshots-release-1369150",
+    "pref-flip-search-composition-57-release-1413565",
+    "pref-hotfix-tls-13-avast-rollback")
   private case class NormandyRecipeBranch(ratio: Int, slug: String, value: Any)
   private case class NormandyRecipeArguments(branches: List[NormandyRecipeBranch],
                                              slug: Option[String],

--- a/src/test/scala/com/mozilla/telemetry/views/ExperimentSummaryViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/ExperimentSummaryViewTest.scala
@@ -55,7 +55,7 @@ class ExperimentSummaryViewTest extends FlatSpec with Matchers with DataFrameSui
     val testExperimentsLocation = com.mozilla.telemetry.utils.temporaryFileName().toString.replace("file:", "")
     val testExperimentsList = List("experiment1")
 
-    ExperimentSummaryView.writeExperiments(testMainLocation, testExperimentsLocation, "20170101", testExperimentsList, spark)
+    ExperimentSummaryView.writeExperiments(testMainLocation, testExperimentsLocation, "20170101", testExperimentsList, spark, 500000)
 
     val actual = spark.read.parquet(testExperimentsLocation)
       .orderBy(col("document_id"), col("experiment_id"))


### PR DESCRIPTION
Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1473641

The 'pref-hotfix-tls-13-avast-rollback' experiment has _much_ higher enrollment
than any other experiment in the past month.
It turned on on 6/28 with ~4 million appearances, which ballooned to 61M by 7/2.
This is at least an order of magnitude higher than any other experiment.

I'm pretty certain the problem we're hitting is that ExperimentSummaryView
is partitioning by experiment_id when writing with no cap on how
large a partition is, so it's trying to accumulate all 62M records
on a single node before writing out an object.

If we apply maxRecordsPerFile as we do on MainSummaryView,
then I think we'll be good.