### PR TITLE
Bug 1458356 - Migrate jodatime usage in telemetry-batch-view to java.time API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,6 @@ lazy val root = (project in file(".")).
     libraryDependencies += "org.rogach" %% "scallop" % "3.1.2",
     libraryDependencies += "org.scalaj" %% "scalaj-http" % "2.4.0",
     libraryDependencies += "org.yaml" % "snakeyaml" % "1.21",
-    libraryDependencies += "com.github.nscala-time" %% "nscala-time" % "2.10.0",
     libraryDependencies += "org.scalanlp" %% "breeze" % "0.13.2",
 
     // Test dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,6 @@ lazy val root = (project in file(".")).
     libraryDependencies += "org.apache.parquet" % "parquet-avro" % "1.7.0",
     libraryDependencies += "net.sandrogrzicic" %% "scalabuff-runtime" % "1.4.0",
     libraryDependencies += "org.xerial.snappy" % "snappy-java" % "1.1.7.2",
-    libraryDependencies += "joda-time" % "joda-time" % "2.10",
     libraryDependencies += "org.apache.hadoop" % "hadoop-client" % hadoopVersion excludeAll(ExclusionRule(organization = "javax.servlet")),
     libraryDependencies += "org.apache.hadoop" % "hadoop-aws" % hadoopVersion excludeAll(ExclusionRule(organization = "javax.servlet")),
     libraryDependencies += "org.rogach" %% "scallop" % "3.1.2",

--- a/scripts/test_run.sh
+++ b/scripts/test_run.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+#
+# Run a basic sanity check for command line arguments in jobs.
+#
+# This script will submit the telemetry-batch-view job to Spark. This is meant
+# to catch runtime errors that occur within the first few minutes of execution.
+# This script can be run to determine whether a job will fail on EMR.
+#
+# To run the test:
+#   - sbt assembly
+#   - scp the target/scala-*/telemetry-batch-view-*.jar to an ATMO cluster
+#   - scp this script to the same directory
+#   - execute
+#       * `$ ./test_run.sh <jar_path>`
+#
+# The test will run each of the specified jobs for a minute and timeout. If the
+# job is fated to fail, it'll generally happen when parsing the command line
+# options ~40 seconds after submission.
+
 
 set -uo pipefail
 set -x
@@ -23,6 +41,7 @@ submit() {
     classname="$1"
     options="$2"
 
+    # timeout once the job has had enough time to run through scallop configurations
     timeout $timeout spark-submit \
         --master yarn \
         --deploy-mode client \

--- a/scripts/test_run.sh
+++ b/scripts/test_run.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-set -euo pipefail
+set -uo pipefail
 set -x
 
 tbv_jar=$1
-date=${2:-$(date +%Y%m%d --date=yesterday)}
+date=${2:-$(date +%Y%m%d --date='2 days ago')}
 bucket=${3:-"telemetry-test-bucket"}
+timeout=${4:-60}
 
 if [[ -z ${tbv_jar} ]]; then
     echo "Missing telemetry-batch-view jar!"
@@ -22,33 +23,39 @@ submit() {
     classname="$1"
     options="$2"
 
-    spark-submit \
+    timeout $timeout spark-submit \
         --master yarn \
         --deploy-mode client \
         --class com.mozilla.telemetry.views.${classname} \
         ${tbv_jar} ${options}
+
+    # A timeout results in an error code of 124
+    rv=$?
+    if [[ $rv != 0 && $rv != 124 ]]; then
+        echo "bad error code for $classname";
+        exit 1;
+    fi
 }
 
 baseopt="--to $date --from $date --bucket $bucket"
 
 submit MainSummaryView          "$baseopt --channel nightly --read-mode aligned"
-submit ExperimentSummaryView    "$baseopt --experiment-limit 1"
+submit SyncView                 "$baseopt"
+submit CrashAggregateView       "$baseopt"
+submit MainEventsView           "$baseopt --inbucket telemetry-parquet"
+submit AddonsView               "$baseopt --inbucket telemetry-parquet"
+submit CrashSummaryView         "--to $date --from $date --outputBucket $bucket --dryRun"
+submit LongitudinalView         "--to $date --bucket $bucket"
+submit ExperimentAnalysisView   "--date $date --input s3://telemetry-parquet/experiments/v1 --output s3://$bucket/experiments_aggregates/v1"
+submit ExperimentSummaryView    "$baseopt --inbucket telemetry-parquet --experiment-limit 1"
 
-# long running
-submit CrashSummaryView         "$baseopt --dry-run"
 
 ###########################################################
 #               Jobs without Test Options
 ###########################################################
 
-# submit AddonsView
-# submit CrashAggregateView
-# submit ExperimentAnalysisView
-# submit LongitudinalView
-# submit MainEventsView
 # submit SyncEventView
 # submit SyncFlatView
-# submit SyncView
 
 # submit GenericCountView
 # submit GenericLongitudinalView

--- a/src/main/scala/com/mozilla/telemetry/ml/AddonRecommender.scala
+++ b/src/main/scala/com/mozilla/telemetry/ml/AddonRecommender.scala
@@ -5,6 +5,8 @@ package com.mozilla.telemetry.ml
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths}
+import java.time.{Instant, ZoneOffset}
+import java.time.format.DateTimeFormatter
 
 import breeze.linalg.{DenseMatrix, DenseVector}
 import com.github.fommil.netlib.BLAS.{getInstance => blas}
@@ -13,7 +15,6 @@ import org.apache.spark.ml.evaluation.NaNRegressionEvaluator
 import org.apache.spark.ml.recommendation.{ALS, ALSModel}
 import org.apache.spark.ml.tuning.{CrossValidator, ParamGridBuilder}
 import org.apache.spark.sql.SparkSession
-import org.joda.time.{DateTime, format}
 import org.json4s.JsonDSL._
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
@@ -305,10 +306,10 @@ object AddonRecommender {
         val cwd = new java.io.File(".").getCanonicalPath
         val outputDir = new java.io.File(cwd, output)
 
-        val fmt = format.DateTimeFormat.forPattern("yyyyMMdd")
+        val fmt = DateTimeFormatter.ofPattern("yyyyMMdd")
         val date = conf.train.runDate.get match {
           case Some(f) => f
-          case _ => fmt.print(DateTime.now)
+          case _ => Instant.now().atOffset(ZoneOffset.UTC).format(fmt)
         }
 
         train(outputDir.getCanonicalPath, date, conf.train.privateBucket(), conf.train.publicBucket(), conf.train.longitudinalOverride.toOption)

--- a/src/main/scala/com/mozilla/telemetry/utils/SyncPingConversion.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/SyncPingConversion.scala
@@ -3,10 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.utils
 
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, ZoneOffset}
+
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
-import org.joda.time.DateTime
-import org.json4s.{DefaultFormats, JValue}
+import org.json4s.JValue
 import org.json4s.JsonAST._
 import java.util.UUID
 
@@ -497,7 +499,7 @@ object SyncPingConversion {
     }
     val (osName, osVersion, osLocale) = extractOSData(ping, payload)
 
-    val syncDay = new DateTime(when).toDateTime.toString("yyyyMMdd")
+    val syncDay = Instant.ofEpochMilli(when).atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("yyyMMdd"))
 
     val rowRepeatedPart = List(
       // The metadata...

--- a/src/main/scala/com/mozilla/telemetry/views/GenericCountView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/GenericCountView.scala
@@ -3,7 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.views
 
-import com.github.nscala_time.time.Imports._
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
 import com.mozilla.telemetry.utils.UDFs._
 import com.mozilla.telemetry.utils.getOrCreateSparkSession
 import org.apache.spark.sql.functions._
@@ -86,19 +88,19 @@ object GenericCountView extends BatchJobBase {
     verify()
   }
 
-  private val fmt = DateTimeFormat.forPattern("yyyyMMdd")
+  private val fmt = DateTimeFormatter.ofPattern("yyyyMMdd")
 
   private def getFrom(conf: Conf): String = {
-    conf.from.get match {
+    conf.from.toOption match {
       case Some(t) => t
-      case _ => fmt.print(fmt.parseDateTime(getTo(conf)).minusMonths(6))
+      case _ => LocalDate.parse(getTo(conf), fmt).minusMonths(6).format(fmt)
     }
   }
 
   private def getTo(conf: Conf): String = {
     conf.to.get match {
       case Some(t) => t
-      case _ => fmt.print(DateTime.now.minusDays(1))
+      case _ => LocalDate.now(clock).minusDays(1).format(fmt)
     }
   }
 

--- a/src/main/scala/com/mozilla/telemetry/views/GenericLongitudinal.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/GenericLongitudinal.scala
@@ -3,7 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.views
 
-import com.github.nscala_time.time.Imports._
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
 import com.mozilla.telemetry.utils.{CollectList, getOrCreateSparkSession}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StructType
@@ -78,17 +80,17 @@ object GenericLongitudinalView extends BatchJobBase {
   }
 
   def getFrom(opts: Opts): String = {
-    val fmt = DateTimeFormat.forPattern("yyyyMMdd")
+    val fmt = DateTimeFormatter.ofPattern("yyyyMMdd")
     val to = opts.to()
 
-    opts.from.get match {
+    opts.from.toOption match {
       case Some(f) => f
-      case _ => fmt.print(fmt.parseDateTime(to).minusMonths(6))
+      case _ => LocalDate.parse(to, fmt).minusMonths(6).format(fmt)
     }
   }
 
   def getInputTable(sqlContext: SQLContext, opts: Opts): DataFrame = {
-    opts.inputTablename.get match {
+    opts.inputTablename.toOption match {
       case Some(t) => sqlContext.sql(s"SELECT * FROM $t")
       case _ => sqlContext.read.load(opts.inputFiles())
     }

--- a/src/main/scala/com/mozilla/telemetry/views/Longitudinal.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/Longitudinal.scala
@@ -3,7 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.views
 
-import com.github.nscala_time.time.Imports._
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
 import com.mozilla.telemetry.avro
 import com.mozilla.telemetry.heka.{Dataset, Message}
 import com.mozilla.telemetry.metrics._
@@ -21,7 +23,6 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 import scala.math.abs
 import scala.reflect.ClassTag
-
 import scala.collection.mutable.ListBuffer
 
 class S3Handler extends Serializable {
@@ -162,15 +163,15 @@ object LongitudinalView extends BatchJobBase {
 
   def main(args: Array[String]): Unit = {
     val opts = new Opts(args)
-    val fmt = DateTimeFormat.forPattern("yyyyMMdd")
+    val fmt = DateTimeFormatter.ofPattern("yyyyMMdd")
 
     val to = opts.to()
-    val from = opts.from.get match {
+    val from = opts.from.toOption match {
       case Some(f) => f
-      case _ => fmt.print(fmt.parseDateTime(to).minusMonths(6))
+      case _ => LocalDate.parse(to, fmt).minusMonths(6).format(fmt)
     }
 
-    val channels = opts.channels.get.map(_.split(","))
+    val channels = opts.channels.toOption.map(_.split(","))
 
     val samples = opts.samples.get match {
         case Some(s) => s.split(",")

--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -12,7 +12,6 @@ import com.mozilla.telemetry.metrics._
 import com.mozilla.telemetry.utils._
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
-import org.joda.time.{DateTime, Days, format}
 import org.json4s.JsonAST._
 import org.json4s.{DefaultFormats, JValue}
 import org.rogach.scallop._

--- a/src/test/scala/com/mozilla/telemetry/utils/UtilsTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/utils/UtilsTest.scala
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package com.mozilla.telemetry.utils
+
+import java.time.{LocalDate, OffsetDateTime, ZoneOffset}
+import java.time.format.{DateTimeFormatter, DateTimeParseException}
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class UtilsTest extends FlatSpec with Matchers {
+
+  private def parseUTCDateTime(ds: String): OffsetDateTime = {
+    OffsetDateTime.parse(ds, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+  }
+
+  "camelize" should "camelize strings" in {
+    camelize("") should be ("")
+    camelize("foo") should be ("foo")
+    camelize("foo_bar") should be ("fooBar")
+  }
+
+  "uncamelize" should "uncamelize strings" in {
+    uncamelize("") should be ("")
+    uncamelize("foo") should be ("foo")
+    uncamelize("fooBar") should be ("foo_bar")
+  }
+
+  "normalizeISOTimestamp" should "handle valid timestamps" in {
+    val cases = Seq(
+      "2018-09-01T08:00:00.0-08:00",
+      "2018-09-01T08:00:00.0+00:00",
+      "2018-09-01T08:00:00.0+08:00",
+      "2018-09-01T08:00:00.0-12:00",
+      "2018-09-01T08:00:00.0+14:00")
+
+    for (datestring <- cases) {
+      val expect = parseUTCDateTime(datestring)
+      val actual = parseUTCDateTime(normalizeISOTimestamp(datestring))
+
+      actual should be (expect)
+    }
+  }
+
+  it should "wrap the timezone" in {
+    val cases = Seq(
+      ("2018-09-01T08:00:00.0-08:00", ZoneOffset.ofHours(-8)),
+      ("2018-09-01T08:00:00.0-00:00", ZoneOffset.ofHours(0)),
+      ("2018-09-01T08:00:00.0-12:00", ZoneOffset.ofHours(-12)),
+      ("2018-09-01T08:00:00.0-13:00", ZoneOffset.ofHours(-1)),
+      ("2018-09-01T08:00:00.0+14:00", ZoneOffset.ofHours(14)),
+      ("2018-09-01T08:00:00.0+15:00", ZoneOffset.ofHours(3)))
+
+    for ((datestring, zone) <- cases) {
+      val expect = zone
+      val actual = parseUTCDateTime(normalizeISOTimestamp(datestring)).getOffset()
+
+      actual should be (expect)
+    }
+  }
+
+  "normalizeYYYYMMDDTimestamp" should "handle valid dates" in {
+    normalizeYYYYMMDDTimestamp("20180901") should be ("2018-09-01T00:00:00Z")
+  }
+
+  // scalastyle:off
+  it should "throw exception on invalid dates" in {
+    a [DateTimeParseException] should be thrownBy normalizeYYYYMMDDTimestamp("2018901")
+    a [DateTimeParseException] should be thrownBy normalizeYYYYMMDDTimestamp("201809")
+    a [DateTimeParseException] should be thrownBy normalizeYYYYMMDDTimestamp("2018-09-01")
+  }
+  // scalastyle:on
+
+  "normalizeEpochTimestamp" should "handle valid timestamps" in {
+    val format = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+    val expect = LocalDate.parse("2018-09-01", format).atStartOfDay(ZoneOffset.UTC)
+    normalizeEpochTimestamp(expect.toInstant.toEpochMilli) == expect.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+  }
+}

--- a/src/test/scala/com/mozilla/telemetry/views/LongitudinalViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/LongitudinalViewTest.scala
@@ -345,14 +345,14 @@ class LongitudinalViewTest extends FlatSpec with Matchers with PrivateMethodTest
 
   "Scalar fields" must "be converted correctly" in {
     val stringFields = Array(
-      "submission_date"       -> "2016-01-28T00:00:00.000Z",
+      "submission_date"       -> "2016-01-28T00:00:00Z",
       "geo_country"           -> "US",
       "geo_city"              -> "New York",
       "dnt_header"            -> "1",
-      "subsession_start_date" -> "2015-12-09T12:00:00.000-02:00",
-      "session_start_date"    -> "2015-12-09T12:00:00.000-02:00",
-      "profile_creation_date" -> "2014-02-21T00:00:00.000Z",
-      "profile_reset_date"    -> "2014-03-03T00:00:00.000Z"
+      "subsession_start_date" -> "2015-12-09T12:00:00-02:00",
+      "session_start_date"    -> "2015-12-09T12:00:00-02:00",
+      "profile_creation_date" -> "2014-02-21T00:00:00Z",
+      "profile_reset_date"    -> "2014-03-03T00:00:00Z"
     )
 
     val floatFields = Array(

--- a/src/test/scala/com/mozilla/telemetry/views/SyncFlatViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/SyncFlatViewTest.scala
@@ -3,11 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry
 
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, ZoneOffset}
+
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
 import com.mozilla.telemetry.utils.{SyncPingConversion, getOrCreateSparkSession}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
-import org.joda.time.DateTime
 import org.json4s.JsonAST.{JArray, JNothing, JObject}
 import org.json4s.{DefaultFormats, JValue}
 import org.scalatest.{FlatSpec, Matchers}
@@ -70,7 +72,10 @@ class SyncFlatViewTest extends FlatSpec with Matchers with DataFrameSuiteBase {
         sync.getAs[String]("device_id") should be((pingSync \ "deviceID").extract[String])
         sync.getAs[Long]("took") should be((pingSync \ "took").extract[Long])
         sync.getAs[GenericRowWithSchema]("status") should be(null)
-        sync.getAs[String]("sync_day") should be (new DateTime((pingSync \ "when").extract[Long]).toDateTime.toString("yyyyMMdd"))
+        sync.getAs[String]("sync_day") should be (
+          Instant.ofEpochMilli((pingSync \ "when").extract[Long])
+            .atOffset(ZoneOffset.UTC)
+            .format(DateTimeFormatter.ofPattern("yyyyMMdd")))
 
         // engine specific data
         val engineName = sync.getAs[String]("engine_name")


### PR DESCRIPTION
[bug link](Bug 1458356)

This removes `joda-time` and the scala wrapper `nscala_time` from this repo. I tested the changes against `scripts/test_run.sh` which runs jobs with defaults and times out after a minute. If our jobs are going to fail at the entrypoint, they usually do it around the 40 second mark.

