### PR TITLE
Bug 1484341 - Add a base class to telemetry-batch-view

### DIFF
--- a/scripts/test_run.sh
+++ b/scripts/test_run.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -euo pipefail
+set -x
+
+tbv_jar=$1
+date=${2:-$(date +%Y%m%d --date=yesterday)}
+bucket=${3:-"telemetry-test-bucket"}
+
+if [[ -z ${tbv_jar} ]]; then
+    echo "Missing telemetry-batch-view jar!"
+    exit 1
+fi
+
+if [[ ${bucket} == "telemetry-parquet" ]]; then
+    echo "Writing to telemetry-parquet is not allowed!"
+    exit 1
+fi
+
+
+submit() {
+    classname="$1"
+    options="$2"
+
+    spark-submit \
+        --master yarn \
+        --deploy-mode client \
+        --class com.mozilla.telemetry.views.${classname} \
+        ${tbv_jar} ${options}
+}
+
+baseopt="--to $date --from $date --bucket $bucket"
+
+submit MainSummaryView          "$baseopt --channel nightly --read-mode aligned"
+submit ExperimentSummaryView    "$baseopt --experiment-limit 1"
+
+# long running
+submit CrashSummaryView         "$baseopt --dry-run"
+
+###########################################################
+#               Jobs without Test Options
+###########################################################
+
+# submit AddonsView
+# submit CrashAggregateView
+# submit ExperimentAnalysisView
+# submit LongitudinalView
+# submit MainEventsView
+# submit SyncEventView
+# submit SyncFlatView
+# submit SyncView
+
+# submit GenericCountView
+# submit GenericLongitudinalView
+# submit QuantumRCView
+# submit RetentionView

--- a/src/main/scala/com/mozilla/telemetry/views/BatchJobBase.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/BatchJobBase.scala
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package com.mozilla.telemetry.views
+
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import java.time.{Clock, LocalDate}
+
+import com.mozilla.telemetry.views.BatchJobBase._
+import org.apache.spark.sql.SparkSession
+import org.rogach.scallop.{ScallopConf, ScallopOption}
+
+/***
+  * Base class for batch processing jobs
+  */
+abstract class BatchJobBase extends Serializable {
+
+  val clock: Clock = Clock.systemUTC()
+
+  /**
+    * Generates list of dates for querying `com.mozilla.telemetry.heka.Dataset`
+    * If `to` is empty, uses yesterday as the upper bound.
+    *
+    * @param from start date, in "yyyyMMdd" format
+    * @param to   (optional) end date, in "yyyyMMdd" format
+    * @return sequence of dates formatted as "yyyyMMdd" strings
+    */
+  def datesBetween(from: String, to: Option[String]): Seq[String] = {
+    val parsedFrom: LocalDate = LocalDate.parse(from, DateFormatter)
+    val parsedTo: LocalDate = to match {
+      case Some(t) => LocalDate.parse(t, DateFormatter)
+      case _ => LocalDate.now(clock).minusDays(1)
+    }
+    (0L to ChronoUnit.DAYS.between(parsedFrom, parsedTo)).map { offset =>
+      parsedFrom.plusDays(offset).format(DateFormatter)
+    }
+  }
+
+  private[views] class BaseOpts(args: Array[String]) extends ScallopConf(args) {
+    val from: ScallopOption[String] = opt[String](
+      "from",
+      descr = "Start submission date, defaults to yesterday. Format: YYYYMMDD",
+      default=Some(LocalDate.now(clock).minusDays(1).format(DateFormatter)),
+      required = false)
+    val to: ScallopOption[String] = opt[String](
+      "to",
+      descr = "End submission date. Default: yesterday. Format: YYYYMMDD",
+      required = false)
+    val outputBucket = opt[String](
+      "bucket",
+      descr = "Destination bucket for parquet data",
+      required = true)
+  }
+
+  protected def shouldStopContextAtEnd(spark: SparkSession): Boolean = {
+    !spark.conf.get("spark.home", "").startsWith("/databricks")
+  }
+}
+
+object BatchJobBase {
+  /**
+    * Date format for parsing input arguments and formatting partitioning columns
+    */
+  val DateFormat = "yyyyMMdd"
+  val DateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern(DateFormat)
+}

--- a/src/main/scala/com/mozilla/telemetry/views/ExperimentAnalysisView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/ExperimentAnalysisView.scala
@@ -13,7 +13,7 @@ import org.rogach.scallop.ScallopConf
 
 import scala.util.{Failure, Success, Try}
 
-object ExperimentAnalysisView {
+object ExperimentAnalysisView extends BatchJobBase {
   private val defaultErrorAggregatesBucket = "net-mozaws-prod-us-west-2-pipeline-data"
   private val errorAggregatesPath = "experiment_error_aggregates/v1"
   private val jobName = "experiment_analysis"
@@ -132,7 +132,8 @@ object ExperimentAnalysisView {
         .write.mode("overwrite").parquet(outputLocation)
 
       logger.info(s"Wrote aggregates to $outputLocation")
-      spark.stop()
+
+      if (shouldStopContextAtEnd(spark)) { spark.stop() }
     }
   }
 

--- a/src/main/scala/com/mozilla/telemetry/views/GenericCountView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/GenericCountView.scala
@@ -10,7 +10,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.rogach.scallop._
 
-object GenericCountView {
+object GenericCountView extends BatchJobBase {
 
   val DefaultSubmissionDateCol = "submission_date_s3"
   val DefaultHllBits = 12
@@ -159,6 +159,6 @@ object GenericCountView {
       .mode(conf.writeMode())
       .parquet(s"s3://${conf.outputBucket()}/$version$partition")
 
-    spark.stop()
+    if (shouldStopContextAtEnd(spark)) { spark.stop() }
   }
 }

--- a/src/main/scala/com/mozilla/telemetry/views/GenericLongitudinal.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/GenericLongitudinal.scala
@@ -10,7 +10,7 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{Column, DataFrame, SQLContext}
 import org.rogach.scallop._
 
-object GenericLongitudinalView {
+object GenericLongitudinalView extends BatchJobBase {
 
   val DefaultWriteMode = "overwrite"
 
@@ -119,7 +119,7 @@ object GenericLongitudinalView {
       .mode(opts.writeMode())
       .parquet(s"s3://$outputPath/$version")
 
-    spark.stop()
+    if (shouldStopContextAtEnd(spark)) { spark.stop() }
   }
 
   def run(sqlContext: SQLContext, opts: Opts): DataFrame = {

--- a/src/main/scala/com/mozilla/telemetry/views/Longitudinal.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/Longitudinal.scala
@@ -87,7 +87,7 @@ protected class ClientIterator(it: Iterator[(String, Map[String, Any])], maxHist
   // scalastyle:on return
 }
 
-object LongitudinalView {
+object LongitudinalView extends BatchJobBase {
   @transient lazy val logger = org.apache.log4j.Logger.getLogger(this.getClass.getName)
 
   val jobName = "longitudinal"
@@ -214,7 +214,7 @@ object LongitudinalView {
 
     run(opts.to(), opts.outputBucket(), messages, sc.defaultParallelism, handler, histogramDefinitions, scalarDefinitions, DefaultFilterLimit)
 
-    sc.stop()
+    if (shouldStopContextAtEnd(spark)) { spark.stop() }
   }
 
   private def getOrderKey(message: Message): Option[((String, String, Int), Int)] = {

--- a/src/main/scala/com/mozilla/telemetry/views/QuantumRCView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/QuantumRCView.scala
@@ -19,7 +19,7 @@ import org.rogach.scallop._
   * We use HLLs to get client_counts for a set of
   * values across a set of dimensions.
   */
-object QuantumRCView {
+object QuantumRCView extends BatchJobBase {
 
   val TotalCountColName = "total_clients"
   val DatasetPrefix = "quantum_rc"
@@ -129,6 +129,6 @@ object QuantumRCView {
       .mode(WriteMode)
       .parquet(s"s3://${conf.bucket()}/$DatasetPrefix/$Version/$WeekPartitionName=$from")
 
-    spark.stop()
+    if (shouldStopContextAtEnd(spark)) { spark.stop() }
   }
 }

--- a/src/main/scala/com/mozilla/telemetry/views/RetentionView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/RetentionView.scala
@@ -11,7 +11,7 @@ import org.apache.spark.sql.functions._
 import org.rogach.scallop._
 
 
-object RetentionView {
+object RetentionView extends BatchJobBase {
   class Conf(args: Array[String]) extends ScallopConf(args) {
     val date = opt[String]("date", descr = "Run date for this job", required = true)
     val input = opt[String]("input", descr = "Source for parquet data", required = true)
@@ -85,6 +85,6 @@ object RetentionView {
       .mode("overwrite")
       .parquet(s"s3://${conf.bucket()}/${conf.prefix()}/start_date=${conf.date()}")
 
-    spark.stop()
+    if (shouldStopContextAtEnd(spark)) { spark.stop() }
   }
 }

--- a/src/main/scala/com/mozilla/telemetry/views/SyncView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/SyncView.scala
@@ -6,23 +6,20 @@ package com.mozilla.telemetry.views
 import com.mozilla.telemetry.heka.Dataset
 import com.mozilla.telemetry.utils.{S3Store, SyncPingConversion, getOrCreateSparkSession}
 import org.apache.spark.SparkContext
-import org.joda.time.{DateTime, Days, format}
 import org.json4s.jackson.JsonMethods.parse
 import org.json4s.string2JsonInput
-import org.rogach.scallop._ // Just for my attempted mocks below.....
+import org.rogach.scallop._
 
 
-object SyncView {
+object SyncView extends BatchJobBase {
   private val logger = org.apache.log4j.Logger.getLogger(this.getClass.getName)
 
   def schemaVersion: String = "v2"
   def jobName: String = "sync_summary"
 
   // Configuration for command line arguments
-  private class Conf(args: Array[String]) extends ScallopConf(args) {
-    val from = opt[String]("from", descr = "From submission date", required = false)
-    val to = opt[String]("to", descr = "To submission date", required = false)
-    val outputBucket = opt[String]("bucket", descr = "Destination bucket for parquet data", required = false)
+  private class Conf(args: Array[String]) extends BaseOpts(args) {
+    override val outputBucket = opt[String]("bucket", descr = "Destination bucket for parquet data", required = false)
     val outputFilename = opt[String]("outputFilename", descr = "Destination local filename for parquet data", required = false)
     val limit = opt[Int]("limit", descr = "Maximum number of files to read from S3", required = false)
     verify()
@@ -32,15 +29,6 @@ object SyncView {
     val conf = new Conf(args) // parse command line arguments
     if (!conf.outputBucket.supplied && !conf.outputFilename.supplied) {
       conf.errorMessageHandler("One of outputBucket or outputFilename must be specified")
-    }
-    val fmt = format.DateTimeFormat.forPattern("yyyyMMdd")
-    val to = conf.to.get match {
-      case Some(t) => fmt.parseDateTime(t)
-      case _ => DateTime.now.minusDays(1)
-    }
-    val from = conf.from.get match {
-      case Some(f) => fmt.parseDateTime(f)
-      case _ => DateTime.now.minusDays(1)
     }
 
     // Set up Spark
@@ -55,10 +43,7 @@ object SyncView {
     hadoopConf.set("parquet.enable.summary-metadata", "false")
 
 
-    for (offset <- 0 to Days.daysBetween(from, to).getDays) {
-      val currentDate = from.plusDays(offset)
-      val currentDateString = currentDate.toString("yyyyMMdd")
-
+    for (currentDateString <- datesBetween(conf.from(), conf.to.toOption)) {
       logger.info("=======================================================================================")
       logger.info(s"BEGINNING JOB $jobName $schemaVersion FOR $currentDateString")
 
@@ -74,7 +59,7 @@ object SyncView {
       }.where("docType") {
         case "sync" => true
       }.where("submissionDate") {
-        case date if date == currentDate.toString("yyyyMMdd") => true
+        case date if date == currentDateString => true
       }.records(conf.limit.get, Some(100))
 
       val rowRDD = messages.flatMap(m => {
@@ -134,7 +119,7 @@ object SyncView {
       logger.info("=======================================================================================")
     }
 
-    spark.stop()
+    if (shouldStopContextAtEnd(spark)) { spark.stop() }
   }
 
 }

--- a/src/test/scala/com/mozilla/telemetry/views/BatchJobBase.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/BatchJobBase.scala
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package com.mozilla.telemetry.views
+
+import java.time.{Clock, LocalDate, ZoneId}
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class BatchJobBaseTest extends FlatSpec with Matchers {
+  private val base = new BatchJobBase {
+    override val clock: Clock = Clock.fixed(
+      LocalDate.of(2018, 4, 5).atStartOfDay(ZoneId.of("UTC")).toInstant, ZoneId.of("UTC"))
+  }
+
+  "Base streaming job" should "generate range of parsed dates for querying Dataset API" in {
+    base.datesBetween("20180401", Some("20180401")) should contain theSameElementsInOrderAs Seq("20180401")
+    base.datesBetween("20180401", Some("20180403")) should contain theSameElementsInOrderAs Seq("20180401", "20180402", "20180403")
+    base.datesBetween("20180403", None) should contain theSameElementsInOrderAs Seq("20180403", "20180404")
+  }
+}


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1484341)

This adds a base class that has some context on whether to run `spark.stop`, as well as a helper for implementing backfills within the class. I tried to make changes with the least amount of invasion.

Here is a table with some information about how our jobs use input fields and dates. 

| View name           | input date fields | output date format | built-in backfill |
|---------------------|-------------------|--------------------|-------------------|
| Addons              | to/from           | nodash             | yes               |
| ClientsDaily        | date              | nodash             | no                |
| CrashAggregates     | to/from           | dash               | yes               |
| CrashSummary        | to/from           | dash               | yes               |
| ExperimentAnalysis  | date              | nodash             | no                |
| ExperimentSummary   | to/from           | nodash             | yes               |
| GenericCount        | to/from           | ? nodash           | no                |
| GenericLongitudinal | to/from           | nodash             | no                |
| Longitudinal        | to/from           | nodash             | no                |
| MainEvents          | to/from           | nodash             | yes               |
| MainSummary         | to/from           | nodash             | yes               |
| QuantumRC           | to                | nodash             | no                |
| Retention           | date              | nodash             | no                |
| SyncEventView       | to/from           | nodash             | yes               |
| SyncFlatView        | to/from           | nodash             | yes               |
| SyncView            | to/from           | nodash             | yes               |