### PR TITLE
Bug 1567339 - Add parameters to attribution in environment data

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
+++ b/src/main/scala/com/mozilla/telemetry/views/MainSummaryView.scala
@@ -778,6 +778,8 @@ object MainSummaryView extends BatchJobBase {
         (settings \ "update" \ "enabled").extractOpt[Boolean],
         (settings \ "update" \ "autoDownload").extractOpt[Boolean],
         getAttribution(settings \ "attribution"),
+        (settings \ "attribution" \ "experiment").extractOpt[String],
+        (settings \ "attribution" \ "variation").extractOpt[String],
         (settings \ "sandbox" \ "effectiveContentProcessLevel").extractOpt[Int],
         (addons \ "activeExperiment" \ "id").extractOpt[String],
         (addons \ "activeExperiment" \ "branch").extractOpt[String],
@@ -1185,6 +1187,8 @@ object MainSummaryView extends BatchJobBase {
       StructField("update_enabled", BooleanType, nullable = true), // environment/settings/update/enabled
       StructField("update_auto_download", BooleanType, nullable = true), // environment/settings/update/autoDownload
       StructField("attribution", buildAttributionSchema, nullable = true), // environment/settings/attribution/
+      StructField("attribution_experiment", StringType, nullable = true), // environment/settings/attribution/experiment
+      StructField("attribution_variation", StringType, nullable = true), // environment/settings/attribution/variation
       StructField("sandbox_effective_content_process_level", IntegerType, nullable = true), // environment/settings/sandbox/effectiveContentProcessLevel
       StructField("active_experiment_id", StringType, nullable = true), // environment/addons/activeExperiment/id
       StructField("active_experiment_branch", StringType, nullable = true), // environment/addons/activeExperiment/branch

--- a/src/test/scala/com/mozilla/telemetry/views/MainSummaryViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/MainSummaryViewTest.scala
@@ -709,6 +709,36 @@ class MainSummaryViewTest extends FlatSpec with Matchers with DataFrameSuiteBase
     }
   }
 
+  it can "extract experiment and variation" in {
+    val attribution = """
+      |{
+      |  "attribution": {
+      |    "content": "sample_content",
+      |    "source": "sample_source",
+      |    "medium": "sample_medium",
+      |    "campaign": "sample_campaign",
+      |    "experiment": "sample_experiment",
+      |    "variation": "sample_variation"
+      |  }
+      |}
+    """.stripMargin
+
+    val message = RichMessage("1234",
+      Map(
+        "documentId" -> "foo",
+        "submissionDate" -> "1234",
+        "environment.settings" -> attribution
+      ),
+      None)
+
+    val expected = Map(
+      "attribution_experiment" -> "sample_experiment",
+      "attribution_variation" -> "sample_variation"
+    )
+
+    compare(message, expected)
+  }
+
   "MainSummary plugin counts" can "be summarized" in {
     val message = RichMessage(
       "1234",


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1567339)

This adds `experiment` and `variation` stub attribution fields to main_summary. Unfortunately, attribution was originally added as a nested field, so it can't be updated to accommodate these new fields. They've been added as `attribution_experiment` and `attribution_variation` at the top level instead.

The BigQuery tables are a better choice in this case (see this [schema diff](https://github.com/mozilla-services/mozilla-pipeline-schemas/commit/03466d5532a89c107889ebf3badf333d7da89534)).