### PR TITLE
Bug 1500929: Increase timeout on fetch from normandy api

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/ExperimentSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/ExperimentSummaryView.scala
@@ -132,9 +132,13 @@ object ExperimentSummaryView extends BatchJobBase {
       .parquet(output)
   }
 
-  def getExperimentRecipes(): JValue = {
-    parse(Http(experimentsUrl).params(experimentsUrlParams).asString.body)
-  }
+  def getExperimentRecipes(): JValue = parse(
+    Http(experimentsUrl)
+      .params(experimentsUrlParams)
+      .timeout(connTimeoutMs = 5000, readTimeoutMs = 60000)
+      .asString
+      .body
+  )
 
   def getExperimentList(json: JValue, date: OffsetDateTime, limit: Option[Int] = None): List[String] = {
     val experiments = json match {


### PR DESCRIPTION
This failed twice with timeouts yesterday, so I'm finally getting around to fixing it. This is the job that creates the `experiments` dataset, which has been timing out on the fetch to the Normandy dataset. I ran the method manually and it works fine (although i didn't go as far as introducing latency)