### PR TITLE
Bug 1487902 - Fix bucket options in CrashSummary and Sync views

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/BatchJobBase.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/BatchJobBase.scala
@@ -50,7 +50,7 @@ abstract class BatchJobBase extends Serializable {
     val outputBucket = opt[String](
       "bucket",
       descr = "Destination bucket for parquet data",
-      required = true)
+      required = false)
   }
 
   protected def shouldStopContextAtEnd(spark: SparkSession): Boolean = {

--- a/src/main/scala/com/mozilla/telemetry/views/SyncEventView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/SyncEventView.scala
@@ -20,7 +20,6 @@ object SyncEventView extends BatchJobBase {
 
   // Configuration for command line arguments
   private class Conf(args: Array[String]) extends BaseOpts(args) {
-    override val outputBucket = opt[String]("bucket", descr = "Destination bucket for parquet data", required = false)
     val outputFilename = opt[String]("outputFilename", descr = "Destination local filename for parquet data", required = false)
     val limit = opt[Int]("limit", descr = "Maximum number of files to read from S3", required = false)
     verify()

--- a/src/main/scala/com/mozilla/telemetry/views/SyncFlatView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/SyncFlatView.scala
@@ -18,7 +18,6 @@ object SyncFlatView extends BatchJobBase {
 
   // Configuration for command line arguments
   private class Conf(args: Array[String]) extends BaseOpts(args) {
-    override val outputBucket = opt[String]("bucket", descr = "Destination bucket for parquet data", required = false)
     val outputFilename = opt[String]("outputFilename", descr = "Destination local filename for parquet data", required = false)
     val limit = opt[Int]("limit", descr = "Maximum number of files to read from S3", required = false)
     verify()

--- a/src/main/scala/com/mozilla/telemetry/views/SyncView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/SyncView.scala
@@ -19,7 +19,6 @@ object SyncView extends BatchJobBase {
 
   // Configuration for command line arguments
   private class Conf(args: Array[String]) extends BaseOpts(args) {
-    override val outputBucket = opt[String]("bucket", descr = "Destination bucket for parquet data", required = false)
     val outputFilename = opt[String]("outputFilename", descr = "Destination local filename for parquet data", required = false)
     val limit = opt[Int]("limit", descr = "Maximum number of files to read from S3", required = false)
     verify()


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1487902)

The crash summary and sync views are currently failing due to changes in the base options. This PR sets the bucket value as not required and removes the conflicting options from the sync view. Having an optional bucket means that current jobs may fail with run-time errors if poorly specified.

I will post confirmation from manual runs of this patch on ATMO. 