### PR TITLE
TAAR: Removed the hardcoded blacklist 

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/ml/AddonRecommender.scala
+++ b/src/main/scala/com/mozilla/telemetry/ml/AddonRecommender.scala
@@ -100,7 +100,7 @@ object AddonRecommender {
   /**
     * Get a new dataset from the Longitudinal dataset containing only the relevant addon data.
     * @param sparkSession The SparkSession used for loading the Longitudinal dataset.
-    * @param addonBlacklist The a list of addon GUIDs to exclude.
+    * @param addonWhitelist The a list of addon GUIDs that are valid
     * @param amoDB The AMO database fetched by AMODatabase.
     * @return A 4 columns Dataset with each row having the client id, the addon GUID
     *         and the hashed client id and GUID.

--- a/src/test/scala/com/mozilla/telemetry/ml/AddonRecommenderTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/ml/AddonRecommenderTest.scala
@@ -203,7 +203,7 @@ class AddonRecommenderTest extends FlatSpec with Matchers with DataFrameSuiteBas
     val hash = PrivateMethod[Int]('hash)
 
     // Filter the dataframe, collect and validate the results.
-    val df = AddonRecommender invokePrivate getAddonData(spark, List("{blacklisted-addon-guid}"), amoDB)
+    val df = AddonRecommender invokePrivate getAddonData(spark, List("{webext-addon-guid}", "{legacy-addon-guid}"), amoDB)
 
     val data = df.collect()
     assert(data.length == 2)


### PR DESCRIPTION
This replaces the hardcoded blacklist and replaces it with an S3 loaded whitelist for TAAR addons.

The logic in getAddonData has been inverted to assert that an addonId is contained in the whitelist instead of not within a blacklist.

cc/ @mlopatka