### PR TITLE
Optimize crash summary view

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/CrashSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/CrashSummaryView.scala
@@ -231,7 +231,7 @@ object CrashSummaryView extends BatchJobBase {
       val crashPings = messages.records()
         .map(x => {
           val payload = this.transformPayload(x.fieldsAsMap, x.payload);
-          if (!payload.isDefined) {
+          if (payload.isEmpty) {
             discardedPings.add(1)
           } else {
             processedPings.add(1)


### PR DESCRIPTION
* Integrate accumulation of processed/discarded counts into map
* Use cached accumulator values to calculate total (as opposed to
  getting the size all over again)