### PR TITLE
Upgrade amo api version

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/ml/AMODatabase.scala
+++ b/src/main/scala/com/mozilla/telemetry/ml/AMODatabase.scala
@@ -48,7 +48,7 @@ final object AMODatabase {
   implicit val formats = Serialization.formats(NoTypeHints)
   private val logger = org.apache.log4j.Logger.getLogger(this.getClass.getName)
   // This API URI will fetch all the public addons for Firefox, sorting them by creation date.
-  private val defaultAMORequestURI = "https://addons.mozilla.org/api/v3/addons/search/"
+  private val defaultAMORequestURI = "https://addons.mozilla.org/api/v4/addons/search/"
   private val queryParams = "?app=firefox&sort=created&type=extension"
 
   /**

--- a/src/test/scala/com/mozilla/telemetry/ml/AMODatabaseTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/ml/AMODatabaseTest.scala
@@ -29,7 +29,7 @@ class AMODatabaseTest extends FlatSpec with Matchers with BeforeAndAfterEach {
   }
 
   "AMODatabase" must "fail with incorrect data" in {
-    val path = "/api/v3/addons/search/"
+    val path = "/api/v4/addons/search/"
     // Stub the API and return the sample JSON response when its hit.
     stubFor(get(urlMatching(path + "\\?.*"))
       .withQueryParam("app", equalTo("firefox"))
@@ -51,7 +51,7 @@ class AMODatabaseTest extends FlatSpec with Matchers with BeforeAndAfterEach {
   }
 
   "AMODatabase" must "parse responses correctly" in {
-    val path = "/api/v3/addons/search/"
+    val path = "/api/v4/addons/search/"
     val sampleResponse =
       """
         |{


### PR DESCRIPTION
I compared results for v3 vs v4 for this method: https://addons.mozilla.org/api/v3/addons/search/?app=firefox&sort=created&type=extension

New field added - is_custom
Removed:
is_source_public - no usage
is_featured - no usage

I don't see any other differences, so it should be compatible.

fixes #568 