### PR TITLE
Bug 1485682 - Scalarized Count and Flag histograms

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/utils/MainPing.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/MainPing.scala
@@ -425,7 +425,7 @@ object MainPing{
    * Converts buckets to their labels.
    * Accumulates all non-labeled buckets into the spill bucket.
    */
-  def extractCategoricalHistogramMap(definition: CategoricalHistogram)(histogram: JValue): Map[String, Int] = {
+  private def extractCategoricalHistogramMap(definition: CategoricalHistogram)(histogram: JValue): Map[String, Int] = {
     extractHistogramMap(histogram) match {
       case null => null
       case l => l.toList
@@ -436,7 +436,7 @@ object MainPing{
     }
   }
 
-  def extractCountHistogram(histogram: JValue): Option[Integer] = {
+  private def extractCountHistogram(histogram: JValue): Option[Integer] = {
     // Count histograms are null unless the
     // 0 bucket has a value
     extractHistogramMap(histogram) match {
@@ -445,7 +445,7 @@ object MainPing{
     }
   }
 
-  def extractFlagHistogram(histogram: JValue): Option[Boolean] = {
+  private def extractFlagHistogram(histogram: JValue): Option[Boolean] = {
     // Flag histograms are null unless:
     // both buckets 0 and 1 are present,
     // they both have valid values (0 or 1),
@@ -462,7 +462,7 @@ object MainPing{
     }
   }
 
-  def extract(func: JValue => Any)(histogram: JValue): Any = {
+  private def extract(func: JValue => Any)(histogram: JValue): Any = {
     func(histogram) match {
       case None => null
       case Some(v) => v
@@ -470,7 +470,10 @@ object MainPing{
     }
   }
 
-  def histogramsToRow(histograms: Map[String, JValue], definitions: List[(String, HistogramDefinition)], naturalHistogramRepresentationList: List[String]): Row = {
+  def histogramsToRow(histograms: Map[String, JValue],
+                      definitions: List[(String, HistogramDefinition)],
+                      naturalHistogramRepresentationList: List[String]
+                     ): Row = {
     implicit val formats = DefaultFormats
 
     Row.fromSeq(

--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -25,7 +25,7 @@ object MainSummaryView {
   def schemaVersion: String = "v4"
   def jobName: String = "main_summary"
 
-  // Allow at most .5% of records to be ignored
+  // Allow at most .005% of records to be ignored
   // Records are ignored when we can't properly deserialize them
   val MaxFractionIgnoredPings = .00005
 
@@ -127,7 +127,28 @@ object MainSummaryView {
     "WEBVR_TIME_SPENT_VIEWING_IN_OPENVR" ::
     "WEBVR_USERS_VIEW_IN" :: Nil
 
-
+  /**
+   * Count and Flag histograms are both automatically
+   * transformed into Scalars. Count histograms become
+   * integer counts, and Flag histograms become boolean
+   * values.
+   *
+   * If instead a count or flag histogram should have
+   * it's natural histogram representation - a Map
+   * of buckets and their associated counts - then
+   * including the probe name here will ensure that.
+   *
+   * For example, a Flag histogram with values
+   * {0: 1, 1: 0} will be recorded as False. However,
+   * including the probe name here will store the
+   * {0: 1, 1: 0} Map instead.
+   *
+   * WARNING: Removing or adding to this list will change
+   * the schema for that probe's columns, rendering all
+   * previous data unreadable. The normal method is to
+   * include a probe name here when added to the whitelist,
+   * and never remove it.
+   */
   val NaturalHistogramRepresentationList =
     "A11Y_INSTANTIATED_FLAG" :: Nil
 

--- a/src/test/resources/ShortHistograms.json
+++ b/src/test/resources/ShortHistograms.json
@@ -171,5 +171,23 @@
     "releaseChannelCollection": "opt-out",
     "description": "a testing histogram; not meant to be touched",
     "record_in_processes": ["main", "content", "gpu"]
+  },
+  "MOCK_COUNT": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "count",
+    "keyed": false,
+    "releaseChannelCollection": "opt-out",
+    "description": "a testing histogram; not meant to be touched",
+    "record_in_processes": ["main", "content", "gpu"]
+  },
+  "MOCK_FLAG": {
+    "alert_emails": ["telemetry-client-dev@mozilla.com"],
+    "expires_in_version": "never",
+    "kind": "flag",
+    "keyed": false,
+    "releaseChannelCollection": "opt-out",
+    "description": "a testing histogram; not meant to be touched",
+    "record_in_processes": ["main", "content", "gpu"]
   }
 }

--- a/src/test/scala/com/mozilla/telemetry/views/MainSummaryViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/MainSummaryViewTest.scala
@@ -72,8 +72,21 @@ class MainSummaryViewTest extends FlatSpec with Matchers with DataFrameSuiteBase
               naturalHistogramRepresentationList: List[String] = Nil
              ): Unit = {
     val doc = message.toJValue.get
-    val summary = MainSummaryView.messageToRow(doc, scalarDefinitions, histogramDefinitions, naturalHistogramRepresentationList, userPreferences)
-    val applied = applySchema(summary.get, MainSummaryView.buildSchema(userPreferences, scalarDefinitions, histogramDefinitions, naturalHistogramRepresentationList))
+
+    val summary = MainSummaryView.messageToRow(
+      doc,
+      scalarDefinitions,
+      histogramDefinitions,
+      naturalHistogramRepresentationList,
+      userPreferences)
+
+    val schema = MainSummaryView.buildSchema(
+      userPreferences,
+      scalarDefinitions,
+      histogramDefinitions,
+      naturalHistogramRepresentationList)
+
+    val applied = applySchema(summary.get, schema)
     val actual = applied.getValuesMap(expected.keys.toList)
 
     if (!testInvalidFields.isEmpty) {


### PR DESCRIPTION
Previously, we allowed Flag histograms (but not count), and they
were just stored as histograms (a map of buckets and their counts).

These two histogram types should get special treatment, since
at their heart they are scalars. This change allows people to
add count and flag histograms, but stores them as scalars.

Note that to do so requires a bit of processing of the histogram,
where previously we just stored whatever we found there. So for
example, a flag histogram with value 2 in the 0 bucket will be
a null, since that is not a valid representation. If we stored
that as a histogram, we would find just {0: 2}.

Finally we have one flag histogram which cannot be converted.
A new list of histogram-represented histograms is added,
and if a probe is present in that list it's exact `values`
will be included in main_summary.