### PR TITLE
Add extractors for Sync engine steps

### DIFF
--- a/src/test/scala/com/mozilla/telemetry/views/SyncViewTestPayloads.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/SyncViewTestPayloads.scala
@@ -207,7 +207,7 @@ object SyncViewTestPayloads {
     |}
     """.stripMargin)
 
-  // Sync ping payload with devices and validation data.
+  // Sync ping payload with devices, steps, and validation data.
   def complexSyncPing: JValue = parse(
     """
       |{
@@ -273,6 +273,22 @@ object SyncViewTestPayloads {
       |          {
       |            "name": "bookmarks",
       |            "took": 1000,
+      |            "steps": [{
+      |              "name": "fetchLocalTree",
+      |              "took": 123,
+      |              "counts": [{
+      |                "name": "items",
+      |                "count": 456
+      |              }, {
+      |                "name": "deletions",
+      |                "count": 1
+      |              }]
+      |            }, {
+      |              "name": "fetchRemoteTree",
+      |              "took": 789
+      |            }, {
+      |              "name": "apply"
+      |            }],
       |            "validation": {
       |              "version": 1,
       |              "checked": 290,


### PR DESCRIPTION
The `steps` field is a new field added to the Sync ping in https://bugzilla.mozilla.org/show_bug.cgi?id=1552621. Each step has a name, millisecond time, and optional named counts, using the same format as validation problems. We use these in new bookmark sync, to report timings and counts for each stage.

This extracts the steps into the summary view (but not the flat engines view), so that we can query them.