### PR TITLE
Bug 1476038: Fix experiment summary (again)

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/ExperimentSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/ExperimentSummaryView.scala
@@ -116,7 +116,7 @@ object ExperimentSummaryView {
       .select(col("*"), explode(col("experiments")).as(Array("experiment_id", "experiment_branch")))
       .where(col("experiment_id").isin(experiments:_*))
       .withColumn("submission_date_s3", lit(date))
-      .repartition(col("experiment_id"))
+      .coalesce(10)
       .write
       // Usage characteristics will most likely be "get all pings from an experiment for all days"
       .partitionBy("experiment_id", "submission_date_s3")

--- a/src/main/scala/com/mozilla/telemetry/views/ExperimentSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/ExperimentSummaryView.scala
@@ -28,6 +28,7 @@ object ExperimentSummaryView {
     "pref-hotfix-tls-13-avast-rollback")
   private case class NormandyRecipeBranch(ratio: Int, slug: String, value: Any)
   private case class NormandyRecipeArguments(branches: List[NormandyRecipeBranch],
+                                             isHighVolume: Option[Boolean],
                                              slug: Option[String],
                                              name: Option[String])
   private case class NormandyRecipe(id: Long,
@@ -143,6 +144,7 @@ object ExperimentSummaryView {
 
   def shouldProcessExperiment(r: NormandyRecipe, date: Date): Boolean = {
     experimentsQualifyingAction.contains(r.action) &&
+    r.arguments.isHighVolume != Some(true) &&
     !excludedExperiments.contains(r.arguments.slug.get) &&
     ((r.enabled == true) || r.last_updated.after(date)) // is this experiment enabled for this date?
   }
@@ -158,7 +160,8 @@ object ExperimentSummaryView {
       case Success(r) =>
         Try(r.arguments.slug.getOrElse(r.arguments.name.get)) match {
           case Success(slug) =>
-            Some(r.copy(arguments=NormandyRecipeArguments(r.arguments.branches, Some(slug), Some(slug))))
+            Some(r.copy(arguments=NormandyRecipeArguments(r.arguments.branches, r.arguments.isHighVolume, Some(slug),
+              Some(slug))))
           case _ =>
             None
         }


### PR DESCRIPTION
We were seeing step failures again on this job with what looked like OOMs. It looks like a high-population experiment is the culprit. Two fixes here: ignore experiments tagged as high volume, and don't repartition by experiment_id (which is unbalanced anyway and most of the machines were probably just sitting idle most of the time) -- I'm coalescing down to 10 partitions instead which should keep all the executors busy but keep the number of files from exploding too badly.