### PR TITLE
Aggregate keyed scalars by summing values by key

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/utils/udfs.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/udfs.scala
@@ -291,6 +291,56 @@ class AggMapFirst() extends UserDefinedAggregateFunction {
   override def evaluate(buffer: Row): Any = buffer.getMap(0)
 }
 
+class AggMapSum() extends UserDefinedAggregateFunction {
+  /**
+    * Aggregates a Map[String,Integer] column by summing over each key
+    **/
+
+  override def inputSchema: StructType = StructType(
+    Array(
+      StructField(
+        "value",
+        // This is the actual input type
+        MapType(StringType, IntegerType, true)
+      )
+    )
+  )
+
+  override def bufferSchema: StructType = StructType(
+    List(StructField("map", MapType(StringType, IntegerType, false)))
+  )
+
+  override def dataType: DataType = MapType(StringType, IntegerType, false)
+
+  override def deterministic: Boolean = true
+
+  override def initialize(buffer: MutableAggregationBuffer): Unit = {
+    buffer(0) = Map[String, Int]()
+  }
+
+  // add only keys with non-null values from input
+  override def update(buffer: MutableAggregationBuffer, input: Row): Unit = {
+    if (!input.isNullAt(0)) {
+      val bmap: scala.collection.Map[String, Int] = buffer.getMap(0)
+      val imap = input.getAs[Map[String, Integer]](0)
+      buffer(0) = bmap ++
+        (imap
+        .filter { p: (String, Integer) => p._2 != null }
+        .map { case (k,v) => k -> (v.intValue + bmap.getOrElse(k, 0)) })
+    }
+  }
+
+  override def merge(buffer1: MutableAggregationBuffer, buffer2: Row): Unit = {
+    val map1: scala.collection.Map[String, Int] = buffer1.getMap(0)
+    val map2: scala.collection.Map[String, Int] = buffer2.getMap(0)
+    buffer1(0) = map1 ++
+      map2.map { case (k,v) => k -> (v + map1.getOrElse(k, 0)) }
+  }
+
+  // the buffer is the output value
+  override def evaluate(buffer: Row): Any = buffer.getMap(0)
+}
+
 object UDFs{
   val HllCreate = "hll_create"
   val HllCardinality = "hll_cardinality"

--- a/src/main/scala/com/mozilla/telemetry/views/ClientsDailyView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/ClientsDailyView.scala
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.views
 
-import com.mozilla.telemetry.utils.{AggMapFirst, AggSearchCounts, getOrCreateSparkSession}
+import com.mozilla.telemetry.utils.{AggMapFirst, AggMapSum, AggSearchCounts, getOrCreateSparkSession}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{Column, DataFrame}
 import org.rogach.scallop._
@@ -99,6 +99,9 @@ object ClientsDailyView {
 
   private val mapFirst = new AggMapFirst()
   private def aggMapFirst(field: String): Column = mapFirst(col(field)).alias(field)
+
+  private val mapSum = new AggMapSum()
+  private def aggMapSum(field: String): Column = mapSum(col(field)).alias(s"${field}_sum")
 
   private def aggMax(field: String): Column = max(field).alias(s"${field}_max")
 
@@ -261,6 +264,7 @@ object ClientsDailyView {
     aggSum("scalar_parent_devtools_accessibility_node_inspected_count"),
     aggSum("scalar_parent_devtools_accessibility_opened_count"),
     aggSum("scalar_parent_devtools_accessibility_picker_used_count"),
+    aggMapSum("scalar_parent_devtools_accessibility_select_accessible_for_node"),
     aggSum("scalar_parent_devtools_accessibility_service_enabled_count"),
     aggSum("scalar_parent_devtools_copy_full_css_selector_opened"),
     aggSum("scalar_parent_devtools_copy_unique_css_selector_opened"),

--- a/src/test/scala/com/mozilla/telemetry/views/ClientsDailyViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/ClientsDailyViewTest.scala
@@ -261,4 +261,18 @@ class ClientsDailyViewTest extends FlatSpec with Matchers with DataFrameSuiteBas
       Map("sessions_started_on_this_day" -> 2)
     )
   }
+
+  it must "handle keyed scalars properly" in {
+    test(
+      List(
+        getRowAggMapSum(Some(Map("a" -> Some(1), "b" -> Some(10)))),
+        getRowAggMapSum(Some(Map("a" -> Some(9)))),
+        getRowAggMapSum(Some(Map("c" -> Some(0)))),
+        getRowAggMapSum(Some(Map("b" -> None))),
+        getRowAggMapSum(Some(Map("d" -> None))),
+        MainSummaryRow()
+      ),
+      getExpectAggMapSum(Map("a" -> 10, "b" -> 10, "c" -> 0))
+    )
+  }
 }

--- a/src/test/scala/com/mozilla/telemetry/views/ClientsDailyViewTestHelpers.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/ClientsDailyViewTestHelpers.scala
@@ -148,6 +148,7 @@ object ClientsDailyViewTestHelpers {
     scalar_parent_devtools_accessibility_node_inspected_count: Option[Int] = None,
     scalar_parent_devtools_accessibility_opened_count: Option[Int] = None,
     scalar_parent_devtools_accessibility_picker_used_count: Option[Int] = None,
+    scalar_parent_devtools_accessibility_select_accessible_for_node: Option[scala.collection.Map[String,Option[Int]]] = None,
     scalar_parent_devtools_accessibility_service_enabled_count: Option[Int] = None,
     scalar_parent_devtools_copy_full_css_selector_opened: Option[Int] = None,
     scalar_parent_devtools_copy_unique_css_selector_opened: Option[Int] = None,
@@ -314,6 +315,14 @@ object ClientsDailyViewTestHelpers {
     "vendor" -> sValue,
     "windows_build_number" -> iValue,
     "windows_ubr" -> iValue
+  )
+
+  def getRowAggMapSum(value: Option[scala.collection.Map[String, Option[Int]]]): MainSummaryRow = MainSummaryRow(
+    scalar_parent_devtools_accessibility_select_accessible_for_node = value
+  )
+
+  def getExpectAggMapSum(value: Map[String, Int]): Map[String, Map[String, Int]] = Map(
+    "scalar_parent_devtools_accessibility_select_accessible_for_node_sum" -> value
   )
 
   def getRowAggMax(value: Option[Int]): MainSummaryRow = MainSummaryRow(


### PR DESCRIPTION
My test is failing because `None` values are being implicitly converted to zeros somewhere -- I'm confused about why this is happening but I think it's probably acceptable. Do you see a way to avoid it?