### PR TITLE
Bug 1474703 Add retention metrics to experiments_aggregates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,8 @@ val localMaven = "s3://net-mozaws-data-us-west-2-ops-mavenrepo/"
 
 resolvers += "S3 local maven snapshots" at localMavenHttps + "snapshots"
 
-val sparkVersion = "2.3.0"
+// Bumped from 2.3.0 to 2.3.1 for bugfix: https://issues.apache.org/jira/browse/SPARK-23986
+val sparkVersion = "2.3.1"
 // Should keep hadoop version in sync with the dependency defined by Spark.
 val hadoopVersion = "2.6.5"
 

--- a/src/main/scala/com/mozilla/telemetry/experiments/statistics/StatisticalComputation.scala
+++ b/src/main/scala/com/mozilla/telemetry/experiments/statistics/StatisticalComputation.scala
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package com.mozilla.telemetry.experiments.statistics
+
+object StatisticalComputation {
+  val percentileInts: Seq[Int] = 5 +: (10 to 90 by 10) :+ 95
+  val percentiles: Seq[PercentileComputation] = percentileInts.map(PercentileComputation)
+  val values: Seq[StatisticalComputation] = percentiles :+ MeanComputation
+  val names: Seq[String] = values.map(_.name)
+}
+
+trait StatisticalComputation {
+  def name: String
+  def calculate(arr: Array[Double]): Double
+}
+
+object MeanComputation extends StatisticalComputation {
+  override val name: String = "Mean"
+  override def calculate(arr: Array[Double]): Double = {
+    breeze.stats.mean(arr)
+  }
+}
+
+/**
+  * Object capturing the logic for naming and computing a particular percentile.
+  *
+  * @param pInt The desired percentile as an integer between 0 and 100
+  */
+case class PercentileComputation(pInt: Int) extends StatisticalComputation {
+  val p: Double = pInt * 0.01
+
+  override def name: String = pInt match {
+    case 50 => "Median"
+    case 11 | 12 | 13 => s"${pInt}th Percentile"
+    case _ if pInt % 10 == 1 => s"${pInt}st Percentile"
+    case _ if pInt % 10 == 2 => s"${pInt}nd Percentile"
+    case _ if pInt % 10 == 3 => s"${pInt}rd Percentile"
+    case _ => s"${pInt}th Percentile"
+  }
+
+  /**
+    * Based on https://github.com/scalanlp/breeze/blob/releases/v1.0-RC2/math/src/main/scala/breeze/stats/DescriptiveStats.scala#L523
+    *
+    * We copy this code out of breeze because their implementation always sorts the array.
+    * We call this function many times on a single array, so want to be able to sort once.
+    *
+    * The array must already be sorted.
+    */
+  override def calculate(arr: Array[Double]): Double = {
+    if (p > 1 || p < 0) throw new IllegalArgumentException("p must be in [0,1]")
+    // +1 so that the .5 == mean for even number of elements.
+    val f = (arr.length + 1) * p
+    val i = f.toInt
+    if (i == 0) {
+      arr.head
+    }
+    else if (i >= arr.length) {
+      arr.last
+    }
+    else {
+      arr(i - 1) + (f - i) * (arr(i) - arr(i - 1))
+    }
+  }
+}
+

--- a/src/main/scala/com/mozilla/telemetry/utils/ColumnEnumeration.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/ColumnEnumeration.scala
@@ -14,12 +14,12 @@ import scala.language.implicitConversions
   * name as a val, and then get access to that Scala-level name as a string to
   * pass into Spark SQL expressions.
   *
-  * You can also define a derived column by passing a SQL expression string into Val();
-  * this logical definition is then available as `expr`.
+  * You can also define a derived column by passing a SQL expression string into
+  * the ColumnDefinition constructor; this logical definition is then available as `expr`.
   */
 abstract class ColumnEnumeration extends Enumeration {
 
-  protected case class Val(private val definition: Column = new Column("")) extends super.Val {
+  protected case class ColumnDefinition(private val definition: Column = new Column(this.toString())) extends super.Val {
     /**
       * The name as given in the Scala code.
       *
@@ -35,13 +35,10 @@ abstract class ColumnEnumeration extends Enumeration {
     /**
       * The logic defining the column as a spark.sql.Column
       */
-    def expr: Column = definition.toString match {
-      case "" => new Column(name)
-      case _ => definition.alias(name)
-    }
+    def expr: Column = definition.alias(name)
   }
 
-  implicit def valueToColumnEnumerationVal(value: Value): Val = value.asInstanceOf[Val]
+  implicit def valueToColumnDefinition(value: Value): ColumnDefinition = value.asInstanceOf[ColumnDefinition]
 
   def names: List[String] = {
     values.toList.map(_.name)

--- a/src/main/scala/com/mozilla/telemetry/utils/ColumnEnumeration.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/ColumnEnumeration.scala
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ package com.mozilla.telemetry.utils
+
+import org.apache.spark.sql.Column
+
+import scala.language.implicitConversions
+
+/**
+  * Base class for enumerations of Spark DataFrame column expressions.
+  *
+  * Enumerations are convenient here because they allow us to define a column
+  * name as a val, and then get access to that Scala-level name as a string to
+  * pass into Spark SQL expressions.
+  *
+  * You can also define a derived column by passing a SQL expression string into Val();
+  * this logical definition is then available as `expr`.
+  */
+abstract class ColumnEnumeration extends Enumeration {
+
+  protected case class Val(private val definition: Column = new Column("")) extends super.Val {
+    /**
+      * The name as given in the Scala code.
+      *
+      * For example, `val my_column = Val()` will have name "my_column".
+      */
+    def name: String = this.toString
+
+    /**
+      * The name of the column as a spark.sql.Column
+      */
+    def col: Column = new Column(name)
+
+    /**
+      * The logic defining the column as a spark.sql.Column
+      */
+    def expr: Column = definition.toString match {
+      case "" => new Column(name)
+      case _ => definition.alias(name)
+    }
+  }
+
+  implicit def valueToColumnEnumerationVal(value: Value): Val = value.asInstanceOf[Val]
+
+  def names: List[String] = {
+    values.toList.map(_.name)
+  }
+
+  def cols: List[Column] = {
+    values.toList.map(_.col)
+  }
+
+  def exprs: List[Column] = {
+    values.toList.map(_.expr)
+  }
+
+}

--- a/src/main/scala/com/mozilla/telemetry/utils/udfs.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/udfs.scala
@@ -5,12 +5,13 @@ package com.mozilla.telemetry.utils
 
 import java.math.BigDecimal
 import java.sql.{Date, Timestamp}
+
 import org.apache.spark.sql.expressions.{MutableAggregationBuffer, UserDefinedAggregateFunction}
-import org.apache.spark.sql.{Column, Row, SparkSession}
+import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.functions._
 import com.mozilla.spark.sql.hyperloglog.functions._
 import com.mozilla.spark.sql.hyperloglog.aggregates._
+
 import scala.annotation.tailrec
 
 class CollectList(inputStruct: StructType, orderCols: List[String], maxLength: Option[Int]) extends UserDefinedAggregateFunction {

--- a/src/test/scala/com/mozilla/telemetry/experiments/statistics/StatisticalComputationTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/experiments/statistics/StatisticalComputationTest.scala
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package com.mozilla.telemetry.experiments.statistics
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class StatisticalComputationTest extends FlatSpec with Matchers {
+
+  "PercentileComputation" must "generate correct ordinals" in {
+    PercentileComputation(1).name shouldBe "1st Percentile"
+    PercentileComputation(2).name shouldBe "2nd Percentile"
+    PercentileComputation(3).name shouldBe "3rd Percentile"
+    PercentileComputation(4).name shouldBe "4th Percentile"
+    PercentileComputation(10).name shouldBe "10th Percentile"
+    PercentileComputation(11).name shouldBe "11th Percentile"
+    PercentileComputation(14).name shouldBe "14th Percentile"
+    PercentileComputation(21).name shouldBe "21st Percentile"
+    PercentileComputation(95).name shouldBe "95th Percentile"
+    PercentileComputation(50).name shouldBe "Median"
+  }
+
+}

--- a/src/test/scala/com/mozilla/telemetry/utils/ColumnEnumerationTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/utils/ColumnEnumerationTest.scala
@@ -7,11 +7,11 @@ import org.apache.spark.sql.Column
 import org.scalatest.{FlatSpec, Matchers}
 
 object Cols extends ColumnEnumeration {
-  val first_one, second_one = Val()
-  val custom_definition = Val(new Column("base_column") / 5)
+  val first_one, second_one = ColumnDefinition()
+  val custom_definition = ColumnDefinition(new Column("base_column") / 5)
 }
 
-class ExperimentEngagementAnalyzerTest extends FlatSpec with Matchers {
+class ColumnEnumerationTest extends FlatSpec with Matchers {
 
   "implicit defs" can "be accessed" in {
     Cols.first_one.name shouldBe "first_one"

--- a/src/test/scala/com/mozilla/telemetry/utils/ColumnEnumerationTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/utils/ColumnEnumerationTest.scala
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package com.mozilla.telemetry.utils
+
+import org.apache.spark.sql.Column
+import org.scalatest.{FlatSpec, Matchers}
+
+object Cols extends ColumnEnumeration {
+  val first_one, second_one = Val()
+  val custom_definition = Val(new Column("base_column") / 5)
+}
+
+class ExperimentEngagementAnalyzerTest extends FlatSpec with Matchers {
+
+  "implicit defs" can "be accessed" in {
+    Cols.first_one.name shouldBe "first_one"
+    Cols.first_one.col.toString shouldBe "first_one"
+  }
+
+  "custom definition" can "be accessed" in {
+    Cols.custom_definition.name shouldBe "custom_definition"
+    Cols.custom_definition.col.toString shouldBe "custom_definition"
+    Cols.custom_definition.expr.toString shouldBe "(base_column / 5) AS `custom_definition`"
+  }
+
+}


### PR DESCRIPTION
This adds retention metrics and refactors the analyzer to use fewer bare strings and instead rely on enumerations of column definitions.

I've run this code on recent data via EMR. See retention metric example at the bottom of:

https://dbc-caf9527b-e073.cloud.databricks.com/#notebook/19306