### PR TITLE
Fix clients_daily to preserve legacy decimal scale

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/ClientsDailyView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/ClientsDailyView.scala
@@ -171,7 +171,7 @@ object ClientsDailyView {
     aggMean("session_restored"),
     aggSum(expr("IF(subsession_counter = 1, 1, 0)"), "sessions_started_on_this_day"),
     aggSum("shutdown_kill"),
-    aggSum(expr("subsession_length/3600.0").cast(DecimalType(38,9)), "subsession_hours_sum"),
+    aggSum(expr("subsession_length/3600.0").cast(DecimalType(35,6)), "subsession_hours_sum"),
     aggSum("ssl_handshake_result_failure"),
     aggSum("ssl_handshake_result_success"),
     aggFirst("sync_configured"),

--- a/src/main/scala/com/mozilla/telemetry/views/dau/GenericDauTrait.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/dau/GenericDauTrait.scala
@@ -46,8 +46,9 @@ trait GenericDauTrait {
 
     val input = spark
       .read
+      // schema evolution detection disabled due to error on decimal type precision reduction
       // merge schemas to handle schema evolution
-      .option("mergeSchema", "true")
+      //.option("mergeSchema", "true")
       // detect input date column
       .option("basePath", conf.inputBasePath)
       // read input dates by path


### PR DESCRIPTION
reduce the precision from 37 to 35 for BigQuery compatibility, but keep the scale at `6` to prevent silent invalid data caused by bad schema evolution