### PR TITLE
add launcherProcess pref to main_summary

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -41,6 +41,7 @@ object MainSummaryView extends BatchJobBase {
   // See the `_getPrefData()` function in TelemetryEnvironment.jsm
   // for reference: https://mzl.la/2zo7kyK
   val userPrefsList =
+    BooleanUserPref("browser.launcherProcess.enabled") ::
     BooleanUserPref("browser.search.widget.inNavBar") ::
     BooleanUserPref("extensions.allow-non-mpc-extensions") ::
     BooleanUserPref("extensions.legacy.enabled") ::


### PR DESCRIPTION
Adds `browser.launcherProcess.enabled` to main_summary for pref-flip study.