### PR TITLE
Add WebRender preference to main_summary

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -41,14 +41,14 @@ object MainSummaryView extends BatchJobBase {
   // See the `_getPrefData()` function in TelemetryEnvironment.jsm
   // for reference: https://mzl.la/2zo7kyK
   val userPrefsList =
-    IntegerUserPref("dom.ipc.plugins.sandbox-level.flash") ::
-    IntegerUserPref("dom.ipc.processCount") ::
+    BooleanUserPref("browser.search.widget.inNavBar") ::
     BooleanUserPref("extensions.allow-non-mpc-extensions") ::
     BooleanUserPref("extensions.legacy.enabled") ::
-    BooleanUserPref("browser.search.widget.inNavBar") ::
+    BooleanUserPref("gfx.webrender.all.qualified") ::
     BooleanUserPref("marionette.enabled") ::
-    StringUserPref("general.config.filename") ::
-    BooleanUserPref("gfx.webrender.all.qualified") :: Nil
+    IntegerUserPref("dom.ipc.plugins.sandbox-level.flash") ::
+    IntegerUserPref("dom.ipc.processCount") ::
+    StringUserPref("general.config.filename") :: Nil
 
 
   val histogramsWhitelist =

--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -47,7 +47,8 @@ object MainSummaryView extends BatchJobBase {
     BooleanUserPref("extensions.legacy.enabled") ::
     BooleanUserPref("browser.search.widget.inNavBar") ::
     BooleanUserPref("marionette.enabled") ::
-    StringUserPref("general.config.filename") :: Nil
+    StringUserPref("general.config.filename") ::
+    BooleanUserPref("gfx.webrender.all.qualified") :: Nil
 
 
   val histogramsWhitelist =


### PR DESCRIPTION
This is the target of the WebRender experiment. Per https://bugzilla.mozilla.org/show_bug.cgi?id=1495152, it is not consistently set for nightly users, so we need to filter pings for enrolled users by the actual value of the pref.