### PR TITLE
Bug 1526278 - Fix PLUGINS_NOTIFICATION_SHOWN

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -824,8 +824,9 @@ object MainSummaryView extends BatchJobBase {
         (simpleMeasures \ "totalTime").extractOpt[Int],
         (simpleMeasures \ "blankWindowShown").extractOpt[Int],
 
-        // bug 1362520 - plugin notifications
-        hsum(histograms("parent") \ "PLUGINS_NOTIFICATION_SHOWN"),
+        // bug 1362520 and 1526278 - plugin notifications
+        (histograms("parent") \ "PLUGINS_NOTIFICATION_SHOWN" \ "values" \ "1").extractOpt[Int],
+        (histograms("parent") \ "PLUGINS_NOTIFICATION_SHOWN" \ "values" \ "0").extractOpt[Int],
         MainPing.enumHistogramToRow(histograms("parent") \ "PLUGINS_NOTIFICATION_USER_ACTION", pluginNotificationUserActionKeys),
         hsum(histograms("parent") \ "PLUGINS_INFOBAR_SHOWN"),
         hsum(histograms("parent") \ "PLUGINS_INFOBAR_BLOCK"),
@@ -1234,8 +1235,9 @@ object MainSummaryView extends BatchJobBase {
       StructField("total_time", IntegerType, nullable = true),
       StructField("blank_window_shown", IntegerType, nullable = true),
 
-      // bug 1362520 - plugin notifications
+      // bug 1362520 and 1526278 - plugin notifications
       StructField("plugins_notification_shown", IntegerType, nullable = true),
+      StructField("plugins_notification_shown_false", IntegerType, nullable = true),
       StructField("plugins_notification_user_action", buildPluginNotificationUserActionSchema, nullable = true),
       StructField("plugins_infobar_shown", IntegerType, nullable = true),
       StructField("plugins_infobar_block", IntegerType, nullable = true),

--- a/src/test/scala/com/mozilla/telemetry/views/MainSummaryViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/MainSummaryViewTest.scala
@@ -234,6 +234,7 @@ class MainSummaryViewTest extends FlatSpec with Matchers with DataFrameSuiteBase
             "session_restored" -> 3289,
             "total_time" -> 1027690,
             "plugins_notification_shown" -> null,
+            "plugins_notification_shown_false" -> null,
             "plugins_notification_user_action" -> null,
             "plugins_infobar_shown" -> null,
             "plugins_infobar_block" -> null,
@@ -712,7 +713,7 @@ class MainSummaryViewTest extends FlatSpec with Matchers with DataFrameSuiteBase
             |  "PLUGINS_NOTIFICATION_SHOWN":{
             |    "range":[1,2],
             |    "histogram_type":2,
-            |    "values":{"1":3,"0":0,"2":0},
+            |    "values":{"1":3,"0":1,"2":0},
             |    "bucket_count":3,
             |    "sum":3
             |  },
@@ -757,6 +758,7 @@ class MainSummaryViewTest extends FlatSpec with Matchers with DataFrameSuiteBase
     val expected = Map(
       "document_id" -> "foo",
       "plugins_notification_shown" -> 3,
+      "plugins_notification_shown_false" -> 1,
       "plugins_notification_user_action" -> Row(3, 0, 0),
       "plugins_infobar_shown" -> 12,
       "plugins_infobar_allow" -> 2,


### PR DESCRIPTION
Add a new field to count the zero bucket, since accumulating false
in this histogram has a particular meaning. From the description:

The number of times the click-to-activate notification was shown:
false: shown by in-content activation
true: shown by location bar activation