### PR TITLE
Bug 1565600: Add new field with whole experiments object

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/utils/MainPing.scala
+++ b/src/main/scala/com/mozilla/telemetry/utils/MainPing.scala
@@ -34,7 +34,10 @@ case class Attribution(source: Option[String],
                        campaign: Option[String],
                        content: Option[String])
 
-case class Experiment(branch: Option[String])
+case class Experiment(branch: Option[String],
+                      `type`: Option[String],
+                      enrollmentId: Option[String]
+                     )
 
 abstract class UserPref {
   def name: String

--- a/src/test/scala/com/mozilla/telemetry/views/MainSummaryViewTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/views/MainSummaryViewTest.scala
@@ -819,13 +819,16 @@ class MainSummaryViewTest extends FlatSpec with Matchers with DataFrameSuiteBase
         "environment.experiments" ->
           """{
           "experiment1": { "branch": "alpha" },
-          "experiment2": { "branch": "beta" }
+          "experiment2": { "branch": "beta", "type": "high-population", "enrollmentId": "test ID" }
         }"""),
       None)
 
     val expected = Map(
       "document_id" -> "foo",
-      "experiments" -> Map("experiment1" -> "alpha", "experiment2" -> "beta")
+      "experiments" -> Map("experiment1" -> "alpha", "experiment2" -> "beta"),
+      "experiments_details" -> Map(
+        "experiment1" -> Map("branch" -> "alpha", "type" -> null, "enrollment_id" -> null),
+        "experiment2" -> Map("branch" -> "beta", "type" -> "high-population", "enrollment_id" -> "test ID"))
     )
 
     compare(message, expected)


### PR DESCRIPTION
There's a new property in the experiments block, `enrollmentId`, which is a uuid per experiment enrollment, which should help us distinguish duplicate client IDs. Unfortunately, the way I originally set up the experiments block in main summary, it was a simple map of `experiment_id` -> `branch` and structural changes at this sublevel are disallowed per parquet schema evolution. This PR adds a new field, `experiments_details` structured `experiment_id -> Map(String, String)` which adds the `enrollmentId` as well as `type` properties.