### PR TITLE
Bug 1525702 - Add "intl" fields

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -786,6 +786,15 @@ object MainSummaryView extends BatchJobBase {
         (settings \ "blocklistEnabled").extractOpt[Boolean],
         (settings \ "addonCompatibilityCheckEnabled").extractOpt[Boolean],
         (settings \ "telemetryEnabled").extractOpt[Boolean],
+
+        // bug 1525702
+        (settings \ "intl" \ "acceptLanguages").extractOpt[List[String]],
+        (settings \ "intl" \ "appLocales").extractOpt[List[String]],
+        (settings \ "intl" \ "availableLocales").extractOpt[List[String]],
+        (settings \ "intl" \ "regionalPrefsLocales").extractOpt[List[String]],
+        (settings \ "intl" \ "requestedLocales").extractOpt[List[String]],
+        (settings \ "intl" \ "systemLocales").extractOpt[List[String]],
+
         getOldUserPrefs(settings \ "userPrefs"),
 
         Option(events.flatMap { case (p, e) => Events.getEvents(e, p) }).filter(!_.isEmpty),
@@ -1198,6 +1207,13 @@ object MainSummaryView extends BatchJobBase {
       StructField("blocklist_enabled", BooleanType, nullable = true), // environment.settings.blocklistEnabled
       StructField("addon_compatibility_check_enabled", BooleanType, nullable = true), // environment.settings.addonCompatibilityCheckEnabled
       StructField("telemetry_enabled", BooleanType, nullable = true), // environment.settings.telemetryEnabled
+
+      StructField("environment_settings_intl_accept_languages", ArrayType(StringType, containsNull = false), nullable = true),
+      StructField("environment_settings_intl_app_locales", ArrayType(StringType, containsNull = false), nullable = true),
+      StructField("environment_settings_intl_available_locales", ArrayType(StringType, containsNull = false), nullable = true),
+      StructField("environment_settings_intl_regional_prefs_locales", ArrayType(StringType, containsNull = false), nullable = true),
+      StructField("environment_settings_intl_requested_locales", ArrayType(StringType, containsNull = false), nullable = true),
+      StructField("environment_settings_intl_system_locales", ArrayType(StringType, containsNull = false), nullable = true),
 
       // TODO: Deprecate and eventually remove this field, preferring the top-level
       //       user_pref_* fields for easy schema evolution.

--- a/src/test/scala/com/mozilla/telemetry/views/MainSummaryViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/MainSummaryViewTest.scala
@@ -254,6 +254,12 @@ class MainSummaryViewTest extends FlatSpec with Matchers with DataFrameSuiteBase
             "user_pref_dom_ipc_processcount" -> null,
             "user_pref_extensions_allow_non_mpc_extensions" -> null,
             "user_pref_extensions_legacy_enabled" -> null,
+            "environment_settings_intl_accept_languages" -> List(),
+            "environment_settings_intl_app_locales" -> List(),
+            "environment_settings_intl_available_locales" -> List(),
+            "environment_settings_intl_regional_prefs_locales" -> List(),
+            "environment_settings_intl_requested_locales" -> List(),
+            "environment_settings_intl_system_locales" -> List(),
             "scalar_parent_mock_keyed_scalar_bool" -> null,
             "scalar_parent_mock_keyed_scalar_string" -> null,
             "scalar_parent_mock_keyed_scalar_uint" -> null,
@@ -2248,6 +2254,38 @@ class MainSummaryViewTest extends FlatSpec with Matchers with DataFrameSuiteBase
       None)
 
     val expected = Map("normalized_os_version" -> "14.5.0")
+
+    compare(message, expected)
+  }
+
+  "String lists in settings" can "be handled correctly" in {
+    val message = RichMessage(
+      "1234",
+      Map(
+        "documentId" -> "foo",
+        "submissionDate" -> "1234",
+        "environment.settings" ->
+          """
+            |{
+            |  "intl": {
+            |    "requestedLocales": ["it"],
+            |    "availableLocales": ["it", "en-AA"],
+            |    "appLocales": ["it", "en-BB"],
+            |    "systemLocales": ["it-IT", "en-IT"],
+            |    "regionalPrefsLocales": ["it-IT", "en-CC"],
+            |    "acceptLanguages": ["it-IT", "it", "en-US", "en"]
+            |  }
+            |}""".stripMargin),
+      None)
+
+    val expected = Map(
+      "environment_settings_intl_requested_locales" -> List("it"),
+      "environment_settings_intl_available_locales" -> List("it", "en-AA"),
+      "environment_settings_intl_app_locales" -> List("it", "en-BB"),
+      "environment_settings_intl_system_locales" -> List("it-IT", "en-IT"),
+      "environment_settings_intl_regional_prefs_locales" -> List("it-IT", "en-CC"),
+      "environment_settings_intl_accept_languages" -> List("it-IT", "it", "en-US", "en")
+    )
 
     compare(message, expected)
   }


### PR DESCRIPTION
I named these fields verbosely so they would be compatible with [bug 1476630](https://bugzilla.mozilla.org/show_bug.cgi?id=1476630) if we tackle that in the future.

Another slightly weird thing is that doing `.extractOpt[List[String]]` means that any missing fields will result in an empty list in the output record rather than `null` as we normally do.